### PR TITLE
Macro rework

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -788,8 +788,9 @@ function TS.map_clear(map)
 end
 
 function TS.map_delete(map, key)
+	local deleted = map[key] ~= nil
 	map[key] = nil
-	return has
+	return deleted
 end
 
 local function getNumKeys(map)
@@ -863,7 +864,7 @@ end
 TS.set_clear = TS.map_clear
 
 function TS.set_delete(set, value)
-	local result = TS.set_has(set, value)
+	local result = set[value] == true
 	set[value] = nil
 	return result
 end

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -150,10 +150,6 @@ function TS.exportNamespace(module, ancestor)
 end
 
 -- general utility functions
-function TS.typeIs(value, typeName)
-	return typeof(value) == typeName
-end
-
 function TS.instanceof(obj, class)
 	-- custom Class.instanceof() check
 	if typeof(class) == TYPE_TABLE and typeof(class.instanceof) == TYPE_FUNCTION then
@@ -366,10 +362,6 @@ TS.Object_copy = copy
 TS.Object_deepCopy = deepCopy
 
 TS.Object_deepEquals = deepEquals
-
-function TS.Object_isEmpty(object)
-	return next(object) == nil
-end
 
 local function toString(data)
 	return HttpService:JSONEncode(data)
@@ -662,13 +654,6 @@ function TS.array_push(list, ...)
 	return #list
 end
 
-function TS.array_pop(list)
-	local length = #list
-	local lastValue = list[length]
-	list[length] = nil
-	return lastValue
-end
-
 local table_concat = table.concat
 
 function TS.array_join(list, separator)
@@ -786,16 +771,6 @@ TS.array_deepCopy = deepCopy
 
 TS.array_deepEquals = deepEquals
 
-TS.array_isEmpty = TS.Object_isEmpty
-
-function TS.array_insert(list, index, value)
-	table.insert(list, index + 1, value)
-end
-
-function TS.array_remove(list, index)
-	return table.remove(list, index + 1)
-end
-
 -- map macro functions
 
 function TS.map_new(value)
@@ -813,10 +788,7 @@ function TS.map_clear(map)
 end
 
 function TS.map_delete(map, key)
-	local has = TS.map_has(map, key)
-	if has then
-		map[key] = nil
-	end
+	map[key] = nil
 	return has
 end
 
@@ -842,14 +814,6 @@ function TS.map_forEach(map, callback)
 	for key, value in pairs(map) do
 		callback(value, key, map)
 	end
-end
-
-function TS.map_get(map, key)
-	return map[key]
-end
-
-function TS.map_has(map, key)
-	return map[key] ~= nil
 end
 
 local function getKeys(tab)
@@ -880,7 +844,6 @@ function TS.map_values(map)
 end
 
 TS.map_toString = toString
-TS.map_isEmpty = TS.Object_isEmpty
 
 -- set macro functions
 
@@ -910,8 +873,6 @@ function TS.set_forEach(set, callback)
 		callback(key, key, set)
 	end
 end
-
-TS.set_has = TS.map_has
 
 function TS.set_union(set1, set2)
 	local result = {}
@@ -971,8 +932,6 @@ end
 TS.set_values = getKeys
 
 TS.set_size = getNumKeys
-
-TS.set_isEmpty = TS.Object_isEmpty
 
 TS.set_toString = toString
 

--- a/src/errors/TranspilerError.ts
+++ b/src/errors/TranspilerError.ts
@@ -63,6 +63,7 @@ export enum TranspilerErrorType {
 	BadAddition,
 	InvalidMacroIndex,
 	NoTypeOf,
+	BadBuiltinConstructorCall,
 }
 
 export class TranspilerError extends Error {

--- a/src/transpiler/call.ts
+++ b/src/transpiler/call.ts
@@ -434,7 +434,7 @@ function transpilePropertyMethod(
 		}
 	}
 
-	const accessPath = transpileExpression(state, subExp);
+	const accessPath = className === "Object" ? undefined : transpileExpression(state, subExp);
 	state.usesTSLibrary = true;
 	return `TS.${className}_${property}(${transpileCallArguments(state, params, accessPath)})`;
 }

--- a/src/transpiler/call.ts
+++ b/src/transpiler/call.ts
@@ -3,6 +3,7 @@ import { checkApiAccess, checkNonAny, transpileExpression } from ".";
 import { TranspilerError, TranspilerErrorType } from "../errors/TranspilerError";
 import { TranspilerState } from "../TranspilerState";
 import { isArrayType, isStringType, isTupleReturnTypeCall, typeConstraint } from "../typeUtilities";
+import { appendDeclarationIfMissing } from "./expression";
 
 const STRING_MACRO_METHODS = [
 	"byte",
@@ -19,62 +20,104 @@ const STRING_MACRO_METHODS = [
 	"upper",
 ];
 
+function shouldWrapExpression(state: TranspilerState, subExp: ts.Node, strict: boolean) {
+	return (
+		!ts.TypeGuards.isIdentifier(subExp) &&
+		!ts.TypeGuards.isElementAccessExpression(subExp) &&
+		(strict || (!ts.TypeGuards.isCallExpression(subExp) && !ts.TypeGuards.isPropertyAccessExpression(subExp)))
+	);
+}
+
 function wrapExpressionIfNeeded(
 	state: TranspilerState,
 	subExp: ts.LeftHandSideExpression<ts.ts.LeftHandSideExpression>,
+	strict: boolean = false,
 ) {
 	// If we transpile to a method call, we might need to wrap in parenthesis
-	// We are always going to wrap in parenthesis just to be safe,
+	// We are going to wrap in parenthesis just to be safe,
 	// unless it's a CallExpression, Identifier, ElementAccessExpression, or PropertyAccessExpression
 
 	const accessPath = transpileExpression(state, subExp);
 
-	if (
-		!(
-			ts.TypeGuards.isCallExpression(subExp) ||
-			ts.TypeGuards.isIdentifier(subExp) ||
-			ts.TypeGuards.isElementAccessExpression(subExp) ||
-			ts.TypeGuards.isPropertyAccessExpression(subExp)
-		)
-	) {
+	if (shouldWrapExpression(state, subExp, strict)) {
 		return `(${accessPath})`;
 	} else {
 		return accessPath;
 	}
 }
 
-function getLeftHandSideParent(subExp: ts.Node, climb: number = 3) {
-	let exp = subExp;
-
-	for (let _ = 0; _ < climb; _++) {
-		exp = exp.getParent();
-		while (ts.TypeGuards.isNonNullExpression(exp)) {
-			exp = exp.getExpression();
-		}
+/** Skips over Null expressions */
+export function getNonNull<T extends ts.Node>(exp: T): T {
+	while (ts.TypeGuards.isNonNullExpression(exp)) {
+		exp = (exp.getExpression() as unknown) as T;
 	}
 
 	return exp;
 }
 
+function getLeftHandSideParent(subExp: ts.Node, climb: number = 3) {
+	let exp = subExp;
+
+	for (let _ = 0; _ < climb; _++) {
+		exp = getNonNull(exp.getParent());
+	}
+
+	return exp;
+}
+
+function transpileMapElement(state: TranspilerState, argumentList: Array<ts.Node>) {
+	const key = transpileCallArgument(state, argumentList[0]);
+	const value = transpileCallArgument(state, argumentList[1]);
+	return state.indent + `[${key}] = ${value};\n`;
+}
+
+function transpileSetElement(state: TranspilerState, argument: ts.Node) {
+	const key = transpileCallArgument(state, argument);
+	return state.indent + `[${key}] = true;\n`;
+}
+
+function transpileSetArrayLiteralParameter(state: TranspilerState, elements: Array<ts.Expression>) {
+	return elements.reduce((a, x) => a + transpileSetElement(state, x), "");
+}
+
+function transpileMapArrayLiteralParameter(state: TranspilerState, elements: Array<ts.Expression>) {
+	return elements.reduce((a, x) => {
+		if (ts.TypeGuards.isArrayLiteralExpression(x)) {
+			return a + transpileMapElement(state, x.getElements());
+		} else {
+			throw new TranspilerError(
+				"Bad arguments to Map constructor",
+				x,
+				TranspilerErrorType.BadBuiltinConstructorCall,
+			);
+		}
+	}, "");
+}
+
+export const literalParameterTranspileFunctions = new Map<
+	"set" | "map",
+	(state: TranspilerState, elements: Array<ts.Expression>) => string
+>([["set", transpileSetArrayLiteralParameter], ["map", transpileMapArrayLiteralParameter]]);
+
 function transpileLiterally(
-	params: Array<ts.Node>,
 	state: TranspilerState,
+	params: Array<ts.Node>,
 	subExp: ts.LeftHandSideExpression<ts.ts.LeftHandSideExpression>,
 	funcName: "set" | "add",
-	transpileParamFunc: (argumentList: Array<ts.Node>) => string,
+	transpileParamFunc: (state: TranspilerState, argumentList: Array<ts.Node>) => string,
 ) {
-	// and subExp is inside a VariableDeclaration, check if we can transpile an object literal
-	if (ts.TypeGuards.isVariableDeclaration(getLeftHandSideParent(subExp))) {
+	const leftHandSideParent = getLeftHandSideParent(subExp);
+	if (!getIsExpressionStatement(subExp, leftHandSideParent)) {
 		let child: ts.Node = subExp;
 		const extraParams = new Array<Array<ts.Node>>();
 
 		// Walk down the tree, making sure all descendants of subExp are .set() calls
 		while (ts.TypeGuards.isCallExpression(child)) {
 			extraParams.push(child.getArguments());
-			child = child.getChildAtIndex(0);
+			child = getNonNull(child.getChildAtIndex(0));
 
 			if (ts.TypeGuards.isPropertyAccessExpression(child) && child.getName() === funcName) {
-				child = child.getChildAtIndex(0);
+				child = getNonNull(child.getChildAtIndex(0));
 			} else {
 				break;
 			}
@@ -82,26 +125,35 @@ function transpileLiterally(
 
 		// if all set calls are on a newExpression
 		if (child && ts.TypeGuards.isNewExpression(child)) {
+			let result = "{\n";
 			state.pushIndent();
-			let result = extraParams.reduceRight((a, x) => (a += state.indent + transpileParamFunc(x)), "{\n");
-			result += state.indent + transpileParamFunc(params);
+
+			const newArguments = child.getArguments();
+			const firstArgument = newArguments[0];
+
+			if (newArguments.length === 1 && ts.TypeGuards.isArrayLiteralExpression(firstArgument)) {
+				const elements = firstArgument.getElements();
+				result += literalParameterTranspileFunctions.get(funcName === "add" ? "set" : "map")!(state, elements);
+			} else if (newArguments.length !== 0) {
+				state.popIndent();
+				return undefined;
+			}
+
+			result = extraParams.reduceRight((a, x) => a + transpileParamFunc(state, x), result);
+			result += transpileParamFunc(state, params);
 			state.popIndent();
 			result += state.indent + "}";
-			return result;
+			return appendDeclarationIfMissing(state, leftHandSideParent, result);
 		}
 	}
 }
 
-function getIsExpression(subExp: ts.LeftHandSideExpression<ts.ts.LeftHandSideExpression>, parent: ts.Node) {
+function getIsExpressionStatement(subExp: ts.LeftHandSideExpression<ts.ts.LeftHandSideExpression>, parent: ts.Node) {
 	return !ts.TypeGuards.isNewExpression(subExp) && ts.TypeGuards.isExpressionStatement(parent);
 }
 
-function getPropertyCallParentIsExpression(subExp: ts.LeftHandSideExpression<ts.ts.LeftHandSideExpression>) {
-	return getIsExpression(subExp, getLeftHandSideParent(subExp));
-}
-
-function getCallParentIsExpression(subExp: ts.LeftHandSideExpression<ts.ts.LeftHandSideExpression>) {
-	return getIsExpression(subExp, getLeftHandSideParent(subExp, 2));
+function getPropertyCallParentIsExpressionStatement(subExp: ts.LeftHandSideExpression<ts.ts.LeftHandSideExpression>) {
+	return getIsExpressionStatement(subExp, getLeftHandSideParent(subExp));
 }
 
 type SimpleReplaceFunction = (
@@ -152,10 +204,9 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 
 	.set("push", (params, state, subExp) => {
 		const length = params.length;
-		const propertyCallParentIsExpression = getPropertyCallParentIsExpression(subExp);
-		if (length === 1 && propertyCallParentIsExpression) {
-			const paramStr = transpileCallArgument(state, params[0]);
+		if (length === 1 && getPropertyCallParentIsExpressionStatement(subExp)) {
 			const accessPath = transpileExpression(state, subExp);
+			const paramStr = transpileCallArgument(state, params[0]);
 
 			if (ts.TypeGuards.isIdentifier(subExp)) {
 				return `${accessPath}[#${accessPath} + 1] = ${paramStr}`;
@@ -167,10 +218,9 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 
 	.set("unshift", (params, state, subExp) => {
 		const length = params.length;
-		const propertyCallParentIsExpression = getPropertyCallParentIsExpression(subExp);
-		if (length === 1 && propertyCallParentIsExpression) {
-			const paramStr = transpileCallArgument(state, params[0]);
+		if (length === 1 && getPropertyCallParentIsExpressionStatement(subExp)) {
 			const accessPath = transpileExpression(state, subExp);
+			const paramStr = transpileCallArgument(state, params[0]);
 			return `table.insert(${accessPath}, 1, ${paramStr})`;
 		}
 	})
@@ -190,64 +240,72 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 			const indexParamStr = transpileCallArgument(state, params[0]);
 			return `table.remove(${accessPath}, ${indexParamStr} + 1)`;
 		}),
+	)
+
+	.set("isEmpty", (params, state, subExp) =>
+		appendDeclarationIfMissing(
+			state,
+			getLeftHandSideParent(subExp),
+			`(next(${transpileExpression(state, subExp)}) == nil)`,
+		),
 	);
 
 const MAP_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 	.set("get", (params, state, subExp) => {
-		if (!getPropertyCallParentIsExpression(subExp)) {
-			const accessPath = transpileExpression(state, subExp);
-			const key = transpileCallArgument(state, params[0]);
-			return `${accessPath}[${key}]`;
-		}
+		const accessPath = wrapExpressionIfNeeded(state, subExp, true);
+		const key = transpileCallArgument(state, params[0]);
+		return appendDeclarationIfMissing(state, getLeftHandSideParent(subExp), `${accessPath}[${key}]`);
 	})
 
 	.set("set", (params, state, subExp) => {
-		const literalResults = transpileLiterally(params, state, subExp, "set", (argumentList: Array<ts.Node>) => {
-			const key = transpileCallArgument(state, argumentList[0]);
-			const value = transpileCallArgument(state, argumentList[1]);
-			return `[${key}] = ${value};\n`;
-		});
-
+		const literalResults = transpileLiterally(state, params, subExp, "set", (stately, argumentList) =>
+			transpileMapElement(stately, argumentList),
+		);
 		if (literalResults) {
 			return literalResults;
 		} else {
-			if (getPropertyCallParentIsExpression(subExp)) {
+			if (getPropertyCallParentIsExpressionStatement(subExp)) {
+				const accessPath = wrapExpressionIfNeeded(state, subExp, true);
 				const key = transpileCallArgument(state, params[0]);
 				const value = transpileCallArgument(state, params[1]);
-				const accessPath = transpileExpression(state, subExp);
 				return `${accessPath}[${key}] = ${value}`;
 			}
 		}
 	})
 
 	.set("delete", (params, state, subExp) => {
-		if (getPropertyCallParentIsExpression(subExp)) {
-			const accessPath = transpileExpression(state, subExp);
+		if (getPropertyCallParentIsExpressionStatement(subExp)) {
+			const accessPath = wrapExpressionIfNeeded(state, subExp, true);
 			const key = transpileCallArgument(state, params[0]);
 			return `${accessPath}[${key}] = nil`;
 		}
 	})
 
 	.set("has", (params, state, subExp) => {
-		if (!getPropertyCallParentIsExpression(subExp)) {
-			const accessPath = transpileExpression(state, subExp);
-			const key = transpileCallArgument(state, params[0]);
-			return `(${accessPath}[${key}] ~= nil)`;
-		}
-	});
+		const accessPath = wrapExpressionIfNeeded(state, subExp, true);
+		const key = transpileCallArgument(state, params[0]);
+		return appendDeclarationIfMissing(state, getLeftHandSideParent(subExp), `(${accessPath}[${key}] ~= nil)`);
+	})
+
+	.set("isEmpty", (params, state, subExp) =>
+		appendDeclarationIfMissing(
+			state,
+			getLeftHandSideParent(subExp),
+			`(next(${transpileExpression(state, subExp)}) == nil)`,
+		),
+	);
 
 const SET_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 	.set("add", (params, state, subExp) => {
-		const literalResults = transpileLiterally(params, state, subExp, "add", (argumentList: Array<ts.Node>) => {
-			const key = transpileCallArgument(state, argumentList[0]);
-			return `[${key}] = true;\n`;
-		});
+		const literalResults = transpileLiterally(state, params, subExp, "add", (stately, argumentList) =>
+			transpileSetElement(stately, argumentList[0]),
+		);
 
 		if (literalResults) {
 			return literalResults;
 		} else {
-			if (getPropertyCallParentIsExpression(subExp)) {
-				const accessPath = transpileExpression(state, subExp);
+			if (getPropertyCallParentIsExpressionStatement(subExp)) {
+				const accessPath = wrapExpressionIfNeeded(state, subExp, true);
 				const key = transpileCallArgument(state, params[0]);
 				return `${accessPath}[${key}] = true`;
 			}
@@ -255,29 +313,41 @@ const SET_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 	})
 
 	.set("delete", (params, state, subExp) => {
-		if (getPropertyCallParentIsExpression(subExp)) {
-			const accessPath = transpileExpression(state, subExp);
+		if (getPropertyCallParentIsExpressionStatement(subExp)) {
+			const accessPath = wrapExpressionIfNeeded(state, subExp, true);
 			const key = transpileCallArgument(state, params[0]);
 			return `${accessPath}[${key}] = nil`;
 		}
 	})
 
 	.set("has", (params, state, subExp) => {
-		if (!getPropertyCallParentIsExpression(subExp)) {
-			const accessPath = transpileExpression(state, subExp);
-			const key = transpileCallArgument(state, params[0]);
-			return `(${accessPath}[${key}] ~= nil)`;
-		}
-	});
+		const accessPath = wrapExpressionIfNeeded(state, subExp, true);
+		const key = transpileCallArgument(state, params[0]);
+		return appendDeclarationIfMissing(state, getLeftHandSideParent(subExp), `(${accessPath}[${key}] == true)`);
+	})
+
+	.set("isEmpty", (params, state, subExp) =>
+		appendDeclarationIfMissing(
+			state,
+			getLeftHandSideParent(subExp),
+			`(next(${transpileExpression(state, subExp)}) == nil)`,
+		),
+	);
+
+const OBJECT_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>().set("isEmpty", (params, state, subExp) =>
+	appendDeclarationIfMissing(
+		state,
+		getLeftHandSideParent(subExp),
+		`(next(${transpileCallArgument(state, params[0])}) == nil)`,
+	),
+);
 
 const RBX_MATH_CLASSES = ["CFrame", "UDim", "UDim2", "Vector2", "Vector2int16", "Vector3", "Vector3int16"];
 
 const GLOBAL_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>().set("typeIs", (params, state, subExp) => {
-	if (!getCallParentIsExpression(subExp)) {
-		const obj = transpileCallArgument(state, params[0]);
-		const type = transpileCallArgument(state, params[1]);
-		return `(typeof(${obj}) == ${type})`;
-	}
+	const obj = transpileCallArgument(state, params[0]);
+	const type = transpileCallArgument(state, params[1]);
+	return appendDeclarationIfMissing(state, getLeftHandSideParent(subExp, 2), `(typeof(${obj}) == ${type})`);
 });
 
 export function transpileCallArgument(state: TranspilerState, arg: ts.Node) {
@@ -471,7 +541,7 @@ export function getPropertyAccessExpressionType(
 }
 
 export function transpilePropertyCallExpression(state: TranspilerState, node: ts.CallExpression) {
-	const expression = node.getExpression();
+	const expression = getNonNull(node.getExpression());
 	if (!ts.TypeGuards.isPropertyAccessExpression(expression)) {
 		throw new TranspilerError(
 			"Expected PropertyAccessExpression",
@@ -482,7 +552,7 @@ export function transpilePropertyCallExpression(state: TranspilerState, node: ts
 
 	checkApiAccess(state, expression.getNameNode());
 
-	const subExp = expression.getExpression();
+	const subExp = getNonNull(expression.getExpression());
 	const property = expression.getName();
 	const params = node.getArguments();
 
@@ -502,8 +572,7 @@ export function transpilePropertyCallExpression(state: TranspilerState, node: ts
 		case PropertyCallExpType.Set:
 			return transpilePropertyMethod(state, property, params, subExp, "set", SET_REPLACE_METHODS);
 		case PropertyCallExpType.ObjectConstructor:
-			state.usesTSLibrary = true;
-			return `TS.Object_${property}(${transpileCallArguments(state, params)})`;
+			return transpilePropertyMethod(state, property, params, subExp, "Object", OBJECT_REPLACE_METHODS);
 		case PropertyCallExpType.RbxMathAdd:
 			return `(${transpileExpression(state, subExp)} + (${transpileCallArgument(state, params[0])}))`;
 		case PropertyCallExpType.RbxMathSub:

--- a/src/transpiler/expression.ts
+++ b/src/transpiler/expression.ts
@@ -166,7 +166,19 @@ export function expressionModifiesVariable(
 	return false;
 }
 
-export function placeInStatementIfExpression(
+export function appendDeclarationIfMissing(
+	state: TranspilerState,
+	possibleExpressionStatement: ts.Node,
+	transpiledNode: string,
+) {
+	if (ts.TypeGuards.isExpressionStatement(possibleExpressionStatement)) {
+		return "local _ = " + transpiledNode;
+	} else {
+		return transpiledNode;
+	}
+}
+
+export function placeIncrementorInStatementIfExpression(
 	state: TranspilerState,
 	incrementor: ts.Expression<ts.ts.Expression>,
 	incrementorStr: string,

--- a/src/transpiler/loop.ts
+++ b/src/transpiler/loop.ts
@@ -2,7 +2,7 @@ import * as ts from "ts-morph";
 import {
 	expressionModifiesVariable,
 	getBindingData,
-	placeInStatementIfExpression,
+	placeIncrementorInStatementIfExpression,
 	transpileExpression,
 	transpileStatement,
 	transpileVariableDeclarationList,
@@ -390,7 +390,7 @@ function safelyHandleExpressionsInForStatement(
 	if (ts.TypeGuards.isExpression(incrementor)) {
 		checkLoopClassExp(incrementor);
 	}
-	return state.indent + placeInStatementIfExpression(state, incrementor, incrementorStr);
+	return state.indent + placeIncrementorInStatementIfExpression(state, incrementor, incrementorStr);
 }
 
 function getSimpleForLoopString(

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -437,4 +437,16 @@ export = () => {
 		expect([1, 2, 4].toString()).to.be.ok();
 		expect(typeOf(x.toString())).to.equal("string");
 	});
+
+	it("should support isEmpty", () => {
+		new Array<string>().isEmpty();
+		const v = new Array<string>().isEmpty();
+		const arr = new Array<string>();
+		arr.isEmpty();
+		const x = arr.isEmpty();
+
+		expect(v).to.equal(true);
+		arr.push("Nope");
+		expect(arr.isEmpty()).to.equal(false);
+	});
 };

--- a/tests/src/map.spec.ts
+++ b/tests/src/map.spec.ts
@@ -123,13 +123,41 @@ export = () => {
 	});
 
 	it("should support values", () => {
-		const map = new Map<string, number>()
-			.set("a", 1)
-			.set("b", 2)
-			.set("c", 3);
+		const map = new Map<string, number>([["b", 2], ["c", 4], ["a", 9]]).set("a", 1).set("c", 3);
 		const a = map.values();
 		expect(a.some(v => v === 1)).to.equal(true);
 		expect(a.some(v => v === 2)).to.equal(true);
 		expect(a.some(v => v === 3)).to.equal(true);
+	});
+
+	it("should support constructor parameters", () => {
+		const arr: ReadonlyArray<[string, number]> = [["a", 1], ["b", 2], ["c", 3]];
+
+		const map = new Map<string, number>([["a", 1], ["b", 2], ["c", 3]]);
+		const map2 = new Map<string, number>(arr);
+
+		{
+			const a = map.values();
+			expect(a.some(v => v === 1)).to.equal(true);
+			expect(a.some(v => v === 2)).to.equal(true);
+			expect(a.some(v => v === 3)).to.equal(true);
+		}
+		{
+			const a = map2.values();
+			expect(a.some(v => v === 1)).to.equal(true);
+			expect(a.some(v => v === 2)).to.equal(true);
+			expect(a.some(v => v === 3)).to.equal(true);
+		}
+	});
+
+	it("should support isEmpty", () => {
+		new Map<string, number>().isEmpty();
+		const v = new Map<string, number>().isEmpty();
+		const map = new Map<string, number>();
+		map.isEmpty();
+		const x = map.isEmpty();
+
+		expect(v).to.equal(true);
+		expect(map.set("Nope", 1).isEmpty()).to.equal(false);
 	});
 };

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -1,10 +1,14 @@
 export = () => {
 	it("should support object literal brackets", () => {
+		/* prettier-ignore */
+		/* tslint:disable */
 		const obj = {
 			test: 1,
-			2: 2,
+			"2": 2,
 			[1]: 3,
 		};
+		/* tslint:enable */
+
 		expect(obj.test).to.equal(1);
 		expect(obj["2"]).to.equal(2);
 		expect(obj[1]).to.equal(3);

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -2,7 +2,7 @@ export = () => {
 	it("should support object literal brackets", () => {
 		const obj = {
 			test: 1,
-			"2": 2,
+			2: 2,
 			[1]: 3,
 		};
 		expect(obj.test).to.equal(1);
@@ -202,6 +202,15 @@ export = () => {
 			};
 			expect(object1[1]).to.equal(1);
 			expect(object1[2]).to.equal(1);
+		});
+
+		it("should support isEmpty", () => {
+			expect(Object.isEmpty({})).to.equal(true);
+			expect(
+				Object.isEmpty({
+					1: 2,
+				}),
+			).to.equal(false);
 		});
 	});
 };

--- a/tests/src/set.spec.ts
+++ b/tests/src/set.spec.ts
@@ -198,15 +198,10 @@ export = () => {
 
 	it("should support difference", () => {
 		// the symmetric difference of  { 7, 8, 9, 10 } and { 9, 10, 11, 12 } is the set { 7, 8, 11, 12 }
-		const set1 = new Set<number>()
-			.add(7)
-			.add(8)
-			.add(9)
-			.add(10);
-		const set2 = new Set<number>()
+		const set1 = new Set<number>([7, 8]).add(9).add(10);
+		const set2 = new Set<number>([11])
 			.add(9)
 			.add(10)
-			.add(11)
 			.add(12);
 		const set3 = new Set<number>()
 			.add(7)
@@ -218,5 +213,16 @@ export = () => {
 
 		expect(set3.isSubsetOf(set4)).to.equal(true);
 		expect(set4.isSubsetOf(set3)).to.equal(true);
+	});
+
+	it("should support isEmpty", () => {
+		new Set<string>().isEmpty();
+		const v = new Set<string>().isEmpty();
+		const set = new Set<string>();
+		set.isEmpty();
+		const x = set.isEmpty();
+
+		expect(v).to.equal(true);
+		expect(set.add("Nope").isEmpty()).to.equal(false);
 	});
 };


### PR DESCRIPTION
All of these changes are in regards to the macro functionality. This pull request makes outputted code more consistent, more optimized, and less prone to bugs.

Fixes:

- Fixed occasions where invalid Lua code would be outputted. Now we make sure to wrap table literals in parenthesis when writing or reading from them using `[]` and we make sure to put unused expressions after a `local _ = `. One should note that this fixes a number of potential problems.
	```ts
	if (new Set<number>().has(1)) print("It has 1!");
	```
	What this used to compile to:
	```lua
	-- invalid Lua
	if ({}[1] ~= nil) then
		print("It has 1!");
	end;
	```
	What this compiles to now:
	```lua
	-- Valid!
	if (({})[1] == true) then
		print("It has 1!");
	end;
	```

- Fixes map_set/set_add chains being used together with array literal constructors, although one wouldn't need to in practice:
	```ts
	const foo = new Set<string>(["A"]).add("B");
	```
	Used to compile to:
	```lua
	local foo = { -- Where did that A go? Into the void!
		["B"] = true;
	};
	```
	- This also makes compilation more consistent, so one doesn't get dramatically different code depending on whether a macro is in an expression:
	```ts
	// In an unused expression
	new Set<string>(["A"]).add("B");
	// Old -> TS.set_add(TS.set_new({ "A" }), "B");
	// New -> local _ = { ["A"] = true; ["B"] = true; };

	// Used in an expression
	const foo = new Set<string>(["A"]).add("B");
	// Old -> local foo = { ["B"] = true; };
	// New -> local foo = { ["A"] = true; ["B"] = true; };
	```


- Fixed WeakMap/WeakSet constructors (previously Roblox-TS would not transpile constructor parameters, meaning WeakMap/Sets always transpiled to `setmetatable({}, {... etc})`)

Changes:
- Added complete macro support for `typeIs`, `isEmpty`. That means these will always compile in-line.
- Removed the following Lua definitions from the standard library: `array_pop`, `typeIs`, `array_insert`, `array_remove`, `any_isEmpty`, `any_has`, `map_get`. These are all compiled in-line now and they would never be called by anything compiled by Roblox-TS.
- Optimized constructors called with ArrayLiteralValues for Maps and Sets
	- That means these two snippets now compile to the same code:
	```ts
	const NumberNames = new Map<string, number>()
		.set("None", 0)
		.set("One", 1)
		.set("Two", 2)
		.set("Three", 3);
	```
	```ts
	const NumberNames = new Map<string, number>([
		["None", 0],
		["One", 1],
		["Two", 2],
		["Three", 3],
	]);
	```
	Lua equivalent:
	```lua
	local NumberNames = {
		["None"] = 0;
		["One"] = 1;
		["Two"] = 2;
		["Three"] = 3;
	};
	```
	Lua (5.3) bytecode:
	```
	    1       [4]     NEWTABLE        0 0 4
        2       [5]     SETTABLE        0 -1 -2 ; "None" 0
        3       [6]     SETTABLE        0 -3 -4 ; "One" 1
        4       [7]     SETTABLE        0 -5 -6 ; "Two" 2
        5       [8]     SETTABLE        0 -7 -8 ; "Three" 3
	```
- Made it so you can initialize arrays of a certain length #298. Capped at `200` to protect the user from themself. (the number passed in must be a literal number matchable by `\d+` and between 0 and 200 inclusive)
	```ts
	const arr = new Array(10);
	```
	```lua
	local arr = { nil, nil, nil, nil, nil, nil, nil, nil, nil, nil };
	```

	- Here's the new definition for the ArrayConstructor:
	```ts
	interface ArrayConstructor {
		/** Instantiates a new array.
		 * If length is provided, roblox-TS will load `length` amount of nil's into the new array.
		 * Note that this does not affect the `length` property of the array,
		 * it only keeps it from needing to resize to this `length` later.
		 *
		 * @param length A literal integer between 0 and 200 inclusive, which is the number of nil's to push onto the array
		 */
		new <T>(length?: number): Array<T>;
	}
	```

Fixes #298
Should be merged alongside https://github.com/roblox-ts/rbx-types/pull/57