### PR TITLE
Fix metamethods

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1091,13 +1091,14 @@ export class Transpiler {
 
 		const id = name;
 
+		result += this.indent + `${id} = {};\n`;
+
 		if (baseClassName) {
-			result += this.indent + `${id} = setmetatable({}, ${baseClassName});\n`;
+			result += this.indent + `${id}.__index = setmetatable({}, ${baseClassName});\n`;
 		} else {
-			result += this.indent + `${id} = {};\n`;
+			result += this.indent + `${id}.__index = {};\n`;
 		}
 
-		result += this.indent + `${id}.__index = {};\n`;
 
 		for (const prop of node.getStaticProperties()) {
 			const propName = prop.getName();

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -876,11 +876,11 @@ export class Transpiler {
 			if (ts.TypeGuards.isVariableDeclarationList(initializer)) {
 				result += this.transpileVariableDeclarationList(initializer);
 			} else if (ts.TypeGuards.isExpression(initializer)) {
-				let x = this.transpileExpression(initializer);
-				if (!x.includes("=") && !ts.TypeGuards.isCallExpression(initializer)) {
-					x = `local _ = ` + x;
+				let expStr = this.transpileExpression(initializer);
+				if (!ts.TypeGuards.isVariableDeclarationList(initializer) && !ts.TypeGuards.isCallExpression(initializer)) {
+					expStr = `local _ = ` + expStr;
 				}
-				result += this.indent + x + ";\n";
+				result += this.indent + expStr + ";\n";
 			}
 		}
 		result += this.indent + `while ${conditionStr} do\n`;
@@ -2200,7 +2200,7 @@ export class Transpiler {
 			}
 			result += this.indent + "return _exports;\n";
 		}
-		let runtimeLibImport = "local TS = require(game:GetService(\"ReplicatedStorage\").RobloxTS.Include.RuntimeLib);\n";
+		let runtimeLibImport = `local TS = require(game:GetService("ReplicatedStorage").RobloxTS.Include.RuntimeLib);\n`;
 		if (noHeader) {
 			runtimeLibImport = "-- " + runtimeLibImport;
 		}

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -106,13 +106,13 @@ const LUA_RESERVED_METAMETHODS = [
 	"__len",
 	"__metatable",
 	"__mode",
-]
+];
 
 const LUA_UNDEFINABLE_METAMETHODS = [
 	"__index",
 	"__newindex",
 	"__mode",
-]
+];
 
 function isRbxClassType(type: ts.Type) {
 	const symbol = type.getSymbol();
@@ -1100,7 +1100,6 @@ export class Transpiler {
 			result += this.indent + `${id}.__index = {};\n`;
 		}
 
-
 		for (const prop of node.getStaticProperties()) {
 			const propName = prop.getName();
 			this.checkMethodReserved(propName, prop);
@@ -1122,7 +1121,7 @@ export class Transpiler {
 				}
 				result += this.indent + `${id}.${metamethod} = function(self, ...) return self:${metamethod}(...); end;\n`;
 			}
-		})
+		});
 
 		const extraInitializers = new Array<string>();
 		const instanceProps = node
@@ -1280,7 +1279,6 @@ export class Transpiler {
 		result += this.indent + `${className}.constructor = function(${paramStr})\n`;
 		this.pushIndent();
 
-
 		if (node) {
 			const body = node.getBodyOrThrow();
 			if (ts.TypeGuards.isBlock(body)) {
@@ -1290,10 +1288,10 @@ export class Transpiler {
 				initializers.forEach(initializer => (result += this.indent + initializer + "\n"));
 				result += this.transpileBlock(body);
 
-				for (const child of node.getStatements()) {
-					if (ts.TypeGuards.isReturnStatement(child)) {
-						throw new TranspilerError(`Cannot use return statement in constructor for ${className}`, child)
-					}
+				const returnStatement = node.getStatementByKind(ts.SyntaxKind.ReturnStatement);
+
+				if (returnStatement) {
+					throw new TranspilerError(`Cannot use return statement in constructor for ${className}`, returnStatement);
 				}
 			}
 		} else {

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1145,7 +1145,7 @@ export class Transpiler {
 
 		result += this.indent + `${id}.new = function(...)\n`;
 		this.pushIndent();
-		result += this.indent + `return ${id}.constructor(setmetatable({}, ${id}), ...);\n`;
+		result += this.indent + `return ${id}.constructor(setmetatable({}, ${id}.__index), ...);\n`;
 		this.popIndent();
 		result += this.indent + `end;\n`;
 

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1145,7 +1145,7 @@ export class Transpiler {
 
 		result += this.indent + `${id}.new = function(...)\n`;
 		this.pushIndent();
-		result += this.indent + `return ${id}.constructor(setmetatable({}, ${id}.__index), ...);\n`;
+		result += this.indent + `return ${id}.constructor(setmetatable({}, ${id}), ...);\n`;
 		this.popIndent();
 		result += this.indent + `end;\n`;
 

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -399,6 +399,7 @@ export class Transpiler {
 				break;
 			}
 		}
+
 		const hoists = this.hoistStack.pop();
 		if (hoists && hoists.length > 0) {
 			const hoistsStr = hoists.join(", ");
@@ -1278,6 +1279,8 @@ export class Transpiler {
 		let result = "";
 		result += this.indent + `${className}.constructor = function(${paramStr})\n`;
 		this.pushIndent();
+
+
 		if (node) {
 			const body = node.getBodyOrThrow();
 			if (ts.TypeGuards.isBlock(body)) {
@@ -1286,6 +1289,12 @@ export class Transpiler {
 				}
 				initializers.forEach(initializer => (result += this.indent + initializer + "\n"));
 				result += this.transpileBlock(body);
+
+				for (const child of node.getStatements()) {
+					if (ts.TypeGuards.isReturnStatement(child)) {
+						throw new TranspilerError(`Cannot use return statement in constructor for ${className}`, child)
+					}
+				}
 			}
 		} else {
 			if (baseClassName) {


### PR DESCRIPTION
- Changed `game.ReplicatedStorage` to `game:GetService("ReplicatedStorage")`
- Changed it so there can't be naming conflicts between transpiler-defined functions and methods or static members
- Made it so metamethods are now 100% inter-operable with Lua and respect inheritance
- Removed hard-coded `toString` cheat
- Made it so expressions in the first argument of for loops transpile to valid Lua code

Update:
- Fixed inheritance model

Update 2:
- Edited it according to the code-quality demands of Osyris
- Made the Transpiler error when a script-kiddie tries to use a return statement within a constructor function

Update 3:
- Fixed issues that the linter pointed out
- Updated the code that checks whether or not a return statement is used in a constructor