### PR TITLE
Add support for relative paths across rojo partitions

### DIFF
--- a/src/class/Compiler.ts
+++ b/src/class/Compiler.ts
@@ -324,7 +324,13 @@ export class Compiler {
 		}
 	}
 
-	public getRelativeImportPath(sourceFile: ts.SourceFile, specifier: string) {
+	public getRelativeImportPath(sourceFile: ts.SourceFile, destinationFile: ts.SourceFile | undefined, specifier: string) {
+		const currentPartition = this.syncInfo.find(part => part.dir.isAncestorOf(sourceFile))
+		const destinationPartition = destinationFile && this.syncInfo.find(part => part.dir.isAncestorOf(destinationFile))
+
+		if (destinationFile && currentPartition && currentPartition.target !== (destinationPartition && destinationPartition.target))
+			return this.getImportPathFromFile(destinationFile)
+
 		const parts = path.posix.normalize(specifier)
 			.split("/")
 			.filter(part => part !== ".")
@@ -337,8 +343,8 @@ export class Compiler {
 			prefix += ".Parent";
 		}
 
-		const importRoot = prefix + parts.filter((p) => p === ".Parent").join("")
-		const importParts = parts.filter((p) => p !== ".Parent")
+		const importRoot = prefix + parts.filter((p) => p === ".Parent").join("");
+		const importParts = parts.filter((p) => p !== ".Parent");
 		return `TS.import(${importRoot}${importParts.length > 0 && `, "${importParts.join(`", "`)}"`})`;
 	}
 

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -449,7 +449,8 @@ export class Transpiler {
 		if (node.isModuleSpecifierRelative()) {
 			luaPath = this.compiler.getRelativeImportPath(
 				node.getSourceFile(),
-				node.getModuleSpecifier().getLiteralText(),
+				node.getModuleSpecifierSourceFile(),
+				node.getModuleSpecifier().getLiteralText()
 			);
 		} else {
 			const moduleFile = node.getModuleSpecifierSourceFile();
@@ -520,7 +521,7 @@ export class Transpiler {
 		const moduleSpecifier = node.getModuleSpecifier();
 		if (moduleSpecifier) {
 			if (node.isModuleSpecifierRelative()) {
-				luaPath = this.compiler.getRelativeImportPath(node.getSourceFile(), moduleSpecifier.getLiteralText());
+				luaPath = this.compiler.getRelativeImportPath(node.getSourceFile(), node.getModuleSpecifierSourceFile(), moduleSpecifier.getLiteralText());
 			} else {
 				const moduleFile = node.getModuleSpecifierSourceFile();
 				if (moduleFile) {


### PR DESCRIPTION
Example:
```TypeScript
import TeleportUtil from "../../../../../lua/TeleportUtil";
```
Will now compile to
```Lua
local TeleportUtil = TS.import("ServerScriptService", "TeleportUtil")._default;
```
In the past, it would compile to
```Lua
local TeleportUtil = TS.import(script.Parent.Parent.Parent.Parent.Parent, "lua", "TeleportUtil")._default;
```
Which is invalid, given it is trying to reach a file not in its partition.

Closes #45