### PR TITLE
Add support for yield*

### DIFF
--- a/src/compiler/expression.ts
+++ b/src/compiler/expression.ts
@@ -27,6 +27,7 @@ import {
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { isIdentifierWhoseDefinitionMatchesNode } from "../utility";
+import { compileYieldExpression } from "./yield";
 
 export function compileExpression(state: CompilerState, node: ts.Expression): string {
 	if (ts.TypeGuards.isStringLiteral(node) || ts.TypeGuards.isNoSubstitutionTemplateLiteral(node)) {
@@ -75,6 +76,8 @@ export function compileExpression(state: CompilerState, node: ts.Expression): st
 		return compileSpreadElement(state, node);
 	} else if (ts.TypeGuards.isClassExpression(node)) {
 		return compileClassExpression(state, node);
+	} else if (ts.TypeGuards.isYieldExpression(node)) {
+		return compileYieldExpression(state, node);
 	} else if (ts.TypeGuards.isOmittedExpression(node)) {
 		return "nil";
 	} else if (ts.TypeGuards.isThisExpression(node)) {
@@ -106,15 +109,6 @@ export function compileExpression(state: CompilerState, node: ts.Expression): st
 			node,
 			CompilerErrorType.NoTypeOf,
 		);
-	} else if (ts.TypeGuards.isYieldExpression(node)) {
-		const exp = node.getExpression();
-		let result = `coroutine.yield({\n`;
-		state.pushIndent();
-		result += state.indent + `value = ${exp ? compileExpression(state, exp) : "nil"};\n`;
-		result += state.indent + `done = false;\n`;
-		state.popIndent();
-		result += state.indent + `})`;
-		return result;
 	} else {
 		/* istanbul ignore next */
 		throw new CompilerError(`Bad expression! (${node.getKindName()})`, node, CompilerErrorType.BadExpression);

--- a/src/compiler/yield.ts
+++ b/src/compiler/yield.ts
@@ -4,16 +4,15 @@ import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 
 export function compileYieldExpression(state: CompilerState, node: ts.YieldExpression) {
-	if (!ts.TypeGuards.isExpressionStatement(node.getParent())) {
-		throw new CompilerError(
-			"Yield expressions must be expression statements!",
-			node,
-			CompilerErrorType.YieldNotInExpressionStatement,
-		);
-	}
-
 	const exp = node.getExpression();
 	if (node.isGenerator()) {
+		if (!ts.TypeGuards.isExpressionStatement(node.getParent())) {
+			throw new CompilerError(
+				"Yield expressions must be expression statements!",
+				node,
+				CompilerErrorType.YieldNotInExpressionStatement,
+			);
+		}
 		state.pushIdStack();
 		const id = state.getNewId();
 		let result = `for ${id} in ${compileExpression(state, exp!)}.next do\n`;

--- a/src/compiler/yield.ts
+++ b/src/compiler/yield.ts
@@ -1,0 +1,27 @@
+import * as ts from "ts-morph";
+import { compileExpression } from ".";
+import { CompilerState } from "../CompilerState";
+
+export function compileYieldExpression(state: CompilerState, node: ts.YieldExpression) {
+	const exp = node.getExpression();
+	if (node.isGenerator()) {
+		state.pushIdStack();
+		const id = state.getNewId();
+		let result = `for ${id} in ${compileExpression(state, exp!)}.next do\n`;
+		state.pushIndent();
+		result += state.indent + `if ${id}.done then break end;\n`;
+		result += state.indent + `coroutine.yield(${id});\n`;
+		state.popIndent();
+		result += state.indent + `end`;
+		state.popIdStack();
+		return result;
+	} else {
+		let result = `coroutine.yield({\n`;
+		state.pushIndent();
+		result += state.indent + `value = ${exp ? compileExpression(state, exp) : "nil"};\n`;
+		result += state.indent + `done = false;\n`;
+		state.popIndent();
+		result += state.indent + `})`;
+		return result;
+	}
+}

--- a/src/compiler/yield.ts
+++ b/src/compiler/yield.ts
@@ -1,8 +1,17 @@
 import * as ts from "ts-morph";
 import { compileExpression } from ".";
 import { CompilerState } from "../CompilerState";
+import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 
 export function compileYieldExpression(state: CompilerState, node: ts.YieldExpression) {
+	if (!ts.TypeGuards.isExpressionStatement(node.getParent())) {
+		throw new CompilerError(
+			"Yield expressions must be expression statements!",
+			node,
+			CompilerErrorType.YieldNotInExpressionStatement,
+		);
+	}
+
 	const exp = node.getExpression();
 	if (node.isGenerator()) {
 		state.pushIdStack();

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -64,6 +64,7 @@ export enum CompilerErrorType {
 	BadDestructuringType,
 	NullableIndexOnMapOrSet,
 	BadSpreadType,
+	YieldNotInExpressionStatement,
 }
 
 export class CompilerError extends Error {


### PR DESCRIPTION
This PR allows the following code to work:
```TS
function *getDescendants(instance: Instance): IterableIterator<Instance> {
	for (const child of instance.GetChildren()) {
		yield child;
		yield* getDescendants(child);
	}
}

for (const descendant of getDescendants(game)) {
	print(descendant.GetFullName());
}
```

However, I have some concerns about things like `const x = yield 1;`.

TS seems to indicate that `x` is of type `any` here.
Should we error if it's used like this? Is there a valid workflow that involves this?