### PR TITLE
Numeric literal fix

### DIFF
--- a/src/transpiler/literal.ts
+++ b/src/transpiler/literal.ts
@@ -27,7 +27,7 @@ export function transpileNumericLiteral(state: TranspilerState, node: ts.Numeric
 	if (isSpecialNumberPrefix(text)) {
 		return node.getLiteralText();
 	}
-	return text;
+	return text.replace(/_/g, "");
 }
 
 function sanitizeTemplate(str: string) {

--- a/tests/src/literal.spec.ts
+++ b/tests/src/literal.spec.ts
@@ -4,13 +4,14 @@ export = () => {
 		expect(6).to.equal(6);
 		expect(0xf00d).to.equal(61453);
 		expect(0b1010).to.equal(10);
-		expect(0o744).to.equal(484);
+		expect(0o7_44).to.equal(484);
 
 		// issue #213
 		expect(0.0000000000001).never.to.equal(1);
 		expect(100000000000000).never.to.equal(1);
 		expect(tostring(0.0000000000001)).to.equal("1e-13");
 		expect(tostring(100000000000000)).to.equal("1e+14");
+		expect(100_00).never.to.throw();
 	});
 
 	it("should add numbers", () => {
@@ -23,10 +24,10 @@ export = () => {
 	// prettier-ignore
 	it("should understand string literals", () => {
 		expect("foo").to.equal("foo");
-		expect('foo').to.equal("foo");
+		expect("foo").to.equal("foo");
 		expect(`foo`).to.equal("foo");
 		expect("foo".length).to.equal(3);
-		expect('foo'.length).to.equal(3);
+		expect("foo".length).to.equal(3);
 		expect(`foo`.length).to.equal(3);
 		expect("\"").to.equal("\"");
 		expect(`\"`).to.equal("\"");

--- a/tests/src/literal.spec.ts
+++ b/tests/src/literal.spec.ts
@@ -11,8 +11,7 @@ export = () => {
 		expect(100000000000000).never.to.equal(1);
 		expect(tostring(0.0000000000001)).to.equal("1e-13");
 		expect(tostring(100000000000000)).to.equal("1e+14");
-		expect(100_00).never.to.throw();
-		expect(100_00).to.equal(10000);
+		expect(1_0_0_0_0).to.equal(10000);
 	});
 
 	it("should add numbers", () => {

--- a/tests/src/literal.spec.ts
+++ b/tests/src/literal.spec.ts
@@ -12,6 +12,7 @@ export = () => {
 		expect(tostring(0.0000000000001)).to.equal("1e-13");
 		expect(tostring(100000000000000)).to.equal("1e+14");
 		expect(100_00).never.to.throw();
+		expect(100_00).to.equal(10000);
 	});
 
 	it("should add numbers", () => {
@@ -22,12 +23,13 @@ export = () => {
 	});
 
 	// prettier-ignore
+	/* tslint:disable */
 	it("should understand string literals", () => {
 		expect("foo").to.equal("foo");
-		expect("foo").to.equal("foo");
+		expect('foo').to.equal("foo");
 		expect(`foo`).to.equal("foo");
 		expect("foo".length).to.equal(3);
-		expect("foo".length).to.equal(3);
+		expect('foo'.length).to.equal(3);
 		expect(`foo`.length).to.equal(3);
 		expect("\"").to.equal("\"");
 		expect(`\"`).to.equal("\"");
@@ -35,6 +37,7 @@ export = () => {
 		expect(`"`).to.equal("\"");
 		expect('"').to.equal("\"");
 	});
+	/* tslint:enable */
 
 	it("should understand string templates", () => {
 		const value = "hello";


### PR DESCRIPTION
In TypeScript, you can use underscores in numeric literals for visual purposes. e.g. They can be used as commas to make numbers easier to read.
```ts
const myX = 1_000_000;
```
```lua
local myX = 1000000
```