### PR TITLE
Fix inheritance issues with custom accessors

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1046,7 +1046,7 @@ export class Transpiler {
 		if (getters.length > 0 || ancestorHasGetters) {
 			if (getters.length > 0) {
 				if (ancestorHasGetters) {
-					result += this.indent + `${id}._getters = setmetatable({}, { __index = super._getters })\n`;
+					result += this.indent + `${id}._getters = setmetatable({}, { __index = super._getters });\n`;
 				} else {
 					result += this.indent + `${id}._getters = {};\n`;
 				}
@@ -1093,7 +1093,7 @@ export class Transpiler {
 		if (setters.length > 0 || ancestorHasSetters) {
 			if (setters.length > 0) {
 				if (ancestorHasSetters) {
-					result += this.indent + `${id}._setters = setmetatable({}, { __index = super._setters })\n`;
+					result += this.indent + `${id}._setters = setmetatable({}, { __index = super._setters });\n`;
 				} else {
 					result += this.indent + `${id}._setters = {};\n`;
 				}

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1045,7 +1045,11 @@ export class Transpiler {
 		}
 		if (getters.length > 0 || ancestorHasGetters) {
 			if (getters.length > 0) {
-				result += this.indent + `${id}._getters = {};\n`;
+				if (ancestorHasGetters) {
+					result += this.indent + `${id}._getters = setmetatable({}, { __index = super._getters })\n`;
+				} else {
+					result += this.indent + `${id}._getters = {};\n`;
+				}
 				for (const getter of getters) {
 					const propName = getter.getName();
 					result += this.transpileAccessorDeclaration(getter, id, safeLuaIndex("_getters", propName));
@@ -1088,7 +1092,11 @@ export class Transpiler {
 		}
 		if (setters.length > 0 || ancestorHasSetters) {
 			if (setters.length > 0) {
-				result += this.indent + `${id}._setters = {};\n`;
+				if (ancestorHasSetters) {
+					result += this.indent + `${id}._setters = setmetatable({}, { __index = super._setters })\n`;
+				} else {
+					result += this.indent + `${id}._setters = {};\n`;
+				}
 				for (const setter of setters) {
 					const propName = setter.getName();
 					result += this.transpileAccessorDeclaration(setter, id, safeLuaIndex("_setters", propName));

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1038,8 +1038,9 @@ export class Transpiler {
 				const ancestorGetters = ancestorClass
 					.getInstanceProperties()
 					.filter((prop): prop is ts.GetAccessorDeclaration => ts.TypeGuards.isGetAccessorDeclaration(prop));
-				if (ancestorGetters.length > 0)
+				if (ancestorGetters.length > 0) {
 					ancestorHasGetters = true;
+				}
 			}
 		}
 		if (getters.length > 0 || ancestorHasGetters) {

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1030,16 +1030,16 @@ export class Transpiler {
 		const getters = node
 			.getInstanceProperties()
 			.filter((prop): prop is ts.GetAccessorDeclaration => ts.TypeGuards.isGetAccessorDeclaration(prop));
-		let ancestorHasGetters: boolean = false
-		let ancestorClass: ts.ClassDeclaration | undefined = node
+		let ancestorHasGetters = false;
+		let ancestorClass: ts.ClassDeclaration | undefined = node;
 		while (!ancestorHasGetters && ancestorClass !== undefined) {
-			ancestorClass = ancestorClass.getBaseClass()
+			ancestorClass = ancestorClass.getBaseClass();
 			if (ancestorClass !== undefined) {
 				const ancestorGetters = ancestorClass
 					.getInstanceProperties()
 					.filter((prop): prop is ts.GetAccessorDeclaration => ts.TypeGuards.isGetAccessorDeclaration(prop));
 				if (ancestorGetters.length > 0)
-					ancestorHasGetters = true
+					ancestorHasGetters = true;
 			}
 		}
 		if (getters.length > 0 || ancestorHasGetters) {
@@ -1049,8 +1049,9 @@ export class Transpiler {
 					const propName = getter.getName();
 					result += this.transpileAccessorDeclaration(getter, id, safeLuaIndex("_getters", propName));
 				}
-			} else
-				result += this.indent + `${id}._getters = super._getters;\n`
+			} else {
+				result += this.indent + `${id}._getters = super._getters;\n`;
+			}
 			result += this.indent + `${id}.__index = function(self, index)\n`;
 			this.pushIndent();
 			result += this.indent + `local getter = ${id}._getters[index];\n`;
@@ -1072,16 +1073,16 @@ export class Transpiler {
 		const setters = node
 			.getInstanceProperties()
 			.filter((prop): prop is ts.SetAccessorDeclaration => ts.TypeGuards.isSetAccessorDeclaration(prop));
-		let ancestorHasSetters: boolean = false
-		ancestorClass = node
+		let ancestorHasSetters = false;
+		ancestorClass = node;
 		while (!ancestorHasSetters && ancestorClass !== undefined) {
-			ancestorClass = ancestorClass.getBaseClass()
+			ancestorClass = ancestorClass.getBaseClass();
 			if (ancestorClass !== undefined) {
 				const ancestorSetters = ancestorClass
 					.getInstanceProperties()
 					.filter((prop): prop is ts.GetAccessorDeclaration => ts.TypeGuards.isSetAccessorDeclaration(prop));
 				if (ancestorSetters.length > 0)
-					ancestorHasSetters = true
+					ancestorHasSetters = true;
 			}
 		}
 		if (setters.length > 0 || ancestorHasSetters) {
@@ -1091,8 +1092,9 @@ export class Transpiler {
 					const propName = setter.getName();
 					result += this.transpileAccessorDeclaration(setter, id, safeLuaIndex("_setters", propName));
 				}
-			} else
-				result += this.indent + `${id}._setters = super._setters;\n`
+			} else {
+				result += this.indent + `${id}._setters = super._setters;\n`;
+			}
 			result += this.indent + `${id}.__newindex = function(self, index, value)\n`;
 			this.pushIndent();
 			result += this.indent + `local setter = ${id}._setters[index];\n`;

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -2,7 +2,6 @@ import * as ts from "ts-simple-ast";
 import { safeLuaIndex } from "../utility";
 import { Compiler } from "./Compiler";
 import { TranspilerError } from "./errors/TranspilerError";
-import { SyntaxKind } from "ts-simple-ast";
 
 type HasParameters =
 	| ts.FunctionExpression


### PR DESCRIPTION
This uses the solution as described in #55. The `_getters` and `_setters` are now direct members of class declarations. When a given class does not have getters/setters, but it inherits from a class with them, then the super class's `_getters` and `_setters` tables are used, and the custom `__index` and `__newindex` functions are used as well.

This example illustrates different facets of these changes:
```TypeScript
class RootTest {
    get test() {
        return "Test"
    }
}

class Test1 extends RootTest {
    test = super.test + "Test1"
}

class Test2 extends Test1 {
    test = "Test2"
}

class Test3 extends Test1 {
    otherTest = "Test3"
}

class Test4 extends RootTest {
    get newTest() {
        return "Test4"
    }

    set newTest(_value) { }
}

print(new RootTest().test) // Expected: "Test" Actual: "Test"
print(new Test1().test) // Expected: "TestTest1" Actual: "TestTest1"
print(new Test2().test) // Expected: "Test2" Actual: "Test2"
print(new Test3().test) // Expected: "TestTest1" Actual: "TestTest1"
print(new Test3().otherTest) // Expected: "Test3" Actual: "Test3"
print(new Test4().test) // Expected: "Test" Actual: "Test"
print(new Test4().newTest) // Expected: "Test4" Actual: "Test4"
```
This compiles to:
```Lua
RootTest = (function(super)
	local _4 = setmetatable({}, super);
	_4._getters = {};
	_4._getters.test = function(self)
		return "Test";
	end;
	_4.__index = function(self, index)
		local getter = _4._getters[index];
		if getter then
			return getter(self);
		else
			return _4[index];
		end;
	end;
	_4.new = function(...)
		local self = setmetatable({}, _4);
		self:constructor(...);
		return self;
	end;
	_4.constructor = function(self, ...)
		if super then super.constructor(self, ...) end;
	end;
	return _4;
end)();
Test1 = (function(super)
	local _4 = setmetatable({}, super);
	_4._getters = super._getters;
	_4.__index = function(self, index)
		local getter = _4._getters[index];
		if getter then
			return getter(self);
		else
			return _4[index];
		end;
	end;
	_4.new = function(...)
		local self = setmetatable({}, _4);
		self:constructor(...);
		return self;
	end;
	_4.constructor = function(self, ...)
		if super then super.constructor(self, ...) end;
		self.test = self.test .. "Test1";
	end;
	return _4;
end)(RootTest);
Test2 = (function(super)
	local _4 = setmetatable({}, super);
	_4._getters = super._getters;
	_4.__index = function(self, index)
		local getter = _4._getters[index];
		if getter then
			return getter(self);
		else
			return _4[index];
		end;
	end;
	_4.new = function(...)
		local self = setmetatable({}, _4);
		self:constructor(...);
		return self;
	end;
	_4.constructor = function(self, ...)
		if super then super.constructor(self, ...) end;
		self.test = "Test2";
	end;
	return _4;
end)(Test1);
Test3 = (function(super)
	local _4 = setmetatable({}, super);
	_4._getters = super._getters;
	_4.__index = function(self, index)
		local getter = _4._getters[index];
		if getter then
			return getter(self);
		else
			return _4[index];
		end;
	end;
	_4.new = function(...)
		local self = setmetatable({}, _4);
		self:constructor(...);
		return self;
	end;
	_4.constructor = function(self, ...)
		if super then super.constructor(self, ...) end;
		self.otherTest = "Test3";
	end;
	return _4;
end)(Test1);
Test4 = (function(super)
	local _4 = setmetatable({}, super);
	_4._getters = {};
	_4._getters.newTest = function(self)
		return "Test4";
	end;
	_4.__index = function(self, index)
		local getter = _4._getters[index];
		if getter then
			return getter(self);
		else
			return _4[index];
		end;
	end;
	_4._setters = {};
	_4._setters.newTest = function(self, _value)
	end;
	_4.__newindex = function(self, index, value)
		local setter = _4._setters[index];
		if setter then
			setter(self, value);
		else
			rawset(self, index, value);
		end;
	end;
	_4.new = function(...)
		local self = setmetatable({}, _4);
		self:constructor(...);
		return self;
	end;
	_4.constructor = function(self, ...)
		if super then super.constructor(self, ...) end;
	end;
	return _4;
end)(RootTest);
print(RootTest.new().test);
print(Test1.new().test);
print(Test2.new().test);
print(Test3.new().test);
print(Test3.new().otherTest);
print(Test4.new().test);
print(Test4.new().newTest);
```

I would encourage a reviewer to test this for themselves for verification purposes. I did not have the time to personally test this in Roblox.

Closes #55 