### PR TITLE
Fix ForStatement bugs

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1460,7 +1460,7 @@ export class Transpiler {
 						values.push(rhsStr);
 					} else {
 						values.push("nil");
-          }
+          			}
 				}
 			} else if (isBindingPattern(lhs)) {
 				if (rhs && ts.TypeGuards.isIdentifier(rhs)) {

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -320,7 +320,7 @@ export class Transpiler {
 	private roactIndent: number = 0;
 	private hasRoactImport: boolean = false;
 
-	constructor(private compiler: Compiler) { }
+	constructor(private compiler: Compiler) {}
 
 	private getNewId() {
 		const sum = this.idStack.reduce((accum, value) => accum + value);
@@ -1273,7 +1273,7 @@ export class Transpiler {
 
 		let result = "";
 		let localizations = "";
-		let cleanup = () => { };
+		let cleanup = () => {};
 		result += this.indent + "do\n";
 		this.pushIndent();
 		const initializer = node.getInitializer();
@@ -2737,7 +2737,7 @@ export class Transpiler {
 					} else {
 						throw new TranspilerError(
 							`Roact does not support this type of expression ` +
-							`{${expression.getText()}} (${expression.getKindName()})`,
+								`{${expression.getText()}} (${expression.getKindName()})`,
 							expression,
 							TranspilerErrorType.RoactInvalidExpression,
 						);
@@ -2786,7 +2786,7 @@ export class Transpiler {
 		if (!this.hasRoactImport) {
 			throw new TranspilerError(
 				"Cannot use JSX without importing Roact first!\n" +
-				suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
+					suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
 				node,
 				TranspilerErrorType.RoactJsxWithoutImport,
 			);
@@ -2814,7 +2814,7 @@ export class Transpiler {
 		if (!this.hasRoactImport) {
 			throw new TranspilerError(
 				"Cannot use JSX without importing Roact first!\n" +
-				suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
+					suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
 				node,
 				TranspilerErrorType.RoactJsxWithoutImport,
 			);
@@ -3483,7 +3483,7 @@ export class Transpiler {
 		if (inheritsFromRoact(expressionType)) {
 			throw new TranspilerError(
 				`Roact components cannot be created using new\n` +
-				suggest(`Proper usage: Roact.createElement(${name}), <${name}></${name}> or </${name}>`),
+					suggest(`Proper usage: Roact.createElement(${name}), <${name}></${name}> or </${name}>`),
 				node,
 				TranspilerErrorType.RoactNoNewComponentAllowed,
 			);

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1257,7 +1257,7 @@ export class Transpiler {
 
 							// don't leak
 							const previous = this.unlocalizedVariables.get(name) || "";
-							cleanup = () => (this.unlocalizedVariables.set(name, previous));
+							cleanup = () => this.unlocalizedVariables.set(name, previous);
 							this.unlocalizedVariables.set(name, alias);
 						}
 					}

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -682,12 +682,12 @@ export class Transpiler {
 						}
 					}
 				}
-			} else {
-				if (this.isDefinitionALet(def)) {
-					const namespace = this.unlocalizedVariables.get(name);
-					if (namespace) {
-						return namespace;
-					}
+			}
+
+			if (this.isDefinitionALet(def)) {
+				const namespace = this.unlocalizedVariables.get(name);
+				if (namespace) {
+					return namespace;
 				}
 			}
 		}
@@ -1205,33 +1205,93 @@ export class Transpiler {
 		return result;
 	}
 
+	private checkLoopClassExp(node?: ts.Expression<ts.ts.Expression>) {
+		if (node && ts.TypeGuards.isClassExpression(node)) {
+			throw new TranspilerError(
+				"Loops cannot contain class expressions as their condition/init/incrementor! Seriously, what's wrong with you?",
+				node,
+				TranspilerErrorType.ClassyLoop,
+			);
+		}
+	}
+
+	private statementContainsFunction(statement: ts.Statement<ts.ts.Statement>) {
+		return (
+			statement.getFirstDescendantByKind(ts.SyntaxKind.FunctionExpression) ||
+			statement.getFirstDescendantByKind(ts.SyntaxKind.ArrowFunction) ||
+			statement.getFirstDescendantByKind(ts.SyntaxKind.FunctionDeclaration)
+		);
+	}
+
 	private transpileForStatement(node: ts.ForStatement) {
+		this.pushIdStack();
+		const statement = node.getStatement();
 		const condition = node.getCondition();
+		this.checkLoopClassExp(condition);
 		const conditionStr = condition ? this.transpileExpression(condition) : "true";
 		const incrementor = node.getIncrementor();
+		this.checkLoopClassExp(incrementor);
 		const incrementorStr = incrementor ? this.transpileExpression(incrementor) + ";\n" : undefined;
 
 		let result = "";
+		let localizations = "";
+		let cleanup = () => {};
 		result += this.indent + "do\n";
 		this.pushIndent();
 		const initializer = node.getInitializer();
 		if (initializer) {
 			if (ts.TypeGuards.isVariableDeclarationList(initializer)) {
+				if (
+					initializer.getDeclarationKind() === ts.VariableDeclarationKind.Let &&
+					this.statementContainsFunction(statement)
+				) {
+					const declarations = initializer.getDeclarations();
+					if (declarations.length > 0) {
+						const lhs = declarations[0].getChildAtIndex(0);
+						if (ts.TypeGuards.isIdentifier(lhs)) {
+							const name = lhs.getText();
+							const alias = this.getNewId();
+							this.pushIndent();
+							localizations = this.indent + `local ${alias} = ${name};\n`;
+							this.popIndent();
+
+							// don't leak
+							const previous = this.unlocalizedVariables.get(name) || "";
+							cleanup = () => { this.unlocalizedVariables.set(name, previous); };
+							this.unlocalizedVariables.set(name, alias);
+						}
+					}
+				}
+
 				result += this.transpileVariableDeclarationList(initializer);
 			} else if (ts.TypeGuards.isExpression(initializer)) {
+				this.checkLoopClassExp(initializer);
 				let expStr = this.transpileExpression(initializer);
+
 				if (
 					!ts.TypeGuards.isVariableDeclarationList(initializer) &&
-					!ts.TypeGuards.isCallExpression(initializer)
+					!ts.TypeGuards.isCallExpression(initializer) &&
+					!ts.TypeGuards.isPostfixUnaryExpression(initializer) &&
+					!(
+						ts.TypeGuards.isPrefixUnaryExpression(initializer) &&
+						(initializer.getOperatorToken() === ts.SyntaxKind.PlusPlusToken ||
+							initializer.getOperatorToken() === ts.SyntaxKind.MinusMinusToken)
+					) &&
+					!(
+						ts.TypeGuards.isBinaryExpression(initializer) &&
+						this.isSetToken(initializer.getOperatorToken().getKind())
+					)
 				) {
 					expStr = `local _ = ` + expStr;
 				}
 				result += this.indent + expStr + ";\n";
 			}
 		}
+
 		result += this.indent + `while ${conditionStr} do\n`;
+		result += localizations;
 		this.pushIndent();
-		result += this.transpileLoopBody(node.getStatement());
+		result += this.transpileLoopBody(statement);
 		if (incrementorStr) {
 			result += this.indent + incrementorStr;
 		}
@@ -1239,6 +1299,8 @@ export class Transpiler {
 		result += this.indent + "end;\n";
 		this.popIndent();
 		result += this.indent + `end;\n`;
+		this.popIdStack();
+		cleanup();
 		return result;
 	}
 
@@ -1349,7 +1411,7 @@ export class Transpiler {
 				rhs = equalsToken.getNextSibling();
 			}
 
-			if (lhs.getKind() === ts.SyntaxKind.Identifier) {
+			if (ts.TypeGuards.isIdentifier(lhs)) {
 				const name = lhs.getText();
 				this.checkReserved(name, lhs);
 				names.push(name);
@@ -1407,7 +1469,9 @@ export class Transpiler {
 	}
 
 	private transpileWhileStatement(node: ts.WhileStatement) {
-		const expStr = this.transpileExpression(node.getExpression());
+		const exp = node.getExpression();
+		this.checkLoopClassExp(exp);
+		const expStr = this.transpileExpression(exp);
 		let result = "";
 		result += this.indent + `while ${expStr} do\n`;
 		this.pushIndent();
@@ -3056,6 +3120,23 @@ export class Transpiler {
 		return result;
 	}
 
+	private isSetToken(opKind: ts.ts.SyntaxKind) {
+		return (
+			opKind === ts.SyntaxKind.EqualsToken ||
+			opKind === ts.SyntaxKind.BarEqualsToken ||
+			opKind === ts.SyntaxKind.AmpersandEqualsToken ||
+			opKind === ts.SyntaxKind.CaretEqualsToken ||
+			opKind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
+			opKind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+			opKind === ts.SyntaxKind.PlusEqualsToken ||
+			opKind === ts.SyntaxKind.MinusEqualsToken ||
+			opKind === ts.SyntaxKind.AsteriskEqualsToken ||
+			opKind === ts.SyntaxKind.SlashEqualsToken ||
+			opKind === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
+			opKind === ts.SyntaxKind.PercentEqualsToken
+		);
+	}
+
 	private transpileBinaryExpression(node: ts.BinaryExpression) {
 		const opToken = node.getOperatorToken();
 		const opKind = opToken.getKind();
@@ -3103,20 +3184,7 @@ export class Transpiler {
 			throw new TranspilerError("Unrecognized operation! #1", node, TranspilerErrorType.UnrecognizedOperation1);
 		}
 
-		if (
-			opKind === ts.SyntaxKind.EqualsToken ||
-			opKind === ts.SyntaxKind.BarEqualsToken ||
-			opKind === ts.SyntaxKind.AmpersandEqualsToken ||
-			opKind === ts.SyntaxKind.CaretEqualsToken ||
-			opKind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
-			opKind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
-			opKind === ts.SyntaxKind.PlusEqualsToken ||
-			opKind === ts.SyntaxKind.MinusEqualsToken ||
-			opKind === ts.SyntaxKind.AsteriskEqualsToken ||
-			opKind === ts.SyntaxKind.SlashEqualsToken ||
-			opKind === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
-			opKind === ts.SyntaxKind.PercentEqualsToken
-		) {
+		if (this.isSetToken(opKind)) {
 			if (ts.TypeGuards.isPropertyAccessExpression(lhs) && opKind !== ts.SyntaxKind.EqualsToken) {
 				const expression = lhs.getExpression();
 				const opExpStr = this.transpileExpression(expression);
@@ -3211,6 +3279,16 @@ export class Transpiler {
 		}
 	}
 
+	private useIIFEforUnaryExpression(
+		parent: ts.Node<ts.ts.Node>,
+		node: ts.PrefixUnaryExpression | ts.PostfixUnaryExpression,
+	) {
+		return !(
+			ts.TypeGuards.isExpressionStatement(parent) ||
+			(ts.TypeGuards.isForStatement(parent) && parent.getCondition() !== node)
+		);
+	}
+
 	private transpilePrefixUnaryExpression(node: ts.PrefixUnaryExpression) {
 		const parent = node.getParentOrThrow();
 		const operand = node.getOperand();
@@ -3246,13 +3324,12 @@ export class Transpiler {
 
 		if (opKind === ts.SyntaxKind.PlusPlusToken || opKind === ts.SyntaxKind.MinusMinusToken) {
 			statements.push(getOperandStr());
-			const parentKind = parent.getKind();
-			if (parentKind === ts.SyntaxKind.ExpressionStatement || parentKind === ts.SyntaxKind.ForStatement) {
-				return statements.join("; ");
-			} else {
+			if (this.useIIFEforUnaryExpression(parent, node)) {
 				this.popIdStack();
 				const statementsStr = statements.join("; ");
 				return `(function() ${statementsStr}; return ${expStr}; end)()`;
+			} else {
+				return statements.join("; ");
 			}
 		}
 
@@ -3304,17 +3381,16 @@ export class Transpiler {
 		}
 
 		if (opKind === ts.SyntaxKind.PlusPlusToken || opKind === ts.SyntaxKind.MinusMinusToken) {
-			const parentKind = parent.getKind();
-			if (parentKind === ts.SyntaxKind.ExpressionStatement || parentKind === ts.SyntaxKind.ForStatement) {
-				statements.push(getOperandStr());
-				return statements.join("; ");
-			} else {
+			if (this.useIIFEforUnaryExpression(parent, node)) {
 				const id = this.getNewId();
 				this.popIdStack();
 				statements.push(`local ${id} = ${expStr}`);
 				statements.push(getOperandStr());
 				const statementsStr = statements.join("; ");
 				return `(function() ${statementsStr}; return ${id}; end)()`;
+			} else {
+				statements.push(getOperandStr());
+				return statements.join("; ");
 			}
 		}
 		throw new TranspilerError(

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1257,7 +1257,7 @@ export class Transpiler {
 
 							// don't leak
 							const previous = this.unlocalizedVariables.get(name) || "";
-							cleanup = () => { this.unlocalizedVariables.set(name, previous); };
+							cleanup = () => (this.unlocalizedVariables.set(name, previous));
 							this.unlocalizedVariables.set(name, alias);
 						}
 					}

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -320,7 +320,7 @@ export class Transpiler {
 	private roactIndent: number = 0;
 	private hasRoactImport: boolean = false;
 
-	constructor(private compiler: Compiler) {}
+	constructor(private compiler: Compiler) { }
 
 	private getNewId() {
 		const sum = this.idStack.reduce((accum, value) => accum + value);
@@ -1273,7 +1273,7 @@ export class Transpiler {
 
 		let result = "";
 		let localizations = "";
-		let cleanup = () => {};
+		let cleanup = () => { };
 		result += this.indent + "do\n";
 		this.pushIndent();
 		const initializer = node.getInitializer();
@@ -1460,7 +1460,7 @@ export class Transpiler {
 						values.push(rhsStr);
 					} else {
 						values.push("nil");
-          			}
+					}
 				}
 			} else if (isBindingPattern(lhs)) {
 				if (rhs && ts.TypeGuards.isIdentifier(rhs)) {
@@ -2737,7 +2737,7 @@ export class Transpiler {
 					} else {
 						throw new TranspilerError(
 							`Roact does not support this type of expression ` +
-								`{${expression.getText()}} (${expression.getKindName()})`,
+							`{${expression.getText()}} (${expression.getKindName()})`,
 							expression,
 							TranspilerErrorType.RoactInvalidExpression,
 						);
@@ -2786,7 +2786,7 @@ export class Transpiler {
 		if (!this.hasRoactImport) {
 			throw new TranspilerError(
 				"Cannot use JSX without importing Roact first!\n" +
-					suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
+				suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
 				node,
 				TranspilerErrorType.RoactJsxWithoutImport,
 			);
@@ -2814,7 +2814,7 @@ export class Transpiler {
 		if (!this.hasRoactImport) {
 			throw new TranspilerError(
 				"Cannot use JSX without importing Roact first!\n" +
-					suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
+				suggest('To fix this, put `import * as Roact from "rbx-roact"` at the top of this file.'),
 				node,
 				TranspilerErrorType.RoactJsxWithoutImport,
 			);
@@ -3483,7 +3483,7 @@ export class Transpiler {
 		if (inheritsFromRoact(expressionType)) {
 			throw new TranspilerError(
 				`Roact components cannot be created using new\n` +
-					suggest(`Proper usage: Roact.createElement(${name}), <${name}></${name}> or </${name}>`),
+				suggest(`Proper usage: Roact.createElement(${name}), <${name}></${name}> or </${name}>`),
 				node,
 				TranspilerErrorType.RoactNoNewComponentAllowed,
 			);

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1215,14 +1215,6 @@ export class Transpiler {
 		}
 	}
 
-	private statementContainsFunction(statement: ts.Statement<ts.ts.Statement>) {
-		return (
-			statement.getFirstDescendantByKind(ts.SyntaxKind.FunctionExpression) ||
-			statement.getFirstDescendantByKind(ts.SyntaxKind.ArrowFunction) ||
-			statement.getFirstDescendantByKind(ts.SyntaxKind.FunctionDeclaration)
-		);
-	}
-
 	private transpileForStatement(node: ts.ForStatement) {
 		this.pushIdStack();
 		const statement = node.getStatement();
@@ -1243,7 +1235,7 @@ export class Transpiler {
 			if (ts.TypeGuards.isVariableDeclarationList(initializer)) {
 				if (
 					initializer.getDeclarationKind() === ts.VariableDeclarationKind.Let &&
-					this.statementContainsFunction(statement)
+					this.getFirstFunctionLikeAncestor(statement)
 				) {
 					const declarations = initializer.getDeclarations();
 					if (declarations.length > 0) {

--- a/src/class/errors/TranspilerError.ts
+++ b/src/class/errors/TranspilerError.ts
@@ -58,6 +58,7 @@ export enum TranspilerErrorType {
 	InvalidIdentifier,
 	RobloxTSReservedIdentifier,
 	BadContext,
+	ClassyLoop,
 }
 
 export class TranspilerError extends Error {


### PR DESCRIPTION
**Changes:**
- Variables will now scope to for loops that contain a function definition
- Class expressions are now disallowed as arguments in for statements
- Fixed issues relating to unary expressions as arguments
- Fixed issue with equal statements not being properly detected in the first argument of a for statement.

Fixes #176 
