### PR TITLE
Add bitwise NOT, logical right shift operators.

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -244,6 +244,10 @@ local function bitop(a, b, oper)
 	return r
 end
 
+function TS.bnot(a)
+	return -a - 1
+end
+
 function TS.bor(a, b)
 	a = bitTruncate(tonumber(a))
 	b = bitTruncate(tonumber(b))

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -221,9 +221,7 @@ local function bitTruncate(a)
 	end
 end
 
-TS.round = bitTruncate
-
-TS.bitTruncate = bitTruncate
+TS.bit_truncate = bitTruncate
 
 -- bitwise operations
 local powOfTwo = setmetatable({}, {
@@ -244,38 +242,45 @@ local function bitop(a, b, oper)
 	return r
 end
 
-function TS.bnot(a)
+function TS.bit_not(a)
 	return -a - 1
 end
 
-function TS.bor(a, b)
+function TS.bit_or(a, b)
 	a = bitTruncate(tonumber(a))
 	b = bitTruncate(tonumber(b))
 	return bitop(a, b, 1)
 end
 
-function TS.band(a, b)
+function TS.bit_and(a, b)
 	a = bitTruncate(tonumber(a))
 	b = bitTruncate(tonumber(b))
 	return bitop(a, b, 4)
 end
 
-function TS.bxor(a, b)
+function TS.bit_xor(a, b)
 	a = bitTruncate(tonumber(a))
 	b = bitTruncate(tonumber(b))
 	return bitop(a, b, 3)
 end
 
-function TS.blsh(a, b)
+function TS.bit_lsh(a, b)
 	a = bitTruncate(tonumber(a))
 	b = bitTruncate(tonumber(b))
 	return a * powOfTwo[b]
 end
 
-function TS.brsh(a, b)
+function TS.bit_rsh(a, b)
 	a = bitTruncate(tonumber(a))
 	b = bitTruncate(tonumber(b))
 	return bitTruncate(a / powOfTwo[b])
+end
+
+function TS.bit_lrsh(a, b)
+	a = bitTruncate(tonumber(a))
+	b = bitTruncate(tonumber(b))
+	if a >= 0 then return TS.bit_rsh(a, b) end
+	return TS.bit_rsh((a % powOfTwo[32]), b)
 end
 
 -- utility functions

--- a/src/transpiler/binary.ts
+++ b/src/transpiler/binary.ts
@@ -9,15 +9,15 @@ function getLuaBarExpression(state: TranspilerState, node: ts.BinaryExpression, 
 	state.usesTSLibrary = true;
 	const rhs = node.getRight();
 	if (ts.TypeGuards.isNumericLiteral(rhs) && rhs.getLiteralValue() === 0) {
-		return `TS.round(${lhsStr})`;
+		return `TS.bit_truncate(${lhsStr})`;
 	} else {
-		return `TS.bor(${lhsStr}, ${rhsStr})`;
+		return `TS.bit_or(${lhsStr}, ${rhsStr})`;
 	}
 }
 
 function getLuaBitExpression(state: TranspilerState, lhsStr: string, rhsStr: string, name: string) {
 	state.usesTSLibrary = true;
-	return `TS.b${name}(${lhsStr}, ${rhsStr})`;
+	return `TS.bit_${name}(${lhsStr}, ${rhsStr})`;
 }
 
 function getLuaAddExpression(node: ts.BinaryExpression, lhsStr: string, rhsStr: string, wrap = false) {
@@ -50,6 +50,7 @@ export function isSetToken(opKind: ts.ts.SyntaxKind) {
 		opKind === ts.SyntaxKind.CaretEqualsToken ||
 		opKind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
 		opKind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+		opKind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
 		opKind === ts.SyntaxKind.PlusEqualsToken ||
 		opKind === ts.SyntaxKind.MinusEqualsToken ||
 		opKind === ts.SyntaxKind.AsteriskEqualsToken ||
@@ -140,6 +141,9 @@ export function transpileBinaryExpression(state: TranspilerState, node: ts.Binar
 		} else if (opKind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken) {
 			const rhsExpStr = getLuaBitExpression(state, lhsStr, rhsStr, "rsh");
 			statements.push(`${lhsStr} = ${rhsExpStr}`);
+		} else if (opKind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken) {
+			const rhsExpStr = getLuaBitExpression(state, lhsStr, rhsStr, "lrsh");
+			statements.push(`${lhsStr} = ${rhsExpStr}`);
 		} else if (opKind === ts.SyntaxKind.PlusEqualsToken) {
 			const addExpStr = getLuaAddExpression(node, lhsStr, rhsStr, true);
 			statements.push(`${lhsStr} = ${addExpStr}`);
@@ -193,6 +197,8 @@ export function transpileBinaryExpression(state: TranspilerState, node: ts.Binar
 		return getLuaBitExpression(state, lhsStr, rhsStr, "lsh");
 	} else if (opKind === ts.SyntaxKind.GreaterThanGreaterThanToken) {
 		return getLuaBitExpression(state, lhsStr, rhsStr, "rsh");
+	} else if (opKind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken) {
+		return getLuaBitExpression(state, lhsStr, rhsStr, "lrsh");
 	} else if (opKind === ts.SyntaxKind.PlusToken) {
 		return getLuaAddExpression(node, lhsStr, rhsStr);
 	} else if (opKind === ts.SyntaxKind.MinusToken) {

--- a/src/transpiler/unary.ts
+++ b/src/transpiler/unary.ts
@@ -55,7 +55,7 @@ export function transpilePrefixUnaryExpression(state: TranspilerState, node: ts.
 			return `-${expStr}`;
 		} else if (tokenKind === ts.SyntaxKind.TildeToken) {
 			state.usesTSLibrary = true;
-			return `TS.bnot(${expStr})`;
+			return `TS.bit_not(${expStr})`;
 		} else {
 			/* istanbul ignore next */
 			throw new TranspilerError(

--- a/src/transpiler/unary.ts
+++ b/src/transpiler/unary.ts
@@ -53,6 +53,9 @@ export function transpilePrefixUnaryExpression(state: TranspilerState, node: ts.
 			return `not ${expStr}`;
 		} else if (tokenKind === ts.SyntaxKind.MinusToken) {
 			return `-${expStr}`;
+		} else if (tokenKind === ts.SyntaxKind.TildeToken) {
+			state.usesTSLibrary = true;
+			return `TS.bnot(${expStr})`;
 		} else {
 			/* istanbul ignore next */
 			throw new TranspilerError(

--- a/tests/src/bitwise.spec.ts
+++ b/tests/src/bitwise.spec.ts
@@ -8,8 +8,8 @@ export = () => {
 		expect(a << 1).to.equal(0b1010);
 		expect(a >> 1).to.equal(0b10);
 		expect(a | 0).to.equal(0b101);
-		expect(~a & 0b111).to.equal(0b010);
-		expect(~b & 0b111).to.equal(0b001);
+		expect(~a).to.equal(-6);
+		expect(~b).to.equal(-7);
 	});
 
 	it("should support bitwise assignment", () => {

--- a/tests/src/bitwise.spec.ts
+++ b/tests/src/bitwise.spec.ts
@@ -8,6 +8,8 @@ export = () => {
 		expect(a << 1).to.equal(0b1010);
 		expect(a >> 1).to.equal(0b10);
 		expect(a | 0).to.equal(0b101);
+		expect(~a & 0b111).to.equal(0b010);
+		expect(~b & 0b111).to.equal(0b001);
 	});
 
 	it("should support bitwise assignment", () => {

--- a/tests/src/bitwise.spec.ts
+++ b/tests/src/bitwise.spec.ts
@@ -7,6 +7,7 @@ export = () => {
 		expect(a ^ b).to.equal(0b011);
 		expect(a << 1).to.equal(0b1010);
 		expect(a >> 1).to.equal(0b10);
+		expect(a >>> 1).to.equal(0b10);
 		expect(a | 0).to.equal(0b101);
 		expect(~a).to.equal(-6);
 		expect(~b).to.equal(-7);
@@ -32,6 +33,10 @@ export = () => {
 		let e = 0b101;
 		e >>= 1;
 		expect(e).to.equal(0b10);
+
+		let f = -1;
+		f >>>= 0;
+		expect(f).to.equal(math.pow(2, 32) - 1);
 	});
 
 	it("should support bitwise assignment expressions", () => {
@@ -49,5 +54,8 @@ export = () => {
 
 		let e = 0b101;
 		expect((e >>= 1)).to.equal(0b10);
+
+		let f = -1;
+		expect((f >>>= 0)).to.equal(math.pow(2, 32) - 1);
 	});
 };


### PR DESCRIPTION
- Adds support for the bitwise NOT operator (`~`)
  - Yields one's complement (inverted value) of `a`

### Truth Table
 a | NOT a
-- | ----------
 0 | 1
 1 | 0

Small demo:
```typescript
let a = 0xFE; // decimal: 254
let b = ~a; // -0xFF (decimal: -255)
b &= 0xFF; // 0x01 (decimal: 1)
```
```typescript
let a = 0b01; // 1
let b = ~a & 0b11; // 2
```

Works towards #156 