### PR TITLE
Refactor variable.ts

### DIFF
--- a/src/TranspilerState.ts
+++ b/src/TranspilerState.ts
@@ -41,6 +41,10 @@ export class TranspilerState {
 	// hoist stack
 	public hoistStack = new Array<Set<string>>();
 
+	public pushHoistStack(name: string) {
+		this.hoistStack[this.hoistStack.length - 1].add(name);
+	}
+
 	public popHoistStack(result: string) {
 		const hoists = this.hoistStack.pop();
 		if (hoists && hoists.size > 0) {

--- a/src/transpiler/binding.ts
+++ b/src/transpiler/binding.ts
@@ -4,12 +4,6 @@ import { TranspilerError, TranspilerErrorType } from "../errors/TranspilerError"
 import { TranspilerState } from "../TranspilerState";
 import { HasParameters } from "../types";
 
-export function isBindingPattern(node: ts.Node) {
-	return (
-		node.getKind() === ts.SyntaxKind.ArrayBindingPattern || node.getKind() === ts.SyntaxKind.ObjectBindingPattern
-	);
-}
-
 export function getParameterData(
 	state: TranspilerState,
 	paramNames: Array<string>,
@@ -35,15 +29,8 @@ export function getParameterData(
 		if (ts.TypeGuards.isIdentifier(child)) {
 			name = transpileExpression(state, child);
 			checkReserved(name, node);
-		} else if (isBindingPattern(child)) {
-			name = state.getNewId();
 		} else {
-			const kindName = child.getKindName();
-			throw new TranspilerError(
-				`Unexpected parameter type! (${kindName})`,
-				param,
-				TranspilerErrorType.UnexpectedParameterType,
-			);
+			name = state.getNewId();
 		}
 
 		if (param.isRestParameter()) {
@@ -68,7 +55,7 @@ export function getParameterData(
 			initializers.push(`self.${name} = ${name};`);
 		}
 
-		if (isBindingPattern(child)) {
+		if (ts.TypeGuards.isArrayBindingPattern(child) || ts.TypeGuards.isObjectBindingPattern(child)) {
 			const names = new Array<string>();
 			const values = new Array<string>();
 			const preStatements = new Array<string>();
@@ -115,15 +102,15 @@ export function getBindingData(
 				);
 			}
 
-			if (pattern && isBindingPattern(pattern)) {
+			if (pattern && (ts.TypeGuards.isArrayBindingPattern(child) || ts.TypeGuards.isObjectBindingPattern(child))) {
 				const childId = state.getNewId();
 				preStatements.push(`local ${childId} = ${parentId}[${key}];`);
 				getBindingData(state, names, values, preStatements, postStatements, pattern, childId);
-			} else if (child.getKind() === ts.SyntaxKind.ArrayBindingPattern) {
+			} else if (ts.TypeGuards.isArrayBindingPattern(child)) {
 				const childId = state.getNewId();
 				preStatements.push(`local ${childId} = ${parentId}[${key}];`);
 				getBindingData(state, names, values, preStatements, postStatements, child, childId);
-			} else if (child.getKind() === ts.SyntaxKind.Identifier) {
+			} else if (ts.TypeGuards.isIdentifier(child)) {
 				let id: string;
 				if (pattern && pattern.getKind() === ts.SyntaxKind.Identifier) {
 					id = transpileExpression(state, pattern as ts.Expression);

--- a/src/transpiler/binding.ts
+++ b/src/transpiler/binding.ts
@@ -104,7 +104,7 @@ export function getBindingData(
 
 			if (
 				pattern &&
-				(ts.TypeGuards.isArrayBindingPattern(child) || ts.TypeGuards.isObjectBindingPattern(child))
+				(ts.TypeGuards.isArrayBindingPattern(pattern) || ts.TypeGuards.isObjectBindingPattern(pattern))
 			) {
 				const childId = state.getNewId();
 				preStatements.push(`local ${childId} = ${parentId}[${key}];`);

--- a/src/transpiler/binding.ts
+++ b/src/transpiler/binding.ts
@@ -102,7 +102,10 @@ export function getBindingData(
 				);
 			}
 
-			if (pattern && (ts.TypeGuards.isArrayBindingPattern(child) || ts.TypeGuards.isObjectBindingPattern(child))) {
+			if (
+				pattern &&
+				(ts.TypeGuards.isArrayBindingPattern(child) || ts.TypeGuards.isObjectBindingPattern(child))
+			) {
 				const childId = state.getNewId();
 				preStatements.push(`local ${childId} = ${parentId}[${key}];`);
 				getBindingData(state, names, values, preStatements, postStatements, pattern, childId);

--- a/src/transpiler/class.ts
+++ b/src/transpiler/class.ts
@@ -100,7 +100,7 @@ function transpileClass(state: TranspilerState, node: ts.ClassDeclaration | ts.C
 		result += `(function()\n`;
 	} else {
 		result += state.indent + `do\n`;
-		state.hoistStack[state.hoistStack.length - 1].add(name);
+		state.pushHoistStack(name);
 	}
 	state.pushIndent();
 

--- a/src/transpiler/enum.ts
+++ b/src/transpiler/enum.ts
@@ -11,7 +11,7 @@ export function transpileEnumDeclaration(state: TranspilerState, node: ts.EnumDe
 	const name = node.getName();
 	checkReserved(name, node.getNameNode());
 	state.pushExport(name, node);
-	state.hoistStack[state.hoistStack.length - 1].add(name);
+	state.pushHoistStack(name);
 	result += state.indent + `${name} = ${name} or {};\n`;
 	result += state.indent + `do\n`;
 	state.pushIndent();

--- a/src/transpiler/function.ts
+++ b/src/transpiler/function.ts
@@ -164,7 +164,7 @@ export function transpileFunctionDeclaration(state: TranspilerState, node: ts.Fu
 
 	if (body) {
 		state.pushExport(name, node);
-		state.hoistStack[state.hoistStack.length - 1].add(name);
+		state.pushHoistStack(name);
 		return transpileFunction(state, node, name, body);
 	} else {
 		return "";

--- a/src/transpiler/loop.ts
+++ b/src/transpiler/loop.ts
@@ -1,7 +1,6 @@
 import * as ts from "ts-morph";
 import {
 	getBindingData,
-	isBindingPattern,
 	transpileExpression,
 	transpileStatement,
 	transpileVariableDeclarationList,
@@ -123,7 +122,7 @@ export function transpileForInStatement(state: TranspilerState, node: ts.ForInSt
 	if (ts.TypeGuards.isVariableDeclarationList(init)) {
 		for (const declaration of init.getDeclarations()) {
 			const lhs = declaration.getChildAtIndex(0);
-			if (isBindingPattern(lhs)) {
+			if (ts.TypeGuards.isArrayBindingPattern(lhs) || ts.TypeGuards.isObjectBindingPattern(lhs)) {
 				throw new TranspilerError(
 					`ForIn Loop did not expect binding pattern!`,
 					init,
@@ -182,7 +181,7 @@ export function transpileForOfStatement(state: TranspilerState, node: ts.ForOfSt
 	if (ts.TypeGuards.isVariableDeclarationList(init)) {
 		for (const declaration of init.getDeclarations()) {
 			lhs = declaration.getChildAtIndex(0);
-			if (isBindingPattern(lhs)) {
+			if (ts.TypeGuards.isArrayBindingPattern(lhs) || ts.TypeGuards.isObjectBindingPattern(lhs)) {
 				varName = state.getNewId();
 				const names = new Array<string>();
 				const values = new Array<string>();

--- a/src/transpiler/loop.ts
+++ b/src/transpiler/loop.ts
@@ -1,10 +1,5 @@
 import * as ts from "ts-morph";
-import {
-	getBindingData,
-	transpileExpression,
-	transpileStatement,
-	transpileVariableDeclarationList,
-} from ".";
+import { getBindingData, transpileExpression, transpileStatement, transpileVariableDeclarationList } from ".";
 import { TranspilerError, TranspilerErrorType } from "../errors/TranspilerError";
 import { TranspilerState } from "../TranspilerState";
 import { HasParameters } from "../types";

--- a/src/transpiler/namespace.ts
+++ b/src/transpiler/namespace.ts
@@ -25,7 +25,7 @@ export function transpileNamespaceDeclaration(state: TranspilerState, node: ts.N
 	checkReserved(name, node);
 	const parentNamespace = node.getFirstAncestorByKind(ts.SyntaxKind.ModuleDeclaration);
 	state.pushExport(name, node);
-	state.hoistStack[state.hoistStack.length - 1].add(name);
+	state.pushHoistStack(name);
 	let result = "";
 	const id = state.getNewId();
 	const previousName = state.namespaceStack.get(name);

--- a/src/transpiler/variable.ts
+++ b/src/transpiler/variable.ts
@@ -5,6 +5,121 @@ import { TranspilerState } from "../TranspilerState";
 import { isTupleType } from "../typeUtilities";
 import { checkNonAny } from "./security";
 
+export function transpileVariableDeclaration(state: TranspilerState, node: ts.VariableDeclaration) {
+	const lhs = node.getChildAtIndex(0);
+	const equalsToken = node.getFirstChildByKind(ts.SyntaxKind.EqualsToken);
+
+	let rhs: ts.Node | undefined;
+	if (equalsToken) {
+		rhs = equalsToken.getNextSibling();
+	}
+
+	const parent = node.getParent();
+	const grandParent = parent.getParent();
+	const isExported = ts.TypeGuards.isVariableStatement(grandParent) && grandParent.isExported();
+
+	// If it is a foldable constant
+	if (
+		rhs &&
+		ts.TypeGuards.isNumericLiteral(rhs) &&
+		ts.TypeGuards.isVariableDeclarationList(parent) &&
+		grandParent.getParent() === grandParent.getSourceFile() &&
+		!isExported &&
+		parent.getDeclarationKind() === ts.VariableDeclarationKind.Const
+	) {
+		const declarationName = node.getName();
+		checkReserved(declarationName, node);
+		state.variableAliases.set(declarationName, transpileExpression(state, rhs));
+		return "";
+	}
+
+	// optimized tuple return
+	if (ts.TypeGuards.isArrayBindingPattern(lhs)) {
+		const isFlatBinding = lhs
+			.getElements()
+			.filter(v => ts.TypeGuards.isBindingElement(v))
+			.every(bindingElement => bindingElement.getChildAtIndex(0).getKind() === ts.SyntaxKind.Identifier);
+		if (isFlatBinding && rhs && ts.TypeGuards.isCallExpression(rhs) && isTupleType(rhs.getReturnType())) {
+			const names = new Array<string>();
+			const values = new Array<string>();
+			for (const element of lhs.getElements()) {
+				if (ts.TypeGuards.isBindingElement(element)) {
+					names.push(element.getChildAtIndex(0).getText());
+				} else if (ts.TypeGuards.isOmittedExpression(element)) {
+					names.push("_");
+				}
+			}
+			values.push(transpileCallExpression(state, rhs, true));
+			const flatNamesStr = names.join(", ");
+			const flatValuesStr = values.join(", ");
+			return state.indent + `local ${flatNamesStr} = ${flatValuesStr};\n`;
+		}
+	}
+
+	let parentName = "";
+	if (isExported) {
+		parentName = state.getExportContextName(grandParent);
+	}
+
+	let result = "";
+	if (ts.TypeGuards.isIdentifier(lhs)) {
+		checkNonAny(lhs);
+		const name = lhs.getText();
+		checkReserved(name, lhs);
+
+		if (rhs) {
+			const value = transpileExpression(state, rhs as ts.Expression);
+			if (isExported) {
+				result += state.indent + `${parentName}.${name} = ${value};\n`;
+			} else {
+				if (ts.TypeGuards.isFunctionExpression(rhs) || ts.TypeGuards.isArrowFunction(rhs)) {
+					result += state.indent + `local ${name}; ${name} = ${value};\n`;
+				} else {
+					result += state.indent + `local ${name} = ${value};\n`;
+				}
+			}
+		} else if (!isExported) {
+			result += state.indent + `local ${name};\n`;
+		}
+	} else if (isBindingPattern(lhs)) {
+		let names = new Array<string>();
+		const values = new Array<string>();
+		const preStatements = new Array<string>();
+		const postStatements = new Array<string>();
+		if (rhs && ts.TypeGuards.isIdentifier(rhs)) {
+			const rhsStr = transpileExpression(state, rhs);
+			getBindingData(state, names, values, preStatements, postStatements, lhs, rhsStr);
+		} else {
+			const rootId = state.getNewId();
+			if (rhs) {
+				const rhsStr = transpileExpression(state, rhs as ts.Expression);
+				preStatements.push(`local ${rootId} = ${rhsStr};`);
+			} else {
+				preStatements.push(`local ${rootId};`); // ???
+			}
+			getBindingData(state, names, values, preStatements, postStatements, lhs, rootId);
+		}
+
+		if (isExported) {
+			names = names.map(name => `${parentName}.${name}`);
+		}
+
+		preStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
+
+		const namesStr = names.join(", ");
+		if (values.length > 0) {
+			const valuesStr = values.join(", ");
+			result += state.indent + `local ${namesStr} = ${valuesStr};\n`;
+		} else {
+			result += state.indent + `local ${namesStr};\n`;
+		}
+
+		postStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
+	}
+
+	return result;
+}
+
 export function transpileVariableDeclarationList(state: TranspilerState, node: ts.VariableDeclarationList) {
 	const declarationKind = node.getDeclarationKind();
 	if (declarationKind === ts.VariableDeclarationKind.Var) {
@@ -15,134 +130,10 @@ export function transpileVariableDeclarationList(state: TranspilerState, node: t
 		);
 	}
 
-	const parent = node.getParent();
-	const names = new Array<string>();
-	const values = new Array<string>();
-	const preStatements = new Array<string>();
-	const postStatements = new Array<string>();
-	const declarations = node.getDeclarations();
-	const isExported = parent && ts.TypeGuards.isVariableStatement(parent) && parent.isExported();
-	let parentName: string | undefined;
-
-	if (isExported) {
-		parentName = state.getExportContextName(parent);
-	}
-
-	if (declarations.length === 1) {
-		const declaration = declarations[0];
-		const lhs = declaration.getChildAtIndex(0);
-		const equalsToken = declaration.getFirstChildByKind(ts.SyntaxKind.EqualsToken);
-
-		let rhs: ts.Node | undefined;
-		if (equalsToken) {
-			rhs = equalsToken.getNextSibling();
-		}
-
-		if (ts.TypeGuards.isArrayBindingPattern(lhs)) {
-			const isFlatBinding = lhs
-				.getElements()
-				.filter(v => ts.TypeGuards.isBindingElement(v))
-				.every(bindingElement => bindingElement.getChildAtIndex(0).getKind() === ts.SyntaxKind.Identifier);
-			if (isFlatBinding && rhs && ts.TypeGuards.isCallExpression(rhs) && isTupleType(rhs.getReturnType())) {
-				for (const element of lhs.getElements()) {
-					if (ts.TypeGuards.isBindingElement(element)) {
-						names.push(element.getChildAtIndex(0).getText());
-					} else if (ts.TypeGuards.isOmittedExpression(element)) {
-						names.push("_");
-					}
-				}
-				values.push(transpileCallExpression(state, rhs, true));
-				const flatNamesStr = names.join(", ");
-				const flatValuesStr = values.join(", ");
-				return state.indent + `local ${flatNamesStr} = ${flatValuesStr};\n`;
-			}
-		}
-	}
-
-	for (const declaration of declarations) {
-		const lhs = declaration.getChildAtIndex(0);
-		const equalsToken = declaration.getFirstChildByKind(ts.SyntaxKind.EqualsToken);
-
-		let rhs: ts.Node | undefined;
-		if (equalsToken) {
-			rhs = equalsToken.getNextSibling();
-		}
-
-		// If it is a foldable constant
-		if (
-			rhs &&
-			parent &&
-			parent.getParent() === parent.getSourceFile() &&
-			!isExported &&
-			declarationKind === ts.VariableDeclarationKind.Const
-		) {
-			if (ts.TypeGuards.isNumericLiteral(rhs)) {
-				const declarationName = declaration.getName();
-				checkReserved(declarationName, node);
-				state.variableAliases.set(declarationName, transpileExpression(state, rhs));
-				continue;
-			}
-		}
-
-		if (ts.TypeGuards.isIdentifier(lhs)) {
-			checkNonAny(lhs);
-			if (rhs || !isExported) {
-				const name = lhs.getText();
-				checkReserved(name, lhs);
-				names.push(name);
-				if (rhs) {
-					const rhsStr = transpileExpression(state, rhs as ts.Expression);
-					if (ts.TypeGuards.isArrowFunction(rhs) && declarationKind === ts.VariableDeclarationKind.Const) {
-						if (isExported && ts.TypeGuards.isExportableNode(parent)) {
-							state.pushExport(name, parent);
-						}
-						state.hoistStack[state.hoistStack.length - 1].add(name);
-						return state.indent + name + " = " + rhsStr + ";\n";
-					}
-					values.push(rhsStr);
-				} else {
-					values.push("nil");
-				}
-			}
-		} else if (isBindingPattern(lhs)) {
-			if (rhs && ts.TypeGuards.isIdentifier(rhs)) {
-				const rhsStr = transpileExpression(state, rhs);
-				getBindingData(state, names, values, preStatements, postStatements, lhs, rhsStr);
-			} else {
-				const rootId = state.getNewId();
-				if (rhs) {
-					const rhsStr = transpileExpression(state, rhs as ts.Expression);
-					preStatements.push(`local ${rootId} = ${rhsStr};`);
-				} else {
-					preStatements.push(`local ${rootId};`); // ???
-				}
-				getBindingData(state, names, values, preStatements, postStatements, lhs, rootId);
-			}
-		}
-	}
-
-	while (values[values.length - 1] === "nil") {
-		values.pop();
-	}
-
 	let result = "";
-	preStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
-
-	if (values.length > 0) {
-		const valuesStr = values.join(", ");
-
-		if (isExported) {
-			const namesStr = names.join(`, ${parentName}.`);
-			result += state.indent + `${parentName}.${namesStr} = ${valuesStr};\n`;
-		} else {
-			const namesStr = names.join(", ");
-			result += state.indent + `local ${namesStr} = ${valuesStr};\n`;
-		}
-	} else if (names.length > 0) {
-		result += state.indent + `local ${names.join(", ")};\n`;
+	for (const declaration of node.getDeclarations()) {
+		result += transpileVariableDeclaration(state, declaration);
 	}
-
-	postStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
 	return result;
 }
 

--- a/src/transpiler/variable.ts
+++ b/src/transpiler/variable.ts
@@ -70,7 +70,8 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 				result += state.indent + `${parentName}.${name} = ${value};\n`;
 			} else {
 				if (ts.TypeGuards.isFunctionExpression(rhs) || ts.TypeGuards.isArrowFunction(rhs)) {
-					result += state.indent + `local ${name}; ${name} = ${value};\n`;
+					state.pushHoistStack(name);
+					result += state.indent + `${name} = ${value};\n`;
 				} else {
 					result += state.indent + `local ${name} = ${value};\n`;
 				}

--- a/src/transpiler/variable.ts
+++ b/src/transpiler/variable.ts
@@ -66,7 +66,7 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 		checkReserved(name, lhs);
 
 		if (rhs) {
-			const value = transpileExpression(state, rhs as ts.Expression);
+			const value = transpileExpression(state, rhs);
 			if (isExported) {
 				result += state.indent + `${parentName}.${name} = ${value};\n`;
 			} else {
@@ -89,7 +89,7 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 		} else {
 			const rootId = state.getNewId();
 			if (rhs) {
-				const rhsStr = transpileExpression(state, rhs as ts.Expression);
+				const rhsStr = transpileExpression(state, rhs);
 				preStatements.push(`local ${rootId} = ${rhsStr};`);
 			} else {
 				preStatements.push(`local ${rootId};`); // ???

--- a/src/transpiler/variable.ts
+++ b/src/transpiler/variable.ts
@@ -78,21 +78,17 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 		} else if (!isExported) {
 			result += state.indent + `local ${name};\n`;
 		}
-	} else if (isBindingPattern(lhs)) {
+	} else if (isBindingPattern(lhs) && rhs) { // binding patterns MUST have rhs
 		let names = new Array<string>();
 		const values = new Array<string>();
 		const preStatements = new Array<string>();
 		const postStatements = new Array<string>();
-		if (rhs && ts.TypeGuards.isIdentifier(rhs)) {
+		if (ts.TypeGuards.isIdentifier(rhs)) {
 			getBindingData(state, names, values, preStatements, postStatements, lhs, transpileExpression(state, rhs));
 		} else {
 			const rootId = state.getNewId();
-			if (rhs) {
-				const rhsStr = transpileExpression(state, rhs);
-				preStatements.push(`local ${rootId} = ${rhsStr};`);
-			} else {
-				preStatements.push(`local ${rootId};`); // ???
-			}
+			const rhsStr = transpileExpression(state, rhs);
+			preStatements.push(`local ${rootId} = ${rhsStr};`);
 			getBindingData(state, names, values, preStatements, postStatements, lhs, rootId);
 		}
 		preStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));

--- a/src/transpiler/variable.ts
+++ b/src/transpiler/variable.ts
@@ -1,5 +1,5 @@
 import * as ts from "ts-morph";
-import { checkReserved, getBindingData, isBindingPattern, transpileCallExpression, transpileExpression } from ".";
+import { checkReserved, getBindingData, transpileCallExpression, transpileExpression } from ".";
 import { TranspilerError, TranspilerErrorType } from "../errors/TranspilerError";
 import { TranspilerState } from "../TranspilerState";
 import { isTupleType } from "../typeUtilities";
@@ -78,7 +78,8 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 		} else if (!isExported) {
 			result += state.indent + `local ${name};\n`;
 		}
-	} else if (isBindingPattern(lhs) && rhs) { // binding patterns MUST have rhs
+	} else if ((ts.TypeGuards.isArrayBindingPattern(lhs) || ts.TypeGuards.isObjectBindingPattern(lhs)) && rhs) {
+		// binding patterns MUST have rhs
 		let names = new Array<string>();
 		const values = new Array<string>();
 		const preStatements = new Array<string>();

--- a/src/transpiler/variable.ts
+++ b/src/transpiler/variable.ts
@@ -64,7 +64,6 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 		checkNonAny(lhs);
 		const name = lhs.getText();
 		checkReserved(name, lhs);
-
 		if (rhs) {
 			const value = transpileExpression(state, rhs);
 			if (isExported) {
@@ -96,9 +95,7 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 			}
 			getBindingData(state, names, values, preStatements, postStatements, lhs, rootId);
 		}
-
 		preStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
-
 		if (values.length > 0) {
 			if (isExported) {
 				names = names.map(name => `${parentName}.${name}`);
@@ -109,7 +106,6 @@ export function transpileVariableDeclaration(state: TranspilerState, node: ts.Va
 		} else if (!isExported) {
 			result += state.indent + `local ${names.join(", ")};\n`;
 		}
-
 		postStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
 	}
 


### PR DESCRIPTION
Separates variable declaration lists into multiple lines.

Example:
```TS
const a = 1, b = 2;
```
Before:
```Lua
local a, b = 1, 2;
```
After:
```Lua
local a = 1;
local b = 2;
```

This cleans up the code significantly and allows us to optimize certain cases better.
For example, arrow functions / function expressions will now compile like:
```TS
const foo = () => {};
```
```Lua
local foo;
foo = function() end;
```
This allows `foo` to reference itself recursively.