### PR TITLE
Fix precedence in class inheritance

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1150,7 +1150,18 @@ export class Transpiler {
 					const initializer = prop.getInitializer();
 					if (initializer) {
 						const propValue = this.transpileExpression(initializer);
-						extraInitializers.push(`self.${propName} = ${propValue};\n`);
+						const initializerKind = initializer.getKind();
+
+						if (
+							initializerKind === ts.SyntaxKind.StringLiteral ||
+							initializerKind === ts.SyntaxKind.NumericLiteral ||
+							initializerKind === ts.SyntaxKind.TrueKeyword ||
+							initializerKind === ts.SyntaxKind.FalseKeyword
+						) {
+							result += this.indent + `${id}.__index.${propName} = ${propValue};\n`;
+						} else {
+							extraInitializers.push(`self.${propName} = ${propValue};\n`);
+						}
 					}
 				}
 			}

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1151,6 +1151,16 @@ export class Transpiler {
 			}
 		}
 
+		node.getMethods()
+			.filter(method => method.getBody() !== undefined)
+			.forEach(method => {
+				if (!hasIndexMembers) {
+					hasIndexMembers = true;
+					result += "\n";
+				}
+				result += this.transpileMethodDeclaration(id, method);
+			});
+
 		this.popIndent();
 
 		if (baseClassName) {
@@ -1191,10 +1201,6 @@ export class Transpiler {
 		}
 
 		result += this.transpileConstructorDeclaration(id, getConstructor(node), extraInitializers, baseClassName);
-
-		node.getMethods()
-			.filter(method => method.getBody() !== undefined)
-			.forEach(method => (result += this.transpileMethodDeclaration(id, method)));
 
 		const getters = node
 			.getInstanceProperties()
@@ -1403,9 +1409,9 @@ export class Transpiler {
 
 		let result = "";
 		if (node.isAsync()) {
-			result += this.indent + `${className}.__index.${name} = TS.async(function(${paramStr})\n`;
+			result += this.indent + `${name} = TS.async(function(${paramStr})\n`;
 		} else {
-			result += this.indent + `${className}.__index.${name} = function(${paramStr})\n`;
+			result += this.indent + `${name} = function(${paramStr})\n`;
 		}
 		this.pushIndent();
 		if (ts.TypeGuards.isBlock(body)) {

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1112,29 +1112,6 @@ export class Transpiler {
 			result += this.indent + `${id}.__index = {};\n`;
 		}
 
-		for (const prop of node.getStaticProperties()) {
-			const propName = prop.getName();
-			this.checkMethodReserved(propName, prop);
-
-			let propValue = "nil";
-			if (ts.TypeGuards.isInitializerExpressionableNode(prop)) {
-				const initializer = prop.getInitializer();
-				if (initializer) {
-					propValue = this.transpileExpression(initializer);
-				}
-			}
-			result += this.indent + `${id}.${propName} = ${propValue};\n`;
-		}
-
-		LUA_RESERVED_METAMETHODS.forEach(metamethod => {
-			if (getClassMethod(node, metamethod)) {
-				if (LUA_UNDEFINABLE_METAMETHODS.indexOf(metamethod) !== -1) {
-					throw new TranspilerError(`Cannot use undefinable Lua metamethod as identifier '${metamethod}' for a class`, node);
-				}
-				result += this.indent + `${id}.${metamethod} = function(self, ...) return self:${metamethod}(...); end;\n`;
-			}
-		});
-
 		const extraInitializers = new Array<string>();
 		const instanceProps = node
 			.getInstanceProperties()
@@ -1166,6 +1143,29 @@ export class Transpiler {
 				}
 			}
 		}
+
+		for (const prop of node.getStaticProperties()) {
+			const propName = prop.getName();
+			this.checkMethodReserved(propName, prop);
+
+			let propValue = "nil";
+			if (ts.TypeGuards.isInitializerExpressionableNode(prop)) {
+				const initializer = prop.getInitializer();
+				if (initializer) {
+					propValue = this.transpileExpression(initializer);
+				}
+			}
+			result += this.indent + `${id}.${propName} = ${propValue};\n`;
+		}
+
+		LUA_RESERVED_METAMETHODS.forEach(metamethod => {
+			if (getClassMethod(node, metamethod)) {
+				if (LUA_UNDEFINABLE_METAMETHODS.indexOf(metamethod) !== -1) {
+					throw new TranspilerError(`Cannot use undefinable Lua metamethod as identifier '${metamethod}' for a class`, node);
+				}
+				result += this.indent + `${id}.${metamethod} = function(self, ...) return self:${metamethod}(...); end;\n`;
+			}
+		});
 
 		if (!node.isAbstract()) {
 			result += this.indent + `${id}.new = function(...)\n`;

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1169,20 +1169,6 @@ export class Transpiler {
 			result += `${((hasIndexMembers) ? this.indent : "")}};\n`;
 		}
 
-		for (const prop of node.getStaticProperties()) {
-			const propName = prop.getName();
-			this.checkMethodReserved(propName, prop);
-
-			let propValue = "nil";
-			if (ts.TypeGuards.isInitializerExpressionableNode(prop)) {
-				const initializer = prop.getInitializer();
-				if (initializer) {
-					propValue = this.transpileExpression(initializer);
-				}
-			}
-			result += this.indent + `${id}.${propName} = ${propValue};\n`;
-		}
-
 		LUA_RESERVED_METAMETHODS.forEach(metamethod => {
 			if (getClassMethod(node, metamethod)) {
 				if (LUA_UNDEFINABLE_METAMETHODS.indexOf(metamethod) !== -1) {
@@ -1201,6 +1187,20 @@ export class Transpiler {
 		}
 
 		result += this.transpileConstructorDeclaration(id, getConstructor(node), extraInitializers, baseClassName);
+
+		for (const prop of node.getStaticProperties()) {
+			const propName = prop.getName();
+			this.checkMethodReserved(propName, prop);
+
+			let propValue = "nil";
+			if (ts.TypeGuards.isInitializerExpressionableNode(prop)) {
+				const initializer = prop.getInitializer();
+				if (initializer) {
+					propValue = this.transpileExpression(initializer);
+				}
+			}
+			result += this.indent + `${id}.${propName} = ${propValue};\n`;
+		}
 
 		const getters = node
 			.getInstanceProperties()


### PR DESCRIPTION
The old system messed things up:
```ts
abstract class Item {
	public static Game: Person = new Person();
	public Owner: Person = Item.Game;
	public readonly ClassName: string = "Item";
}

class Medkit extends Item {
	public readonly ClassName: string = "Medkit";

	constructor() {
		super();
		this.ClassName = "Mine";
	}
}
```

```lua
local Item, Medkit;
do
	Item = {};
	Item.__index = {};
	Item.Game = Person.new();
	Item.constructor = function(self, ...)
		self.Owner = Item.Game;
		self.ClassName = "Item";
		return self;
	end;
end;
do
	Medkit = {};
	Medkit.__index = setmetatable({}, Item);
	Medkit.new = function(...)
		return Medkit.constructor(setmetatable({}, Medkit), ...);
	end;
	Medkit.constructor = function(self)
		self.ClassName = "Medkit";
		Item.constructor(self);
		self.ClassName = "Mine";
		return self;
	end;
end;
```
As you can see, the ClassName would not be written in the proper order. Here is the JS:
```js
class Medkit extends Item {
    constructor() {
        super();
        this.ClassName = "Medkit";
        this.ClassName = "Mine";
    }
}
```
If we removed "Mine", then our Lua `Medkit` would have "Item" for a `ClassName`.

This PR changes to the following precedence in Constructors (first to last):
```
defaults (`if x == nil then x = 5 end`)
superExpression
initializers
extraInitializers
RemainingExpressions
```

This update also drops an Objects methods directly into its `__index` metamethod. This is preferable because a superclass's `__newindex` can be called when declaring a function if done after setting the metatable of the `__index` table. String literals, numeric literals, and true/false values are dropped into the __index metamethod rather than being individually assigned in each constructor. This is preferable, especially for large inheritance chains. Any value that doesn't change or need new instantiation can get this treatment. For example, if a class has a non-static member set to `new Person()` by default, that means that each constructor should generate a `new Person()` object, and not that one is generated initially by the class and simply referred back to. For this reason I was conservative about what we can detect as a non-object and just went with basic literals for now.

Update: Static members of a class now follow constructors as they do when transpiling to JS. This makes it possible to instantiate a static `new Person()` as a member of a Person Class.