### PR TITLE
Fix importing default exportEquals statements

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -815,10 +815,10 @@ export class Transpiler {
 
 		const defaultImport = node.getDefaultImport();
 		if (defaultImport) {
-			const defintions = defaultImport.getDefinitions();
+			const definitions = defaultImport.getDefinitions();
 			const exportAssignments =
-				defintions.length > 0 &&
-				defintions[0]
+				definitions.length > 0 &&
+				definitions[0]
 					.getNode()
 					.getSourceFile()
 					.getExportAssignments();

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -815,7 +815,22 @@ export class Transpiler {
 
 		const defaultImport = node.getDefaultImport();
 		if (defaultImport) {
-			lhs.push(this.transpileExpression(defaultImport));
+			const defintions = defaultImport.getDefinitions();
+			const exportAssignments =
+				defintions.length > 0 &&
+				defintions[0]
+					.getNode()
+					.getSourceFile()
+					.getExportAssignments();
+
+			const defaultImportExp = this.transpileExpression(defaultImport);
+
+			if (exportAssignments && exportAssignments.length === 1 && exportAssignments[0].isExportEquals()) {
+				// If the defaultImport is importing an `export = ` statement,
+				return `local ${defaultImportExp} = ${luaPath};\n`;
+			}
+
+			lhs.push(defaultImportExp);
 			rhs.push(`._default`);
 		}
 


### PR DESCRIPTION
I don't know how people even use Roblox-TS without this. 

Allows a user to define a TS library like so
```ts
export = class {};
```
Then import like so
```ts
import Event from "./Event";
```

Relatated to this: https://github.com/roblox-ts/roblox-ts.github.io/pull/12