### PR TITLE
Move Accessor Index Functions Into RuntimeLib

### DIFF
--- a/include/RuntimeLib.lua
+++ b/include/RuntimeLib.lua
@@ -137,6 +137,31 @@ function TS.add(a, b)
 	end
 end
 
+-- accessor index functions
+TS.accessors = {}
+
+function TS.accessors.gettersIndex(classIndex, getters)
+	return function(self, index)
+		local getter = getters[index]
+		if getter then
+			return getter(self)
+		else
+			return classIndex[index]
+		end
+	end
+end
+
+function TS.accessors.settersNewIndex(setters)
+	return function(self, index, value)
+		local setter = setters[index]
+		if setter then
+			setter(self, value)
+		else
+			rawset(self, index, value)
+		end
+	end
+end
+
 -- array macro functions
 TS.array = {}
 

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1217,21 +1217,7 @@ export class Transpiler {
 			} else {
 				result += this.indent + `${id}._getters = ${baseClassName}._getters;\n`;
 			}
-			result += this.indent + `local __index = ${id}.__index\n`;
-			result += this.indent + `${id}.__index = function(self, index)\n`;
-			this.pushIndent();
-			result += this.indent + `local getter = ${id}._getters[index];\n`;
-			result += this.indent + `if getter then\n`;
-			this.pushIndent();
-			result += this.indent + `return getter(self);\n`;
-			this.popIndent();
-			result += this.indent + `else\n`;
-			this.pushIndent();
-			result += this.indent + `return __index[index];\n`;
-			this.popIndent();
-			result += this.indent + `end;\n`;
-			this.popIndent();
-			result += this.indent + `end;\n`;
+			result += this.indent + `${id}.__index = TS.accessors.gettersIndex(${id}.__index, ${id}._getters);\n`
 		}
 
 		const setters = node
@@ -1265,20 +1251,7 @@ export class Transpiler {
 			} else {
 				result += this.indent + `${id}._setters = ${baseClassName}._setters;\n`;
 			}
-			result += this.indent + `${id}.__newindex = function(self, index, value)\n`;
-			this.pushIndent();
-			result += this.indent + `local setter = ${id}._setters[index];\n`;
-			result += this.indent + `if setter then\n`;
-			this.pushIndent();
-			result += this.indent + `setter(self, value);\n`;
-			this.popIndent();
-			result += this.indent + `else\n`;
-			this.pushIndent();
-			result += this.indent + `rawset(self, index, value);\n`;
-			this.popIndent();
-			result += this.indent + `end;\n`;
-			this.popIndent();
-			result += this.indent + `end;\n`;
+			result += this.indent + `${id}.__newindex = TS.accessors.settersNewIndex(${id}._setters);\n`
 		}
 
 		this.popIndent();

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1217,7 +1217,7 @@ export class Transpiler {
 			} else {
 				result += this.indent + `${id}._getters = ${baseClassName}._getters;\n`;
 			}
-			result += this.indent + `${id}.__index = TS.accessors.gettersIndex(${id}.__index, ${id}._getters);\n`
+			result += this.indent + `${id}.__index = TS.accessors.gettersIndex(${id}.__index, ${id}._getters);\n`;
 		}
 
 		const setters = node
@@ -1251,7 +1251,7 @@ export class Transpiler {
 			} else {
 				result += this.indent + `${id}._setters = ${baseClassName}._setters;\n`;
 			}
-			result += this.indent + `${id}.__newindex = TS.accessors.settersNewIndex(${id}._setters);\n`
+			result += this.indent + `${id}.__newindex = TS.accessors.settersNewIndex(${id}._setters);\n`;
 		}
 
 		this.popIndent();


### PR DESCRIPTION
This simplifies the compiled code of getters/setters further by moving the `__index` and `__newindex` functions into the runtime library.

As an example:
```TypeScript
class Test {
    get test() {
        return "test"
    }
}
```
This used to compile to
```Lua
do
	Test = {};
	Test.__index = {};
	Test.new = function(...)
		return Test.constructor(setmetatable({}, Test), ...);
	end;
	Test.constructor = function(self, ...)
		return self;
	end;
	Test._getters = {};
	Test._getters.test = function(self)
		return "test";
	end;
	local __index = Test.__index
	Test.__index = function(self, index)
		local getter = Test._getters[index];
		if getter then
			return getter(self);
		else
			return __index[index];
		end;
	end;
end;
```
But, now it will compile like so:
```Lua
do
	Test = {};
	Test.__index = {};
	Test.new = function(...)
		return Test.constructor(setmetatable({}, Test), ...);
	end;
	Test.constructor = function(self, ...)
		return self;
	end;
	Test._getters = {};
	Test._getters.test = function(self)
		return "test";
	end;
	Test.__index = TS.accessors.gettersIndex(Test.__index, Test._getters);
end;
```

The one consideration here is that if you compile with `noHeader`, then this approach will break.