### PR TITLE
ClassExpression hotfix

### DIFF
--- a/src/transpiler/expression.ts
+++ b/src/transpiler/expression.ts
@@ -80,7 +80,8 @@ export function transpileExpression(state: TranspilerState, node: ts.Expression)
 	} else if (ts.TypeGuards.isThisExpression(node)) {
 		if (
 			!node.getFirstAncestorByKind(ts.SyntaxKind.ClassDeclaration) &&
-			!node.getFirstAncestorByKind(ts.SyntaxKind.ObjectLiteralExpression)
+			!node.getFirstAncestorByKind(ts.SyntaxKind.ObjectLiteralExpression) &&
+			!node.getFirstAncestorByKind(ts.SyntaxKind.ClassExpression)
 		) {
 			throw new TranspilerError(
 				"'this' may only be used inside a class definition or object literal",


### PR DESCRIPTION
The transpiler will incorrectly error when using `this` inside of a ClassExpression. This PR fixes that.