### PR TITLE
Tuple array fixes

### DIFF
--- a/src/transpiler/loop.ts
+++ b/src/transpiler/loop.ts
@@ -50,8 +50,10 @@ export function transpileLoopBody(state: TranspilerState, node: ts.Statement) {
 	if (ts.TypeGuards.isBlock(node)) {
 		const statements = node.getStatements();
 		const lastStatement = statements[statements.length - 1];
-		if (ts.TypeGuards.isBreakStatement(lastStatement) || ts.TypeGuards.isReturnStatement(lastStatement)) {
-			endsWithBreakOrReturn = true;
+		if (lastStatement) {
+			if (ts.TypeGuards.isBreakStatement(lastStatement) || ts.TypeGuards.isReturnStatement(lastStatement)) {
+				endsWithBreakOrReturn = true;
+			}
 		}
 	}
 

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -159,15 +159,17 @@ export function isEnumType(type: ts.Type) {
 }
 
 export function isArrayType(type: ts.Type) {
-	return typeConstraint(type, t => {
-		const symbol = t.getSymbol();
-		if (symbol) {
-			if (getCompilerDirective(symbol, [CompilerDirective.Array]) === CompilerDirective.Array) {
-				return true;
+	return (
+		typeConstraint(type, t => {
+			const symbol = t.getSymbol();
+			if (symbol) {
+				if (getCompilerDirective(symbol, [CompilerDirective.Array]) === CompilerDirective.Array) {
+					return true;
+				}
 			}
-		}
-		return t.isArray();
-	});
+			return t.isArray();
+		}) || isTupleType(type)
+	);
 }
 
 export function isTupleType(type: ts.Type) {
@@ -175,10 +177,7 @@ export function isTupleType(type: ts.Type) {
 }
 
 export function isTupleReturnType(node: ts.CallExpression) {
-	if (isTupleType(node.getReturnType())) {
-		return true;
-	}
-	return false;
+	return isTupleType(node.getReturnType());
 }
 
 function isAncestorOf(ancestor: ts.Node, descendant: ts.Node) {

--- a/tests/src/tuple.spec.ts
+++ b/tests/src/tuple.spec.ts
@@ -73,4 +73,13 @@ export = () => {
 		expect(y).to.equal(2);
 		expect(z).to.equal(3);
 	});
+
+	it("should allow tuples access to array functions", () => {
+		function foo(): [number, number, number] {
+			const result: [number, number, number] = [1, 2, 3];
+			return result;
+		}
+
+		expect(foo().pop()).never.to.throw();
+	});
 };

--- a/tests/src/tuple.spec.ts
+++ b/tests/src/tuple.spec.ts
@@ -80,6 +80,6 @@ export = () => {
 			return result;
 		}
 
-		expect(foo().pop()).never.to.throw();
+		expect(foo().pop()).to.equal(3);
 	});
 };


### PR DESCRIPTION
## Fixes
- For loops without a final statement won't cause the transpiler to explode.
- Tuples will be treated as Arrays.

## Demo
```ts
function returnsTuple(): [number, number, number] {
	return [1, 2, 3];
}

const x = returnsTuple();

for (const y of x) {
	print(y); // Previously, removing this line would cause a transpiler explosion
}
print(x.pop());
```

Before:
```lua
local returnsTuple = function()
	return 1, 2, 3;
end;
local x = { returnsTuple() };
for _, y in pairs(x) do -- Not broken, but not as great either
	print(y);
end;
print(x:pop()); -- does not exist, error!
```

After:
```lua
local returnsTuple = function()
	return 1, 2, 3;
end;
local x = { returnsTuple() };
for _0 = 1, #x do -- optimized!
	local y = x[_0];
	print(y);
end;
print(table.remove(x)); -- great!
```