### PR TITLE
Transpiler Error on "new RoactComponent(...)"

### DIFF
--- a/src/class/Compiler.ts
+++ b/src/class/Compiler.ts
@@ -376,7 +376,13 @@ export class Compiler {
 							}
 							prefix += " - ";
 						}
-						console.log("%s%s %s", prefix, red("Diagnostic Error:"), diagnostic.getMessageText());
+
+						const messageText = diagnostic.getMessageText();
+						if (messageText instanceof ts.DiagnosticMessageChain) {
+							console.log("%s%s %s", prefix, red("Diagnostic Error:"), messageText.getMessageText());
+						} else {
+							console.log("%s%s %s", prefix, red("Diagnostic Error:"), diagnostic.getMessageText());
+						}
 					}
 					errors++;
 				}

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -211,10 +211,15 @@ function getFullTypeList(type: ts.Type): Array<string> {
 
 function inheritsFromRoact(type: ts.Type): boolean {
 	const fullName = getFullTypeList(type);
-	if (fullName.length >= 2) {
-		return ROACT_COMPONENT_CLASSES.findIndex(value => fullName[1].startsWith(value)) !== -1;
+	let isRoactClass = false;
+	for (const name of fullName) {
+		if (ROACT_COMPONENT_CLASSES.findIndex(value => name.startsWith(value)) !== -1) {
+			isRoactClass = true;
+			break;
+		}
 	}
-	return false;
+
+	return isRoactClass;
 }
 
 function inheritsFrom(type: ts.Type, className: string): boolean {
@@ -2842,7 +2847,9 @@ export class Transpiler {
 		const params = this.transpileArguments(args);
 
 		if (inheritsFromRoact(expressionType)) {
-			throw new TranspilerError("Roact components cannot be created using new",
+			throw new TranspilerError(
+				`Roact components cannot be created using new\n` +
+				`\x1b[33mRecommendation: Roact.createElement(${name}), <${name}></${name}> or </${name}>\x1b[0m`,
 				node, TranspilerErrorType.RoactNoNewComponentAllowed);
 		}
 

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -120,7 +120,7 @@ const LUA_UNDEFINABLE_METAMETHODS = ["__index", "__newindex", "__mode"];
 const ROACT_ELEMENT_TYPE = "Roact.Element";
 const ROACT_COMPONENT_TYPE = "Roact.Component";
 const ROACT_PURE_COMPONENT_TYPE = "Roact.PureComponent";
-const ROACT_COMPONENT_CLASSES = ["Roact.Component", "Roact.PureComponent"];
+const ROACT_COMPONENT_CLASSES = [ROACT_COMPONENT_TYPE, ROACT_PURE_COMPONENT_TYPE];
 
 /**
  * A list of lowercase names that map to Roblox elements for JSX
@@ -212,7 +212,6 @@ function getFullTypeList(type: ts.Type): Array<string> {
 function inheritsFromRoact(type: ts.Type): boolean {
 	const fullName = getFullTypeList(type);
 	if (fullName.length >= 2) {
-		// return ROACT_COMPONENT_CLASSES.indexOf(fullName[1]) !== -1;
 		return ROACT_COMPONENT_CLASSES.findIndex(value => fullName[1].startsWith(value)) !== -1;
 	}
 	return false;
@@ -1413,15 +1412,6 @@ export class Transpiler {
 		return declaration;
 	}
 
-	private isRoactType(type: ts.Type<ts.ts.Type>) {
-		const isRoactType = type.getBaseTypes()
-			.filter(bc => {
-				const text = bc.getText();
-				return text.startsWith(ROACT_COMPONENT_TYPE) || text.startsWith(ROACT_PURE_COMPONENT_TYPE);
-			});
-		return isRoactType.length > 0;
-	}
-
 	private transpileClassDeclaration(node: ts.ClassDeclaration) {
 		const name = node.getName() || this.getNewId();
 		const nameNode = node.getNameNode();
@@ -1443,10 +1433,7 @@ export class Transpiler {
 				return this.transpileRoactClassDeclaration("PureComponent", name, node);
 			}
 
-			// Handle erroring on subclasses with roact
-			const isRoactSubType = this.isRoactType(baseType);
-
-			if (isRoactSubType) {
+			if (inheritsFromRoact(baseType)) {
 				throw new TranspilerError("Derived Classes are not supported in Roact!",
 					node, TranspilerErrorType.RoactSubClassesNotSupported);
 			}

--- a/src/class/errors/TranspilerError.ts
+++ b/src/class/errors/TranspilerError.ts
@@ -44,6 +44,7 @@ export enum TranspilerErrorType {
 	RoactSettersNotAllowed,
 	RoactSubClassesNotSupported,
 	RoactJsxTextNotSupported,
+	RoactNoNewComponentAllowed,
 }
 
 export class TranspilerError extends Error {

--- a/src/test.ts
+++ b/src/test.ts
@@ -89,6 +89,11 @@ const errorMatrix: ErrorMatrix = {
 		instance: TranspilerError,
 		type: TranspilerErrorType.RoactJsxTextNotSupported,
 	},
+	"roactNew.spec.tsx": {
+		message: "should not allow roact components to be created with new keyword",
+		instance: TranspilerError,
+		type: TranspilerErrorType.RoactNoNewComponentAllowed,
+	},
 };
 /* tslint:enable:object-literal-sort-keys */
 

--- a/tests/src/errors/roactNew.spec.tsx
+++ b/tests/src/errors/roactNew.spec.tsx
@@ -1,0 +1,10 @@
+import * as Roact from "rbx-roact";
+
+class FailedRoactClass extends Roact.Component<{}, {}> {
+	public render(): Roact.Element {
+		return <frame/>;
+	}
+}
+
+// This should not compile.
+const value = new FailedRoactClass({});


### PR DESCRIPTION
```ts
class RoactCustomComponent extends Roact.Component {
    // ...
}

const myComponent = new RoactCustomComponent({});
```
This is not supported by Roact.

Will also give recommended usage in error message as well.