### PR TITLE
Add delete macro to maps and optimize push macro

### DIFF
--- a/src/transpiler/call.ts
+++ b/src/transpiler/call.ts
@@ -147,7 +147,12 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 		if (length === 1 && propertyCallParentIsExpression) {
 			const paramStr = transpileCallArgument(state, params[0]);
 			const accessPath = transpileExpression(state, subExp);
-			return `table.insert(${accessPath}, ${paramStr})`;
+
+			if (ts.TypeGuards.isIdentifier(subExp)) {
+				return `${accessPath}[#${accessPath} + 1] = ${paramStr}`;
+			} else {
+				return `table.insert(${accessPath}, ${paramStr})`;
+			}
 		}
 	})
 
@@ -203,6 +208,14 @@ const MAP_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 				const accessPath = transpileExpression(state, subExp);
 				return `${accessPath}[${key}] = ${value}`;
 			}
+		}
+	})
+
+	.set("delete", (params, state, subExp) => {
+		if (getPropertyCallParentIsExpression(subExp)) {
+			const accessPath = transpileExpression(state, subExp);
+			const key = transpileCallArgument(state, params[0]);
+			return `${accessPath}[${key}] = nil`;
 		}
 	})
 

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -28,6 +28,24 @@ export = () => {
 		const a = new Array<number>();
 		a.push(123);
 		expect(a[0]).to.equal(123);
+
+		class Noodle {
+			public strings = new Array<string>();
+		}
+
+		const noodle = new Noodle();
+		noodle.strings.push("Rigatoni");
+		const strings = noodle.strings;
+		strings.push("Spaghetti");
+
+		if (strings.push("Lasagna")) {
+		}
+
+		expect(noodle.strings.push("Penne")).to.equal(4);
+		expect(noodle.strings[0]).to.equal("Rigatoni");
+		expect(noodle.strings[1]).to.equal("Spaghetti");
+		expect(noodle.strings[2]).to.equal("Lasagna");
+		expect(noodle.strings[3]).to.equal("Penne");
 	});
 
 	it("should support pop", () => {


### PR DESCRIPTION
Pretty straightforward and simple PR:
- add delete macro to Maps (just copy and pasted from Set)
- optimize Push calls when subExp is an Identifier (only takes one check: `if (ts.TypeGuards.isIdentifier(subExp))`). Now spits out `t[#t + 1] = v`

This means this ts will now compile to the following Lua:
```ts
class Noodle {
	public strings = new Array<string>();
}

const noodle = new Noodle();
const strings = noodle.strings;

noodle.strings.push("Rigatoni");
strings.push("Spaghetti");
```
Transpiled Lua:
```lua
local Noodle;
do
	Noodle = {};
	Noodle.__index = {};
	Noodle.new = function(...)
		return Noodle.constructor(setmetatable({}, Noodle), ...);
	end;
	Noodle.constructor = function(self, ...)
		self.strings = {};
		return self;
	end;
end;
local noodle = Noodle.new();
local strings = noodle.strings;
table.insert(noodle.strings, "Rigatoni");
strings[#strings + 1] = "Spaghetti";
```