### PR TITLE
Fixed TemplateExpressions

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -2052,7 +2052,8 @@ export class Transpiler {
 			.replace(/\\"/g, '"')
 			.replace(/"/g, '\\"')
 			.slice(1, -2);
-		if (headText.length > 2) {
+
+		if (headText.length > 0) {
 			bin.push(`"${headText}"`);
 		}
 


### PR DESCRIPTION
It looks like you may have written the comparison before adding the `slice` method. It should be running for any length greater than 0 now that the `slice` method is included.