### PR TITLE
Replace direct imports with waits using TS.import

### DIFF
--- a/include/RuntimeLib.lua
+++ b/include/RuntimeLib.lua
@@ -31,7 +31,7 @@ local globalModules = script.Parent.Parent:FindFirstChild("Modules")
 
 function TS.getModule(moduleName, object)
 	if not globalModules then
-		error("roblox-ts: Could not find any modules!")
+		error("Could not find any modules!", 2)
 	end
 	if object:IsDescendantOf(globalModules) then
 		while object.Parent do
@@ -50,7 +50,22 @@ function TS.getModule(moduleName, object)
 			return module
 		end
 	end
-	error("roblox-ts: Could not find module: " .. moduleName)
+	error("Could not find module: " .. moduleName, 2)
+end
+
+function TS.import(root, ...)
+	local currentInstance = typeof(root) == "Instance" and root or game:GetService(root)
+	local path = { ... }
+	if currentInstance then
+		for _, part in pairs(path) do
+			currentInstance = currentInstance and currentInstance:WaitForChild(part)
+		end
+	end
+	if currentInstance and currentInstance:IsA("ModuleScript") then
+		return require(currentInstance)
+	else
+		error("Failed to import!", 2)
+	end
 end
 
 function TS.exportNamespace(module, ancestor)

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -490,7 +490,7 @@ export class Transpiler {
 		let result = "";
 		let rhsPrefix: string;
 		if (rhs.length === 1) {
-			rhsPrefix = `require(${luaPath})`;
+			rhsPrefix = luaPath;
 		} else {
 			rhsPrefix = this.getNewId();
 			result += `local ${rhsPrefix} = require(${luaPath});\n`;


### PR DESCRIPTION
This adds a new function to the RuntimeLib, `TS.import`.
`TS.import` takes a root instance or service name, then a variable number of arguments used to traverse to the desired instance. This is then loaded with `require` and returned.

If the instance can't be found, an error is thrown since there would be lots of type issues if the execution were to continue.

Closes #43 