### PR TITLE
Patch bug from fix of #43

### DIFF
--- a/src/class/Compiler.ts
+++ b/src/class/Compiler.ts
@@ -337,9 +337,9 @@ export class Compiler {
 			prefix += ".Parent";
 		}
 
-		const importRoot = prefix + parts.filter((p) => p === ".Parent").join("")
-		const importParts = parts.filter((p) => p !== ".Parent")
-		return `TS.import(${importRoot}${importParts.length > 0 && `, "${importParts.join(`", "`)}"`})`;
+		const importRoot = prefix + parts.filter((p) => p === ".Parent").join("");
+		const importParts = parts.filter((p) => p !== ".Parent");
+		return `TS.import(${importRoot}${importParts.length > 0 ? `, "${importParts.join(`", "`)}"`: ""})`;
 	}
 
 	public getImportPathFromFile(file: ts.SourceFile) {
@@ -398,7 +398,7 @@ export class Compiler {
 				parts.push(last);
 			}
 
-			return `TS.import("${partition.target.split(".").join(`", "`)}${parts.length > 0 && `", "${parts.join(`", "`)}`}")`;
+			return `TS.import("${partition.target.split(".").join(`", "`)}${parts.length > 0 ? `", "${parts.join(`", "`)}`: ""}")`;
 		}
 	}
 }

--- a/src/class/Compiler.ts
+++ b/src/class/Compiler.ts
@@ -398,9 +398,7 @@ export class Compiler {
 				parts.push(last);
 			}
 
-			parts = parts.map(part => (isValidLuaIdentifier(part) ? "." + part : `["${part}"]`));
-
-			return `TS.import("${partition.target.split(".").join(`", "`)}")`;
+			return `TS.import("${partition.target.split(".").join(`", "`)}${parts.length > 0 && `", "${parts.join(`", "`)}`}")`;
 		}
 	}
 }

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -493,7 +493,7 @@ export class Transpiler {
 			rhsPrefix = luaPath;
 		} else {
 			rhsPrefix = this.getNewId();
-			result += `local ${rhsPrefix} = require(${luaPath});\n`;
+			result += `local ${rhsPrefix} = ${luaPath};\n`;
 		}
 		const lhsStr = lhs.join(", ");
 		const rhsStr = rhs.map(v => rhsPrefix + v).join(", ");


### PR DESCRIPTION
After #43 was fixed, two things were left out.

In some instances, imports were still being wrapped with `require`, and in another instance, not all parts of the imported path were included.