### PR TITLE
[WIP] Truncate absolute rojo paths into directories

### DIFF
--- a/src/class/Compiler.ts
+++ b/src/class/Compiler.ts
@@ -142,7 +142,9 @@ export class Compiler {
 			const rojoJson = JSON.parse(fs.readFileSync(syncFilePath).toString()) as RojoJson;
 			for (const key in rojoJson.partitions) {
 				const part = rojoJson.partitions[key];
-				const partPath = path.resolve(this.projectPath, part.path).replace(/\\/g, "/");
+				let partPath = path.resolve(this.projectPath, part.path).replace(/\\/g, "/");
+				if (path.extname(partPath))
+					partPath = partPath.substring(0, partPath.lastIndexOf("/"))
 				if (partPath.startsWith(this.outDir)) {
 					const directory = this.project.getDirectory(
 						path.resolve(this.rootDir, path.relative(this.outDir, partPath)),

--- a/src/class/Compiler.ts
+++ b/src/class/Compiler.ts
@@ -143,8 +143,9 @@ export class Compiler {
 			for (const key in rojoJson.partitions) {
 				const part = rojoJson.partitions[key];
 				let partPath = path.resolve(this.projectPath, part.path).replace(/\\/g, "/");
-				if (path.extname(partPath))
-					partPath = partPath.substring(0, partPath.lastIndexOf("/"))
+				if (path.extname(partPath)) {
+					partPath = partPath.substring(0, partPath.lastIndexOf("/"));
+				}
 				if (partPath.startsWith(this.outDir)) {
 					const directory = this.project.getDirectory(
 						path.resolve(this.rootDir, path.relative(this.outDir, partPath)),


### PR DESCRIPTION
This fixes a bug where the compiler errors if you use an absolute/fully resolved path in your rojo.json config. This fix truncates the path if it contains a file name/extension.

Closes #75