### PR TITLE
Fix Destructuring in/from functions

### DIFF
--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -1256,13 +1256,27 @@ export class Transpiler {
 		return undefined;
 	}
 
+	private arrayLiteralHasNoJSX(exp: ts.ArrayLiteralExpression) {
+		for (const element of exp.getElements()) {
+			if (
+				ts.TypeGuards.isJsxExpression(element) ||
+				ts.TypeGuards.isJsxSelfClosingElement(element) ||
+				ts.TypeGuards.isJsxElement(element)
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private transpileReturnStatement(node: ts.ReturnStatement) {
 		const exp = node.getExpression();
 		if (exp) {
 			const ancestor = this.getFirstFunctionLikeAncestor(node);
 			if (ancestor) {
-				if (ts.TypeGuards.isArrayLiteralExpression(exp)) {
-					let expStr = this.transpileExpression(exp);
+				if (ts.TypeGuards.isArrayLiteralExpression(exp) && this.arrayLiteralHasNoJSX(exp)) {
+					let expStr = this.transpileArrayLiteralExpression(exp);
 					expStr = expStr.substr(2, expStr.length - 4);
 					return this.indent + `return ${expStr};\n`;
 				} else if (isTupleLike(ancestor.getReturnType())) {

--- a/src/class/Transpiler.ts
+++ b/src/class/Transpiler.ts
@@ -3148,7 +3148,6 @@ export class Transpiler {
 					);
 			}
 
-
 			const parentKind = node.getParentOrThrow().getKind();
 			if (parentKind === ts.SyntaxKind.ExpressionStatement || parentKind === ts.SyntaxKind.ForStatement) {
 				return statements.join("; ");


### PR DESCRIPTION
**Changes:**
- 
- This changes the way functions return. If a function returns an array literal, it always returns each individual argument. Currently, our tests are written under different assumptions.
- This fixes destructuring in BinaryExpressions with operator `=`

Fixes #114