### PR TITLE
Fix spread expressions inside set/map constructors

### DIFF
--- a/src/transpiler/new.ts
+++ b/src/transpiler/new.ts
@@ -15,7 +15,11 @@ function transpileSetMapConstructorHelper(
 ) {
 	const firstParam = args[0];
 
-	if (firstParam && !ts.TypeGuards.isArrayLiteralExpression(firstParam)) {
+	if (
+		firstParam &&
+		(!ts.TypeGuards.isArrayLiteralExpression(firstParam) ||
+			firstParam.getChildrenOfKind(ts.SyntaxKind.SpreadElement).length > 0)
+	) {
 		state.usesTSLibrary = true;
 		return `TS.${type}_new(${transpileCallArguments(state, args)})`;
 	} else {


### PR DESCRIPTION
I overlooked this edge case.

```ts
const set = new Set([...[1, 2, 5], 9, ...[0]]);
const set2 = new Set([...[1, 2, 5].concat([1])]);
```

Old:

```lua
local set = {
	[unpack({ 1, 2, 5 })] = true;
	[9] = true;
	[unpack({ 0 })] = true;
};
local set2 = {
	[unpack(TS.array_concat({ 1, 2, 5 }, { 1 }))] = true;
};
```
New:

```lua
local set = TS.set_new(TS.array_concat({ 1, 2, 5 }, { 9 }, { 0 }));
local set2 = TS.set_new(TS.array_concat(TS.array_concat({ 1, 2, 5 }, { 1 })));
```