### PR TITLE
Initialize Transpiled Accessors In-Line

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -137,12 +137,12 @@ function inheritsFrom(type: ts.Type, className: string): boolean {
 	const symbol = type.getSymbol();
 	return symbol !== undefined
 		? symbol.getName() === className ||
-		symbol.getDeclarations().some(declaration =>
-			declaration
-				.getType()
-				.getBaseTypes()
-				.some(baseType => inheritsFrom(baseType, className)),
-		)
+				symbol.getDeclarations().some(declaration =>
+					declaration
+						.getType()
+						.getBaseTypes()
+						.some(baseType => inheritsFrom(baseType, className)),
+				)
 		: false;
 }
 
@@ -183,7 +183,7 @@ export class Transpiler {
 	private isModule = false;
 	private indent = "";
 
-	constructor(private compiler: Compiler) { }
+	constructor(private compiler: Compiler) {}
 
 	private getNewId() {
 		const sum = this.idStack.reduce((accum, value) => accum + value);

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1210,9 +1210,10 @@ export class Transpiler {
 					getterContent += this.transpileAccessorDeclaration(getter, getter.getName());
 				}
 				this.popIndent();
-				getterContent += this.indent
+				getterContent += this.indent;
 				if (ancestorHasGetters) {
-					result += this.indent + `${id}._getters = setmetatable({${getterContent}}, { __index = ${baseClassName}._getters });\n`;
+					result +=
+						this.indent + `${id}._getters = setmetatable({${getterContent}}, { __index = ${baseClassName}._getters });\n`;
 				} else {
 					result += this.indent + `${id}._getters = {${getterContent}};\n`;
 				}
@@ -1260,7 +1261,7 @@ export class Transpiler {
 					setterContent += this.transpileAccessorDeclaration(setter, setter.getName());
 				}
 				this.popIndent();
-				setterContent += this.indent
+				setterContent += this.indent;
 				if (ancestorHasSetters) {
 					result +=
 						this.indent + `${id}._setters = setmetatable({${setterContent}}, { __index = ${baseClassName}._setters });\n`;


### PR DESCRIPTION
This is just a small readability improvement of compiled code. Currently, an accessor table is initialized, and the functions are added separately. This makes it so getters/setters are now initialized inside said table.
Consider this example:
```TypeScript
class Test {
    get test() {
        return "test"
    }
}
```
Previously, it would compile like so:
```Lua
do
	Test = {};
	Test.__index = {};
	Test.new = function(...)
		return Test.constructor(setmetatable({}, Test), ...);
	end;
	Test.constructor = function(self, ...)
		return self;
	end;
	Test._getters = {};
	Test._getters.test = function(self)
		return "test";
	end;
	local __index = Test.__index
	Test.__index = function(self, index)
		local getter = Test._getters[index];
		if getter then
			return getter(self);
		else
			return __index[index];
		end;
	end;
end;
```
Now, it will compile like this:
```Lua
do
	Test = {};
	Test.__index = {};
	Test.new = function(...)
		return Test.constructor(setmetatable({}, Test), ...);
	end;
	Test.constructor = function(self, ...)
		return self;
	end;
	Test._getters = {
		test = function(self)
			return "test";
		end;
	};
	local __index = Test.__index;
	Test.__index = function(self, index)
		local getter = Test._getters[index];
		if getter then
			return getter(self);
		else
			return __index[index];
		end;
	end;
end;
```