### PR TITLE
Roact refactoring and fixes

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1382,8 +1382,6 @@ export class Transpiler {
 				}
 			}
 
-			declaration += this.indent + "self.props.children = self.props[Roact.Children];\n";
-
 			this.popIndent();
 
 			declaration += `${this.indent}end;\n`;

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -205,6 +205,25 @@ function getFullTypeList(type: ts.Type): Array<string> {
 	return typeArray;
 }
 
+function isRoactElementType(type: ts.Type) {
+	const allowed = [ROACT_ELEMENT_TYPE, "undefined"];
+	const types = type.getUnionTypes();
+	let isValidType = false;
+
+	for (const unionType of types) {
+		const unionTypeName = unionType.getText();
+		if (allowed.indexOf(unionTypeName) === -1) {
+			if (unionTypeName === ROACT_ELEMENT_TYPE) {
+				isValidType = true;
+			}
+
+			return false;
+		}
+	}
+
+	return isValidType;
+}
+
 function inheritsFromRoact(type: ts.Type): boolean {
 	const fullName = getFullTypeList(type);
 	let isRoactClass = false;

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -208,22 +208,17 @@ function getFullTypeList(type: ts.Type): Array<string> {
 function isRoactElementType(type: ts.Type) {
 	const allowed = [ROACT_ELEMENT_TYPE, `${ROACT_ELEMENT_TYPE}[]`];
 	const types = type.getUnionTypes();
-	// let isValidType = false;
 
 	if (types.length > 0) {
 		for (const unionType of types) {
 			const unionTypeName = unionType.getText();
-			console.log("check", unionTypeName);
 			if (allowed.indexOf(unionTypeName) === -1 && unionTypeName !== "undefined") {
-				console.log("return false on ", unionTypeName);
 				return false;
 			}
 		}
+	} else {
+		return false;
 	}
-
-	// if (allowed.indexOf(type.getText()) !== -1) {
-	// 	return true;
-	// }
 
 	return true;
 }
@@ -2349,21 +2344,15 @@ export class Transpiler {
 					if (ts.TypeGuards.isCallExpression(expression)) {
 						// Must return Roact.Element :(
 						const returnType = expression.getReturnType();
-						if (
-							isRoactElementType(returnType)
-						) {
+						if (isRoactElementType(returnType)) {
 							extraChildrenCollection.push(this.indent + this.transpileExpression(expression));
 						} else {
 							throw new TranspilerError(
-								`Function call must return Roact.Element -> {${expression.getText()}}`,
+								`Function call in an expression must return Roact.Element or Roact.Element[]`,
 								expression,
 								TranspilerErrorType.RoactInvalidCallExpression,
 							);
 						}
-						// } else {
-						// 	const value = this.transpileExpression(child);
-						// 	childCollection.push(`${this.indent}${value}`);
-						// }
 					} else if (ts.TypeGuards.isIdentifier(expression)) {
 						const definitionNodes = expression.getDefinitionNodes();
 						for (const definitionNode of definitionNodes) {
@@ -2372,8 +2361,7 @@ export class Transpiler {
 								extraChildrenCollection.push(this.indent + this.transpileExpression(expression));
 							} else {
 								throw new TranspilerError(
-									`Roact does not support identifiers that have the return type` +
-										`${type.getText()}`,
+									`Roact does not support identifiers that have the return type ` + type.getText(),
 									expression,
 									TranspilerErrorType.RoactInvalidIdentifierExpression,
 								);
@@ -2386,8 +2374,7 @@ export class Transpiler {
 							extraChildrenCollection.push(this.transpileExpression(expression));
 						} else {
 							throw new TranspilerError(
-								`Roact does not support the property type ` +
-									`${propertyType.getText()}`,
+								`Roact does not support the property type ` + propertyType.getText(),
 								expression,
 								TranspilerErrorType.RoactInvalidPropertyExpression,
 							);

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -2343,7 +2343,15 @@ export class Transpiler {
 						// Must return Roact.Element :(
 						const returnType = expression.getReturnType();
 						if (isRoactElementType(returnType)) {
-							extraChildrenCollection.push(this.indent + this.transpileExpression(expression));
+							if (returnType.isArray()) {
+								// Roact.Element[]
+								extraChildrenCollection.push(this.indent + this.transpileExpression(expression));
+							} else {
+								// Roact.Element
+								extraChildrenCollection.push(
+									this.indent + `{ ${this.transpileExpression(expression)} }`,
+								);
+							}
 						} else {
 							throw new TranspilerError(
 								`Function call in an expression must return Roact.Element or Roact.Element[]`,
@@ -2365,8 +2373,10 @@ export class Transpiler {
 								);
 							}
 						}
-					} else if (ts.TypeGuards.isPropertyAccessExpression(expression) ||
-						ts.TypeGuards.isElementAccessExpression(expression)) {
+					} else if (
+						ts.TypeGuards.isPropertyAccessExpression(expression) ||
+						ts.TypeGuards.isElementAccessExpression(expression)
+					) {
 						const propertyType = expression.getType();
 
 						if (isRoactElementType(propertyType)) {

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -217,7 +217,7 @@ function isRoactElementType(type: ts.Type) {
 			}
 		}
 	} else {
-		return false;
+		return allowed.indexOf(type.getText()) !== -1;
 	}
 
 	return true;
@@ -2367,7 +2367,8 @@ export class Transpiler {
 								);
 							}
 						}
-					} else if (ts.TypeGuards.isPropertyAccessExpression(expression)) {
+					} else if (ts.TypeGuards.isPropertyAccessExpression(expression) ||
+						ts.TypeGuards.isElementAccessExpression(expression)) {
 						const propertyType = expression.getType();
 
 						if (isRoactElementType(propertyType)) {

--- a/src/class/errors/TranspilerError.ts
+++ b/src/class/errors/TranspilerError.ts
@@ -46,6 +46,13 @@ export enum TranspilerErrorType {
 	RoactJsxTextNotSupported,
 	RoactNoNewComponentAllowed,
 	RoactJsxWithoutImport,
+	RoactInvalidSymbol,
+
+	RoactInvalidExpression,
+	RoactInvalidCallExpression,
+	RoactInvalidIdentifierExpression,
+	RoactInvalidPropertyExpression,
+
 	UnexpectedObjectIndex,
 }
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,7 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
-		"rbx-roact": "^0.0.18",
+		"rbx-roact": "^0.0.22",
 		"rbx-types": "^1.0.86"
 	}
 }

--- a/tests/src/roact.spec.tsx
+++ b/tests/src/roact.spec.tsx
@@ -280,13 +280,13 @@ export = () => {
 		expect(handle._rbx!.FindFirstChild("Frame103")).to.be.ok();
 	});
 
-	it("should be able to use this.props.children expressions", () => {
+	it("should be able to use this.props[Roact.Children] expressions", () => {
 		class TestComponent extends Roact.Component {
 			constructor() {
 				super({});
 			}
 			public render(): Roact.Element {
-				return <frame>{this.props.children}</frame>;
+				return <frame>{this.props[Roact.Children]}</frame>;
 			}
 		}
 
@@ -301,8 +301,6 @@ export = () => {
 
 		// expect the returned child to be a frame
 		expect(returned._rbx!.IsA("Frame")).to.be.ok();
-
-		print(returned._rbx!.GetChildren().length);
 
 		// expect there to be a textlabel called "Hello"
 		expect(returned._rbx!.FindFirstChildOfClass("TextLabel")).to.be.ok();


### PR DESCRIPTION
* Tidy up Roact-based code internally
  * Type checks improved and not duplicate (now a function - `isRoactElementType`)
  * Function expressions that return `Roact.Element[]` or `Roact.Element` better differentiated with `type.isArray()`
   * Added proper error types for the other Roact transpiler errors
* Removal of `this.props.children` in favour of `this.props[Roact.Children]` - first one was a hack that would break when an element was reconciled. It's better to just stay consistent with Roact itself.
* Fixed function expressions that returned a `Roact.Element` - Roact_merge would previously merge the element's properties with the other children which would lead to Roact throwing a confusing error.
* Supports using element access expressions that return `Roact.Element[]` to support using `{this.props[Roact.Children]}`