### PR TITLE
Export let fix

### DIFF
--- a/src/transpiler/binding.ts
+++ b/src/transpiler/binding.ts
@@ -3,6 +3,7 @@ import { transpileExpression } from ".";
 import { TranspilerError, TranspilerErrorType } from "../errors/TranspilerError";
 import { TranspilerState } from "../TranspilerState";
 import { HasParameters } from "../types";
+import { transpileIdentifier } from "./identifier";
 
 export function getParameterData(
 	state: TranspilerState,
@@ -123,12 +124,11 @@ export function getBindingData(
 				preStatements.push(`local ${childId} = ${parentId}[${key}];`);
 				getBindingData(state, names, values, preStatements, postStatements, child, childId);
 			} else if (ts.TypeGuards.isIdentifier(child)) {
-				let id: string;
-				if (pattern && pattern.getKind() === ts.SyntaxKind.Identifier) {
-					id = transpileExpression(state, pattern as ts.Expression);
-				} else {
-					id = transpileExpression(state, child as ts.Expression);
-				}
+				const id: string = transpileIdentifier(
+					state,
+					pattern && ts.TypeGuards.isIdentifier(pattern) ? pattern : child,
+					true,
+				);
 				names.push(id);
 				if (op && op.getKind() === ts.SyntaxKind.EqualsToken) {
 					const value = transpileExpression(state, pattern as ts.Expression);

--- a/tests/src/exportLet.spec.ts
+++ b/tests/src/exportLet.spec.ts
@@ -4,11 +4,39 @@ namespace Foo {
 	y = x;
 }
 
+namespace Bar {
+	const plr = {
+		ClassName: "Player",
+		Name: "Validark",
+	};
+
+	export const { ClassName: a } = plr;
+
+	export let { ClassName: b, Name: c } = plr;
+	export let { ClassName, Name } = plr;
+}
+
 export = () => {
 	it("should allow mutatable exports", () => {
 		expect(Foo.x).to.equal(1);
 		Foo.x = 2;
 		expect(Foo.x).to.equal(2);
 		expect(y).to.equal(1);
+	});
+
+	it("should allow destructured let exports", () => {
+		// const check
+		expect(Bar.a).to.equal("Player");
+
+		expect(Bar.ClassName).to.equal("Player");
+		Bar.ClassName = "Attacker";
+		expect(Bar.ClassName).to.equal("Attacker");
+		expect(Bar.Name).to.equal("Validark");
+		expect(Bar.b).to.equal("Player");
+		expect(Bar.c).to.equal("Validark");
+		Bar.b = "Nope";
+		Bar.c = "Osyris";
+		expect(Bar.b).to.equal("Nope");
+		expect(Bar.c).to.equal("Osyris");
 	});
 };


### PR DESCRIPTION
Fixes #267 

It took a while to figure out what the issue was, but I got it working now.

For one, `ts.TypeGuards.isObjectBindingPattern(parent)` needed to be added in the indentifier tree-climbing code. This fixed almost every case, but it was still getting some declarations wrong. Consider the following code:

```ts
const plr = {
	ClassName: "Player",
	Name: "Validark",
};

export let { ClassName: b, Name: c } = plr;
export let { ClassName, Name } = plr;

print(b, c, ClassName, Name);
```
It was transpiling to this:
```lua
local _exports = {};
local plr = {
	ClassName = "Player";
	Name = "Validark";
};
_exports.b, _exports.c = plr["ClassName"], plr["Name"];
ClassName, Name = plr["ClassName"], plr["Name"]; -- WRONG
print(_exports.b, _exports.c, _exports.ClassName, _exports.Name);
return _exports;
```
Why was one correct and not the other?
It was calling this code in binding.ts:

```ts
let id: string;
if (pattern && pattern.getKind() === ts.SyntaxKind.Identifier) {
	// pass in b and c as aliases to transpileIdentifier
	id = transpileExpression(state, pattern as ts.Expression);
} else {
	// pass in ClassName and Name directly into transpileIdentifier
	id = transpileExpression(state, child as ts.Expression);
}
```

Well, the problem with the declaration statements looked like this:
```ts
transpile: export let { ClassName: b, Name: c } = plr;
	b.getDefinitions() -> in here: export let { ClassName: b, Name: c } = plr;
transpile: export let { ClassName, Name } = plr;
	ClassName.getDefinitions() -> in plr, NOT in the declaration line 
```

Thus, I added a third `isDefinition` parameter to transpileIdentifier to force them to treat the passed in node as the definition when `true`, defaulting to `false`. We could go back and start using this boolean in other places where we transpile declaration identifiers as well, but those have all worked just fine using getDefinition and this is one of the few cases where a declared identifier can have a definition other than the declaration site. I added the extra boolean in the problem code. GetBindingData may need to cover one more similar case to this one, but hopefully @osyrisrblx will rewrite most of the function soon.