### PR TITLE
Update string.split implementation

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -981,11 +981,18 @@ function TS.string_split(input, sep, plain)
 		return input:split(sep)
 	else
 		local result = {}
-		local count = 0
-		for str in input:gmatch("[^" .. sep .. "]+") do
+		local count = 1
+		local pos = 1
+		local a, b = input:find(sep, pos)
+
+		while a do
+			result[count] = input:sub(pos, a - 1)
 			count = count + 1
-			result[count] = str
+			pos = b + 1
+			a, b = input:find(sep, pos)
 		end
+
+		result[count] = input:sub(pos)
 		return result
 	end
 end

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -976,14 +976,18 @@ TS.set_toString = toString
 
 -- string macro functions
 
-function TS.string_split(input, sep)
-	local result = {}
-	local count = 0
-	for str in input:gmatch(sep == "" and "." or "[^" .. sep .. "]+") do
-		count = count + 1
-		result[count] = str
+function TS.string_split(input, sep, plain)
+	if sep == "" or plain then
+		return input:split(sep)
+	else
+		local result = {}
+		local count = 0
+		for str in input:gmatch("[^" .. sep .. "]+") do
+			count = count + 1
+			result[count] = str
+		end
+		return result
 	end
-	return result
 end
 
 -- roact functions

--- a/src/transpiler/call.ts
+++ b/src/transpiler/call.ts
@@ -122,7 +122,17 @@ function accessPathWrap(replacer: SimpleReplaceFunction): ReplaceFunction {
 const STRING_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 	.set("trim", wrapExpFunc(accessPath => `${accessPath}:match("^%s*(.-)%s*$")`))
 	.set("trimLeft", wrapExpFunc(accessPath => `${accessPath}:match("^%s*(.-)$")`))
-	.set("trimRight", wrapExpFunc(accessPath => `${accessPath}:match("^(.-)%s*$")`));
+	.set("trimRight", wrapExpFunc(accessPath => `${accessPath}:match("^(.-)%s*$")`))
+	.set("split", (params, state, subExp) => {
+		const firstParam = params[0];
+		const secondParam = params[1];
+		if (
+			(ts.TypeGuards.isStringLiteral(firstParam) && firstParam.getLiteralText() === "") ||
+			(secondParam && ts.TypeGuards.isTrueKeyword(secondParam))
+		) {
+			return `${wrapExpressionIfNeeded(state, subExp)}:split(${transpileCallArgument(state, params[0])})`;
+		}
+	});
 
 STRING_REPLACE_METHODS.set("trimStart", STRING_REPLACE_METHODS.get("trimLeft")!);
 STRING_REPLACE_METHODS.set("trimEnd", STRING_REPLACE_METHODS.get("trimRight")!);

--- a/tests/src/string.spec.ts
+++ b/tests/src/string.spec.ts
@@ -1,0 +1,56 @@
+export = () => {
+	it("should support string methods", () => {
+		expect("Hello, world".sub(1, 1)).to.equal("H");
+	});
+
+	it("should support string methods on identifiers", () => {
+		const str = "Hello, world";
+		expect(str.sub(1, 1)).to.equal("H");
+	});
+
+	it("should support string.split", () => {
+		function checkLen<T>(len: number, arr: Array<T>) {
+			expect(arr.length).to.equal(len);
+			return arr;
+		}
+
+		const str = "Hello, world";
+		const chars = [str.byte(1, -1)].map(i => string.char(i));
+		const words = ["Hello", "world"];
+		const hSplit = ["", "ello, world"];
+
+		expect(str.split("").every((char, i) => char === chars[i])).to.equal(true);
+		expect(str.split("", true).every((char, i) => char === chars[i])).to.equal(true);
+		expect(str.split(", ").every((word, i) => word === words[i])).to.equal(true);
+		expect(str.split(", ", true).every((word, i) => word === words[i])).to.equal(true);
+		expect(str.split(".").every(word => word === str)).to.equal(true);
+		expect(str.split(".", true).every(word => word === str)).to.equal(true);
+		expect(str.split("H").every((word, i) => word === hSplit[i])).to.equal(true);
+		expect(str.split("H", true).every((word, i) => word === hSplit[i])).to.equal(true);
+		expect(checkLen(1, "".split("a"))[0]).to.equal("");
+
+		for (let i = 2; 2 < 10; i++) {
+			const str = "d".rep(i - 1);
+			const str1 = str.split("d");
+			const str2 = str.split("d", true);
+			expect(str1.length).to.equal(i);
+			expect(str2.length).to.equal(i);
+			expect(str1.every(c => c === "")).to.equal(true);
+			expect(str2.every(c => c === "")).to.equal(true);
+		}
+
+		expect("".split("").isEmpty()).to.equal(true);
+		expect("".split("", true).isEmpty()).to.equal(true);
+
+		const slasher = ["", "Validark", "Osyris", "Vorlias", ""];
+		expect(checkLen(5, "/Validark/Osyris/Vorlias/".split("/")).every((word, i) => word === slasher[i])).to.equal(
+			true,
+		);
+		expect(checkLen(4, "Validark/Osyris/Vorlias/".split("/")).every((word, i) => word === slasher[i + 1])).to.equal(
+			true,
+		);
+		expect(checkLen(3, "Validark/Osyris/Vorlias".split("/")).every((word, i) => word === slasher[i + 1])).to.equal(
+			true,
+		);
+	});
+};


### PR DESCRIPTION
- Make our string.split implementation match the output of Roblox's and JavaScript's split functions (our previous version failed a lot of the test cases I added)
- Add a second parameter, `plain`, to `string.split`. This is modeled after the third parameter of `string.find`. 
- Add string.split macro for an empty string separator or when the plain parameter is set to true
- Add a bunch of test cases

After merging, please put this in rbx-types:
```ts
	/** Returns an array of substrings, separated by each `sep`.
	 * Accepts Lua character classes, unless `plain` is true.
	 */
	split(sep: string, plain?: boolean): Array<string>;
```

Requires merging this:
https://github.com/roblox-ts/rbx-types/pull/59