### PR TITLE
Fix Switch Statements with Return

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1306,9 +1306,9 @@ export class Transpiler {
 				this.pushIndent();
 			}
 
-			let statements = clause.getStatements();
-			let lastChild = statements[statements.length - 1];
-			let endsInReturnStatement = lastChild && lastChild.getKind() === ts.SyntaxKind.ReturnStatement;
+			const statements = clause.getStatements();
+			const lastChild = statements[statements.length - 1];
+			const endsInReturnStatement = lastChild && lastChild.getKind() === ts.SyntaxKind.ReturnStatement;
 
 			result += this.transpileStatementedNode(clause);
 

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1305,9 +1305,17 @@ export class Transpiler {
 				result += this.indent + `if ${fallThroughVar} or ${expStr} == ( ${clauseExpStr} ) then\n`;
 				this.pushIndent();
 			}
+
+			let statements = clause.getStatements();
+			let lastChild = statements[statements.length - 1];
+			let endsInReturnStatement = lastChild && lastChild.getKind() === ts.SyntaxKind.ReturnStatement;
+
 			result += this.transpileStatementedNode(clause);
+
 			if (ts.TypeGuards.isCaseClause(clause)) {
-				result += this.indent + `${fallThroughVar} = true;\n`;
+				if (!endsInReturnStatement) {
+					result += this.indent + `${fallThroughVar} = true;\n`;
+				}
 				this.popIndent();
 				result += this.indent + `end;\n`;
 			}


### PR DESCRIPTION
Switch statements previously would not compile properly when returning out of them. Now they do!

The problem was that `${fallThroughVar} = true;` would be appended no matter what, even after a return statement.
```ts
function t(k : string) : number {
	switch (k) {
		case "a:":
		case "Hello":
			print("Nope")
			return 1;
		default:
			print("Soup")
			return 2;
	}
}

t("a:")
```

By the way, I just started TypeScript today so please look very carefully at my submitted code!