### PR TITLE
Default export hotfix

### DIFF
--- a/src/TranspilerState.ts
+++ b/src/TranspilerState.ts
@@ -72,7 +72,7 @@ export class TranspilerState {
 		}
 
 		const ancestorName = this.getExportContextName(node);
-		const alias = node.isDefaultExport() ? "_default" : name;
+		const alias = node.hasDefaultKeyword() ? "_default" : name;
 		this.exportStack[this.exportStack.length - 1].add(`${ancestorName}.${alias} = ${name};\n`);
 	}
 


### PR DESCRIPTION
This TS code should transpile to the following Lua code:
```ts
export function bar() {}
export function foo() {}

export default foo;
```
```lua
local _exports = {};
local bar = function()
end;
local foo = function()
end;
_exports._default = foo;
_exports.bar = bar;
_exports.foo = foo;
return _exports;
```
Previously, we were getting 2 default values because `(_exports.foo).isDefaultExport()` is true, even if it isn't the particular statement that makes it the default export.