### PR TITLE
Fix for varargs bug

### DIFF
--- a/src/transpiler/binding.ts
+++ b/src/transpiler/binding.ts
@@ -48,40 +48,7 @@ export function getParameterData(
 
 		if (param.isRestParameter()) {
 			paramNames.push("...");
-			let needsNameDeclaration = false;
-			const replaceWithSelect = new Array<ts.PropertyAccessExpression<ts.ts.PropertyAccessExpression>>();
-
-			const body = node.getBody();
-			if (body) {
-				for (const value of body.getDescendantsOfKind(ts.SyntaxKind.Identifier)) {
-					if (value.getText() === name) {
-						const parent = value.getParent();
-						if (
-							(ts.TypeGuards.isSpreadElement(parent) &&
-								!ts.TypeGuards.isArrayLiteralExpression(parent.getParent())) ||
-							(ts.TypeGuards.isForOfStatement(parent) || ts.TypeGuards.isForInStatement(parent))
-						) {
-						} else if (ts.TypeGuards.isPropertyAccessExpression(parent) && parent.getName() === "length") {
-							replaceWithSelect.push(parent);
-						} else {
-							needsNameDeclaration = true;
-							break;
-						}
-					}
-				}
-
-				if (!needsNameDeclaration) {
-					state.canOptimizeParameterTuple.set(node, name);
-
-					if (replaceWithSelect) {
-						replaceWithSelect.forEach(parent => parent.replaceWithText(`select("#", ...${name})`));
-					}
-				}
-			}
-
-			if (needsNameDeclaration) {
-				initializers.push(`local ${name} = { ... };`);
-			}
+			initializers.push(`local ${name} = { ... };`);
 		} else {
 			paramNames.push(name);
 		}

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -127,4 +127,19 @@ export = () => {
 		expect(b).to.equal(2);
 		expect(c).to.equal(4);
 	});
+
+	it("should localize varargs if they are destructured in nested functions", () => {
+		function b(arg1?: number, arg2?: number): [number, number] {
+			return [arg1 || 1, arg2 || 1]
+		}
+		function a(...args: any[]): [number, number] {
+			const x = () => {
+				return b(...args);
+			}
+			return x()
+		}
+		const [c,d] = a(1, 2);
+		expect(c).to.equal(1);
+		expect(d).to.equal(2);
+	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -130,15 +130,15 @@ export = () => {
 
 	it("should localize varargs if they are destructured in nested functions", () => {
 		function b(arg1?: number, arg2?: number): [number, number] {
-			return [arg1 || 1, arg2 || 1]
+			return [arg1 || 1, arg2 || 1];
 		}
 		function a(...args: any[]): [number, number] {
 			const x = () => {
 				return b(...args);
-			}
-			return x()
+			};
+			return x();
 		}
-		const [c,d] = a(1, 2);
+		const [c, d] = a(1, 2);
 		expect(c).to.equal(1);
 		expect(d).to.equal(2);
 	});


### PR DESCRIPTION
An optimization from #200 caused an issue (#221) with varargs.
There may be a better way to implement this optimization, but for now I think it should be reverted.