### PR TITLE
Make for in statements access proper keys in arrays

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1144,9 +1144,14 @@ export class Transpiler {
 			throw new TranspilerError(`ForIn Loop empty varName!`, init, TranspilerErrorType.ForEmptyVarName);
 		}
 
-		const expStr = this.transpileExpression(node.getExpression());
+		const exp = node.getExpression();
+		const expStr = this.transpileExpression(exp);
 		let result = "";
-		result += this.indent + `for ${varName} in pairs(${expStr}) do\n`;
+		if (exp.getType().isArray()) {
+			result += this.indent + `for ${varName} = 0, #${expStr} - 1 do\n`;
+		} else {
+			result += this.indent + `for ${varName} in pairs(${expStr}) do\n`;
+		}
 		this.pushIndent();
 		initializers.forEach(initializer => (result += this.indent + initializer + "\n"));
 		result += this.transpileLoopBody(node.getStatement());


### PR DESCRIPTION
- Make for in statements access proper keys in arrays
- Also makes arrays start indexing at 0 in for in loops.
```ts
const children = [1, 2, 3];

for (const key in children) {
	print(children[key]);
}
```
```lua
local children = {1, 2, 3}
for key = 0, #children - 1 do
	print(key, children[key + 1])
end
```
```
0	1
1	2
2	3
```
Fixes #181