### PR TITLE
Fix exporting and importing

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1172,7 +1172,7 @@ export class Transpiler {
 				parent.getParent().getKind() === ts.SyntaxKind.SourceFile
 			) {
 				throw new TranspilerError(
-					"'export let' is not supported! Use 'export const' instead.",
+					"'export let' is not supported in the main source! Please use 'export const' or wrap it in an object.",
 					node,
 					TranspilerErrorType.NoExportLetKeyword,
 				);

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -379,10 +379,17 @@ export class Transpiler {
 
 	private getExportContextName(node: ts.VariableStatement | ts.Node): string {
 		const myNamespace = node.getFirstAncestorByKind(ts.SyntaxKind.ModuleDeclaration);
-		let name: string;
+		let name;
 
 		if (myNamespace) {
-			name = this.namespaceStack.get(myNamespace) as string;
+			name = this.namespaceStack.get(myNamespace);
+			if (!name) {
+				throw new TranspilerError(
+					`Failed to find context for ${node.getKindName()}`,
+					node,
+					TranspilerErrorType.BadContext,
+				);
+			}
 		} else {
 			name = "_exports";
 			this.isModule = true;

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1166,7 +1166,11 @@ export class Transpiler {
 
 		const parent = node.getParent();
 		if (parent && ts.TypeGuards.isVariableStatement(parent)) {
-			if (parent.hasExportKeyword() && declarationKind === ts.VariableDeclarationKind.Let) {
+			if (
+				parent.hasExportKeyword() &&
+				declarationKind === ts.VariableDeclarationKind.Let &&
+				parent.getParent().getKind() === ts.SyntaxKind.SourceFile
+			) {
 				throw new TranspilerError(
 					"'export let' is not supported! Use 'export const' instead.",
 					node,

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1527,8 +1527,10 @@ export class Transpiler {
 		return declaration;
 	}
 
-	private transpileClassDeclaration(node: ts.ClassDeclaration | ts.ClassExpression) {
-		const name = node.getName() || this.getNewId();
+	private transpileClassDeclaration(
+		node: ts.ClassDeclaration | ts.ClassExpression,
+		name: string = node.getName() || this.getNewId(),
+	) {
 		const nameNode = node.getNameNode();
 		if (nameNode) {
 			this.checkReserved(name, nameNode);
@@ -2030,10 +2032,10 @@ export class Transpiler {
 			this.isModule = true;
 			const exp = node.getExpression();
 			if (ts.TypeGuards.isClassExpression(exp)) {
-				const className = this.idStack[this.idStack.length - 1];
-				result += `${this.transpileClassDeclaration(exp)}`;
+				const className = exp.getName() || this.getNewId();
+				result += this.transpileClassDeclaration(exp, className);
 				result += this.indent;
-				result += `_exports = _${className};\n`;
+				result += `_exports = ${className};\n`;
 			} else {
 				const expStr = this.transpileExpression(exp);
 				result += `_exports = ${expStr};\n`;

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -3537,7 +3537,7 @@ export class Transpiler {
 					throw new TranspilerError(
 						"ModuleScript contains multiple ExportEquals. You can only do `export = ` once.",
 						node,
-						TranspilerErrorType.ExportInNonModuleScript,
+						TranspilerErrorType.MultipleExportEquals,
 					);
 				}
 				if (Descendant.isExportEquals()) {

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -381,7 +381,7 @@ export class Transpiler {
 	}
 
 	private pushExport(name: string, node: ts.Node & ts.ExportableNode) {
-		if (!node.isExported()) {
+		if (!node.hasExportKeyword()) {
 			return;
 		}
 

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -634,7 +634,8 @@ export class Transpiler {
 				}
 			}
 		}
-		for (const def of node.getDefinitions()) { // I have no idea why, but getDefinitionNodes() cannot replace this
+		// I have no idea why, but getDefinitionNodes() cannot replace this
+		for (const def of node.getDefinitions()) {
 			const definition = def.getNode();
 			const parent = definition.getFirstAncestorByKind(ts.SyntaxKind.VariableStatement);
 
@@ -2042,7 +2043,8 @@ export class Transpiler {
 		} else {
 			const symbol = node.getSymbol();
 			if (symbol) {
-				if (symbol.getName() === "default") { // I couldn't find a better way to do this
+				// I couldn't find a better way to do this
+				if (symbol.getName() === "default") {
 					this.isModule = true;
 					result += "_exports._default = " + this.transpileExpression(node.getExpression()) + ";\n";
 				}

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -634,7 +634,6 @@ export class Transpiler {
 				}
 			}
 		}
-
 		for (const def of node.getDefinitions()) { // I have no idea why, but getDefinitionNodes() cannot replace this
 			const definition = def.getNode();
 			const parent = definition.getFirstAncestorByKind(ts.SyntaxKind.VariableStatement);
@@ -885,7 +884,7 @@ export class Transpiler {
 			let rhsPrefix: string;
 			const lhsPrefix = ancestorName + ".";
 			if (rhs.length <= 1) {
-				rhsPrefix = (luaPath !== "") ? `require(${luaPath})` : "";
+				rhsPrefix = luaPath !== "" ? `require(${luaPath})` : "";
 			} else {
 				rhsPrefix = this.getNewId();
 				result += `${rhsPrefix} = require(${luaPath});\n`;
@@ -2042,7 +2041,6 @@ export class Transpiler {
 			}
 		} else {
 			const symbol = node.getSymbol();
-
 			if (symbol) {
 				if (symbol.getName() === "default") { // I couldn't find a better way to do this
 					this.isModule = true;

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -639,7 +639,7 @@ export class Transpiler {
 			const parent = definition.getFirstAncestorByKind(ts.SyntaxKind.VariableStatement);
 
 			if (parent && parent.isExported()) {
-				return `${this.getExportContextName(parent)}.${name}`;
+				return this.getExportContextName(parent) + "." + name;
 			}
 		}
 
@@ -2690,9 +2690,11 @@ export class Transpiler {
 					this.pushIndent();
 				}
 
-				let rhs: string;
-				if (ts.TypeGuards.isShorthandPropertyAssignment(prop)) {
-					rhs = prop.getName();
+				let rhs: string; // You may want to move this around
+				if (ts.TypeGuards.isShorthandPropertyAssignment(prop) && ts.TypeGuards.isIdentifier(child)) {
+					lhs = prop.getName();
+					rhs = this.transpileIdentifier(child);
+					this.checkReserved(lhs, child);
 				} else {
 					rhs = this.transpileExpression(prop.getInitializerOrThrow());
 				}

--- a/src/class/errors/TranspilerError.ts
+++ b/src/class/errors/TranspilerError.ts
@@ -55,6 +55,8 @@ export enum TranspilerErrorType {
 	NoExportLetKeyword,
 	MultipleExportEquals,
 	NoDynamicImport,
+	InvalidIdentifier,
+	RobloxTSReservedIdentifier,
 }
 
 export class TranspilerError extends Error {

--- a/src/class/errors/TranspilerError.ts
+++ b/src/class/errors/TranspilerError.ts
@@ -53,6 +53,7 @@ export enum TranspilerErrorType {
 	RoactInvalidPropertyExpression,
 	UnexpectedObjectIndex,
 	NoExportLetKeyword,
+	MultipleExportEquals,
 }
 
 export class TranspilerError extends Error {

--- a/src/class/errors/TranspilerError.ts
+++ b/src/class/errors/TranspilerError.ts
@@ -57,6 +57,7 @@ export enum TranspilerErrorType {
 	NoDynamicImport,
 	InvalidIdentifier,
 	RobloxTSReservedIdentifier,
+	BadContext,
 }
 
 export class TranspilerError extends Error {

--- a/src/class/errors/TranspilerError.ts
+++ b/src/class/errors/TranspilerError.ts
@@ -54,6 +54,7 @@ export enum TranspilerErrorType {
 	UnexpectedObjectIndex,
 	NoExportLetKeyword,
 	MultipleExportEquals,
+	NoDynamicImport,
 }
 
 export class TranspilerError extends Error {


### PR DESCRIPTION
**Exporting and importing should work normally now.**

- Added support for `export let`
- Made it so variables exported from namespaces are referenced properly
- Made it so `export default` works for class expressions and function literals (and possibly tuples, I don't remember whether that was broken)
- Made it so `export {REFERENCE as NAME};` works properly
- Fixed some bugs where `export = ` would not work as it should.

- Changed the exportStack to a `Set` so that it would not have duplicates in the `_exports` dump. This would occur if a developer defined a namespace twice.

Also added an error if there are multiple `export =` statements.

UPDATE:
- Fixed dynamic import() function calls
- Fixed imports of the form `import "./Source"`
- Fixed bug where variables from another library would detect as being inside of `_exports`

UPDATE 2:
- Fixed importing and exporting
- Made dynamic import function calls error
- Made invalid identifiers in Lua an error
- *Controversial* Made identifiers of the form `_\d+` error, so these can be reserved for Roblox-TS
- Fixed namespace rabbit hole
- Fixed 1 or 2 other bugs I encountered
- Added more bugs for later :)