### PR TITLE
Disallow nil indexing in maps/sets

### DIFF
--- a/src/errors/TranspilerError.ts
+++ b/src/errors/TranspilerError.ts
@@ -64,6 +64,7 @@ export enum TranspilerErrorType {
 	InvalidMacroIndex,
 	NoTypeOf,
 	BadBuiltinConstructorCall,
+	NullableIndexOnMapOrSet,
 }
 
 export class TranspilerError extends Error {

--- a/src/transpiler/new.ts
+++ b/src/transpiler/new.ts
@@ -13,6 +13,18 @@ function transpileSetMapConstructorHelper(
 	args: Array<ts.Node>,
 	type: "set" | "map",
 ) {
+	if (
+		node
+			.getType()
+			.getTypeArguments()
+			.some(myType => myType.isUndefined() || myType.isNullable())
+	) {
+		throw new TranspilerError(
+			`Cannot create a ${type} with a nullable index!`,
+			node,
+			TranspilerErrorType.NullableIndexOnMapOrSet,
+		);
+	}
 	const firstParam = args[0];
 
 	if (firstParam && !ts.TypeGuards.isArrayLiteralExpression(firstParam)) {


### PR DESCRIPTION
Problem:
```ts
const foo = new Map([[, "Decay"]]);
```
```ts
local foo = {
	[nil] = "Decay"; //error
};
```