### PR TITLE
Improve for-loop logic

### DIFF
--- a/src/transpiler/indexed.ts
+++ b/src/transpiler/indexed.ts
@@ -11,7 +11,6 @@ import { TranspilerError, TranspilerErrorType } from "../errors/TranspilerError"
 import { TranspilerState } from "../TranspilerState";
 import { inheritsFrom, isArrayType, isNumberType, isTupleReturnTypeCall } from "../typeUtilities";
 import { safeLuaIndex } from "../utility";
-import { transpileNumericLiteral } from "./literal";
 
 export function transpilePropertyAccessExpression(state: TranspilerState, node: ts.PropertyAccessExpression) {
 	const exp = node.getExpression();
@@ -104,7 +103,7 @@ export function transpileElementAccessExpression(state: TranspilerState, node: t
 	let offset = "";
 	let argExpStr: string;
 	if (ts.TypeGuards.isNumericLiteral(argExp) && argExp.getText().indexOf("e") === -1) {
-		let value = Number(transpileNumericLiteral(state, argExp));
+		let value = argExp.getLiteralValue();
 		if (addOne) {
 			value++;
 		}

--- a/src/transpiler/indexed.ts
+++ b/src/transpiler/indexed.ts
@@ -11,6 +11,7 @@ import { TranspilerError, TranspilerErrorType } from "../errors/TranspilerError"
 import { TranspilerState } from "../TranspilerState";
 import { inheritsFrom, isArrayType, isNumberType, isTupleType } from "../typeUtilities";
 import { safeLuaIndex } from "../utility";
+import { transpileNumericLiteral } from "./literal";
 
 export function transpilePropertyAccessExpression(state: TranspilerState, node: ts.PropertyAccessExpression) {
 	const exp = node.getExpression();
@@ -103,7 +104,7 @@ export function transpileElementAccessExpression(state: TranspilerState, node: t
 	let offset = "";
 	let argExpStr: string;
 	if (ts.TypeGuards.isNumericLiteral(argExp) && argExp.getText().indexOf("e") === -1) {
-		let value = argExp.getLiteralValue();
+		let value = Number(transpileNumericLiteral(state, argExp));
 		if (addOne) {
 			value++;
 		}

--- a/src/transpiler/loop.ts
+++ b/src/transpiler/loop.ts
@@ -480,13 +480,6 @@ export function transpileForStatement(state: TranspilerState, node: ts.ForStatem
 							const rhsType = rhs.getType();
 							if (isNumberType(rhsType)) {
 								if (expressionModifiesVariable(incrementor, lhs)) {
-									// if (
-									// 	ts.TypeGuards.isPostfixUnaryExpression(incrementor) ||
-									// 	(ts.TypeGuards.isPrefixUnaryExpression(incrementor) &&
-									// 		(incrementor.getOperatorToken() === ts.SyntaxKind.PlusPlusToken ||
-									// 			incrementor.getOperatorToken() === ts.SyntaxKind.MinusMinusToken))
-									// ) {
-									// }
 									const [incrSign, incrValue] = getSignAndIncrementorForStatement(
 										state,
 										incrementor,

--- a/src/transpiler/loop.ts
+++ b/src/transpiler/loop.ts
@@ -239,23 +239,23 @@ export function checkLoopClassExp(node?: ts.Expression<ts.ts.Expression>) {
 	}
 }
 
-function isExpressionConstantNumbers(node: ts.Node) {
+function isExpressionConstantNumbers(node: ts.Node): boolean {
+	const children = node.getChildren();
 	return (
-		node.getChildren().length > 0 &&
-		node
-			.getChildren()
-			.every(
-				child =>
-					isConstantNumberVariableOrLiteral(child) ||
-					child.getKind() === ts.SyntaxKind.PlusToken ||
-					child.getKind() === ts.SyntaxKind.MinusToken ||
-					child.getKind() === ts.SyntaxKind.AsteriskToken ||
-					child.getKind() === ts.SyntaxKind.SlashToken ||
-					child.getKind() === ts.SyntaxKind.AsteriskAsteriskToken ||
-					child.getKind() === ts.SyntaxKind.PercentToken ||
-					(ts.TypeGuards.isPrefixUnaryExpression(child) &&
-						child.getOperatorToken() === ts.SyntaxKind.MinusToken),
-			)
+		children.length > 0 &&
+		children.every(
+			child =>
+				isConstantNumberVariableOrLiteral(child) ||
+				child.getKind() === ts.SyntaxKind.PlusToken ||
+				child.getKind() === ts.SyntaxKind.MinusToken ||
+				child.getKind() === ts.SyntaxKind.AsteriskToken ||
+				child.getKind() === ts.SyntaxKind.SlashToken ||
+				child.getKind() === ts.SyntaxKind.AsteriskAsteriskToken ||
+				child.getKind() === ts.SyntaxKind.PercentToken ||
+				(ts.TypeGuards.isPrefixUnaryExpression(child) &&
+					child.getOperatorToken() === ts.SyntaxKind.MinusToken) ||
+				(ts.TypeGuards.isBinaryExpression(child) && isExpressionConstantNumbers(child)),
+		)
 	);
 }
 
@@ -413,7 +413,8 @@ function getSimpleForLoopString(
 function isConstantNumberVariableOrLiteral(condValue: ts.Node) {
 	return (
 		ts.TypeGuards.isNumericLiteral(condValue) ||
-		(ts.TypeGuards.isIdentifier(condValue) &&
+		(isNumberType(condValue.getType()) &&
+			ts.TypeGuards.isIdentifier(condValue) &&
 			condValue.getDefinitions().every(a => {
 				const declNode = a.getDeclarationNode();
 				if (declNode && ts.TypeGuards.isVariableDeclaration(declNode)) {
@@ -423,8 +424,7 @@ function isConstantNumberVariableOrLiteral(condValue: ts.Node) {
 					}
 				}
 				return false;
-			}) &&
-			isNumberType(condValue.getType()))
+			}))
 	);
 }
 

--- a/tests/src/loop.spec.ts
+++ b/tests/src/loop.spec.ts
@@ -86,8 +86,32 @@ export = () => {
 
 	it("should support optimized simple loops #6", () => {
 		const hit = new Set<number>();
+		const limit = 1;
 		let n = 0;
-		for (let i = 3; i >= 1; i -= 1) {
+		for (let i = 3; i >= limit; i -= 1) {
+			hit.add(i);
+			n++;
+		}
+		expect(n).to.equal(3);
+		expect(hit.has(1)).to.equal(true);
+		expect(hit.has(2)).to.equal(true);
+		expect(hit.has(3)).to.equal(true);
+	});
+
+	it("should support optimized simple loops #7", () => {
+		const hit = new Set<number>();
+		const limit = 1;
+		let n = 0;
+		for (let i = 3; i <= limit; i -= 1) {
+			hit.add(i);
+			n++;
+		}
+		expect(n).to.equal(0);
+		expect(hit.has(1)).to.equal(false);
+		expect(hit.has(2)).to.equal(false);
+		expect(hit.has(3)).to.equal(false);
+
+		for (let i = 3; i >= limit; i -= 1) {
 			hit.add(i);
 			n++;
 		}


### PR DESCRIPTION
Previously, we could optimize for loops if they were in the form
```ts
for (let i = 0; i <= 10; i++) {

}
```
The 10 had to be a numeric literal in order to work. Now, the 10 can be an identifier, if it is a number type, and it is a constant. That way, we can be sure the value will not change during the for-loop.

EDIT: Moved small bug fix to separate PR