### PR TITLE
Add modulo operator support

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -651,7 +651,8 @@ export class Transpiler {
 					expression.getOperatorToken().getKind() === ts.SyntaxKind.MinusEqualsToken ||
 					expression.getOperatorToken().getKind() === ts.SyntaxKind.AsteriskEqualsToken ||
 					expression.getOperatorToken().getKind() === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
-					expression.getOperatorToken().getKind() === ts.SyntaxKind.SlashEqualsToken)
+					expression.getOperatorToken().getKind() === ts.SyntaxKind.SlashEqualsToken ||
+					expression.getOperatorToken().getKind() === ts.SyntaxKind.PercentEqualsToken)
 			)
 		) {
 			throw new TranspilerError(
@@ -1588,6 +1589,8 @@ export class Transpiler {
 					return `${lhsStr} = ${lhsStr} / (${rhsStr})`;
 				case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
 					return `${lhsStr} = ${lhsStr} ^ (${rhsStr})`;
+				case ts.SyntaxKind.PercentEqualsToken:
+					return `${lhsStr} = ${lhsStr} % (${rhsStr})`;
 			}
 			throw new TranspilerError("Unrecognized operation!", node);
 		}
@@ -1598,7 +1601,8 @@ export class Transpiler {
 			opKind === ts.SyntaxKind.MinusEqualsToken ||
 			opKind === ts.SyntaxKind.AsteriskEqualsToken ||
 			opKind === ts.SyntaxKind.SlashEqualsToken ||
-			opKind === ts.SyntaxKind.AsteriskAsteriskEqualsToken
+			opKind === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
+			opKind === ts.SyntaxKind.PercentEqualsToken
 		) {
 			if (ts.TypeGuards.isPropertyAccessExpression(lhs) && opKind !== ts.SyntaxKind.EqualsToken) {
 				const expression = lhs.getExpression();

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1654,6 +1654,8 @@ export class Transpiler {
 				return `${lhsStr} >= ${rhsStr}`;
 			case ts.SyntaxKind.LessThanEqualsToken:
 				return `${lhsStr} <= ${rhsStr}`;
+			case ts.SyntaxKind.PercentToken:
+				return `${lhsStr} % ${rhsStr}`;
 			case ts.SyntaxKind.InstanceOfKeyword:
 				if (inheritsFrom(node.getRight().getType(), "Rbx_Instance")) {
 					return `TS.isA(${lhsStr}, "${rhsStr}")`;


### PR DESCRIPTION
This adds transpiler support for the modulo operator (`%`), which currently causes a compilation error.
This fixes #37 