### PR TITLE
Improve import

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
 *.json
+**/lib/**
+./lib/**
+*.lua
 **/node_modules/**
 ./node_modules/**
 **/.{git,svn,hg}/**

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -113,7 +113,7 @@ function TS.import(module, ...)
 				currentModule = currentlyLoading[currentModule]
 
 				if currentModule == module then
-					local String = currentModule.Name -- Get the string traceback
+					local str = currentModule.Name -- Get the string traceback
 
 					for _ = 1, depth do
 						currentModule = currentlyLoading[currentModule]

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -95,7 +95,7 @@ function TS.import(module, ...)
 
 		if data == nil then
 			-- If called from command bar, use table as a reference (this is never concatenated)
-			local caller = getfenv(0).script or {Name = "Command bar"}
+			local caller = getfenv(0).script or { Name = "Command bar" }
 			currentlyLoading[caller] = module
 
 			-- Check to see if a case like this occurs:

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -117,7 +117,7 @@ function TS.import(module, ...)
 
 					for _ = 1, depth do
 						currentModule = currentlyLoading[currentModule]
-						String = String .. " -> " .. currentModule.Name
+						str = str .. " -> " .. currentModule.Name
 					end
 
 					error("Failed to import! Detected a circular dependency chain: " .. String, 2)

--- a/src/transpiler/module.ts
+++ b/src/transpiler/module.ts
@@ -193,11 +193,12 @@ function getImportPathFromFile(state: TranspilerState, sourceFile: ts.SourceFile
 			.split(".")
 			.concat(parts)
 			.filter(v => v.length > 0)
-			.map(v => `"${v}"`)
-			.join(", ");
+			.map(v => `"${v}"`);
 
+		// We could probably check this is a valid service at compile-time
+		params[0] = "game:GetService(" + params[0] + ")";
 		state.usesTSLibrary = true;
-		return `TS.import(${params})`;
+		return `TS.import(${params.join(", ")})`;
 	}
 }
 


### PR DESCRIPTION
### Changes

- Make it so the first parameter to `TS.import` is always an object. Previously, we would pass in a string upon which we could call `GetService`, but we now instead do `GetService` in-line.

- Make it so TS.import caches data returned from `require` and checks for circular dependency chains. 