### PR TITLE
Ban underscore identifier and convert arrays to sets

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -14,10 +14,10 @@ const LIB_PATH = path.resolve(__dirname, "..", "lib");
 const SYNC_FILE_NAMES = ["rojo.json", "rofresh.json"];
 const MODULE_PREFIX = "rbx-";
 
-const IGNORED_DIAGNOSTIC_CODES = [
+const IGNORED_DIAGNOSTIC_CODES = new Set([
 	2688, // "Cannot find type definition file for '{0}'."
 	6054, // "File '{0}' has unsupported extension. The only supported extensions are {1}."
-];
+]);
 
 interface RojoJson {
 	partitions: {
@@ -424,7 +424,7 @@ export class Project {
 			const diagnostics = file
 				.getPreEmitDiagnostics()
 				.filter(diagnostic => diagnostic.getCategory() === ts.DiagnosticCategory.Error)
-				.filter(diagnostic => IGNORED_DIAGNOSTIC_CODES.indexOf(diagnostic.getCode()) === -1);
+				.filter(diagnostic => IGNORED_DIAGNOSTIC_CODES.has(diagnostic.getCode()));
 			for (const diagnostic of diagnostics) {
 				const diagnosticFile = diagnostic.getSourceFile();
 				const line = diagnostic.getLineNumber();

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -28,7 +28,8 @@ export function getParameterData(
 			if (param.getName() === "this") {
 				continue;
 			}
-			name = compileExpression(state, child);
+
+			name = compileIdentifier(state, child, true);
 		} else {
 			name = state.getNewId();
 		}

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -18,7 +18,7 @@ import {
 	typeConstraint,
 } from "../typeUtilities";
 
-const STRING_MACRO_METHODS = [
+const STRING_MACRO_METHODS = new Set([
 	"byte",
 	"find",
 	"format",
@@ -31,7 +31,7 @@ const STRING_MACRO_METHODS = [
 	"reverse",
 	"sub",
 	"upper",
-];
+]);
 
 function shouldWrapExpression(subExp: ts.Node, strict: boolean) {
 	return (
@@ -354,7 +354,7 @@ const OBJECT_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>().se
 	),
 );
 
-const RBX_MATH_CLASSES = ["CFrame", "UDim", "UDim2", "Vector2", "Vector2int16", "Vector3", "Vector3int16"];
+const RBX_MATH_CLASSES = new Set(["CFrame", "UDim", "UDim2", "Vector2", "Vector2int16", "Vector3", "Vector3int16"]);
 
 const GLOBAL_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>().set("typeIs", (params, state, subExp) => {
 	const obj = compileCallArgument(state, params[0]);
@@ -484,7 +484,7 @@ export function getPropertyAccessExpressionType(
 	}
 
 	if (isStringMethodType(subExpType)) {
-		if (STRING_MACRO_METHODS.indexOf(property) !== -1) {
+		if (STRING_MACRO_METHODS.has(property)) {
 			return PropertyCallExpType.BuiltInStringMethod;
 		}
 		return PropertyCallExpType.String;
@@ -521,7 +521,7 @@ export function getPropertyAccessExpressionType(
 		}
 
 		// custom math
-		if (RBX_MATH_CLASSES.indexOf(subExpTypeName) !== -1) {
+		if (RBX_MATH_CLASSES.has(subExpTypeName)) {
 			switch (property) {
 				case "add":
 					return PropertyCallExpType.RbxMathAdd;

--- a/src/compiler/identifier.ts
+++ b/src/compiler/identifier.ts
@@ -14,7 +14,10 @@ export function compileIdentifier(state: CompilerState, node: ts.Identifier, isD
 		return replacement;
 	}
 
-	checkReserved(name, node);
+	if (!isDefinition || name !== "_") {
+		checkReserved(name, node, isDefinition);
+	}
+
 	if (BUILT_INS.has(name)) {
 		state.usesTSLibrary = true;
 		name = `TS.${name}`;

--- a/src/compiler/identifier.ts
+++ b/src/compiler/identifier.ts
@@ -2,7 +2,7 @@ import * as ts from "ts-morph";
 import { checkReserved } from ".";
 import { CompilerState } from "../CompilerState";
 
-export const BUILT_INS = ["Promise", "Symbol", "typeIs", "opcall"];
+export const BUILT_INS = new Set(["Promise", "Symbol", "typeIs", "opcall"]);
 
 export const replacements = new Map<string, string>([["undefined", "nil"], ["typeOf", "typeof"]]);
 
@@ -15,7 +15,7 @@ export function compileIdentifier(state: CompilerState, node: ts.Identifier, isD
 	}
 
 	checkReserved(name, node);
-	if (BUILT_INS.indexOf(name) !== -1) {
+	if (BUILT_INS.has(name)) {
 		state.usesTSLibrary = true;
 		name = `TS.${name}`;
 	}

--- a/src/compiler/roact.ts
+++ b/src/compiler/roact.ts
@@ -23,7 +23,7 @@ export const ROACT_DERIVED_CLASSES_ERROR = suggest(
 );
 const CONSTRUCTOR_METHOD_NAME = "init";
 const INHERITANCE_METHOD_NAME = "extend";
-const RESERVED_METHOD_NAMES = [
+const RESERVED_METHOD_NAMES = new Set([
 	CONSTRUCTOR_METHOD_NAME,
 	"setState",
 	"_update",
@@ -32,7 +32,7 @@ const RESERVED_METHOD_NAMES = [
 	"_mount",
 	"_unmount",
 	INHERITANCE_METHOD_NAME,
-];
+]);
 
 /**
  * A list of lowercase names that map to Roblox elements for JSX
@@ -70,18 +70,18 @@ const INTRINSIC_MAPPINGS: { [name: string]: string } = {
 };
 
 function isRoactElementType(type: ts.Type) {
-	const allowed = [ROACT_ELEMENT_TYPE, `${ROACT_ELEMENT_TYPE}[]`];
+	const allowed = new Set([ROACT_ELEMENT_TYPE, `${ROACT_ELEMENT_TYPE}[]`]);
 	const types = type.getUnionTypes();
 
 	if (types.length > 0) {
 		for (const unionType of types) {
 			const unionTypeName = unionType.getText();
-			if (allowed.indexOf(unionTypeName) === -1 && unionTypeName !== "undefined") {
+			if (allowed.has(unionTypeName) && unionTypeName !== "undefined") {
 				return false;
 			}
 		}
 	} else {
-		return allowed.indexOf(type.getText()) !== -1;
+		return allowed.has(type.getText());
 	}
 
 	return true;
@@ -117,7 +117,7 @@ export function inheritsFromRoact(type: ts.Type): boolean {
 }
 
 function checkRoactReserved(className: string, name: string, node: ts.Node<ts.ts.Node>) {
-	if (RESERVED_METHOD_NAMES.indexOf(name) !== -1) {
+	if (RESERVED_METHOD_NAMES.has(name)) {
 		let userError = `Member ${bold(name)} in component ${bold(className)} is a reserved Roact method name.`;
 
 		if (name === CONSTRUCTOR_METHOD_NAME) {

--- a/src/compiler/security.ts
+++ b/src/compiler/security.ts
@@ -5,7 +5,7 @@ import { HasParameters } from "../types";
 import { isAnyType } from "../typeUtilities";
 import { bold, ScriptContext, yellow } from "../utility";
 
-const LUA_RESERVED_KEYWORDS = [
+const LUA_RESERVED_KEYWORDS = new Set([
 	"and",
 	"break",
 	"do",
@@ -27,9 +27,9 @@ const LUA_RESERVED_KEYWORDS = [
 	"true",
 	"until",
 	"while",
-];
+]);
 
-const LUA_RESERVED_METAMETHODS = [
+const LUA_RESERVED_METAMETHODS = new Set([
 	"__index",
 	"__newindex",
 	"__add",
@@ -48,9 +48,9 @@ const LUA_RESERVED_METAMETHODS = [
 	"__len",
 	"__metatable",
 	"__mode",
-];
+]);
 
-const LUA_RESERVED_NAMESPACES = [
+const LUA_RESERVED_NAMESPACES = new Set([
 	"ipairs",
 	"os",
 	"type",
@@ -109,10 +109,10 @@ const LUA_RESERVED_NAMESPACES = [
 	"Vector2",
 	"Vector3",
 	"Ray",
-];
+]);
 
 export function checkReserved(name: string, node: ts.Node, checkNamespace: boolean = false) {
-	if (LUA_RESERVED_KEYWORDS.indexOf(name) !== -1) {
+	if (LUA_RESERVED_KEYWORDS.has(name)) {
 		throw new CompilerError(
 			`Cannot use '${name}' as identifier (reserved Lua keyword)`,
 			node,
@@ -124,13 +124,13 @@ export function checkReserved(name: string, node: ts.Node, checkNamespace: boole
 			node,
 			CompilerErrorType.InvalidIdentifier,
 		);
-	} else if (name === "_exports" || name === "undefined" || name.match(/^_[0-9]+$/)) {
+	} else if (name === "_exports" || name === "undefined" || name.match(/^_[0-9]*$/)) {
 		throw new CompilerError(
 			`Cannot use '${name}' as identifier (reserved for Roblox-ts)`,
 			node,
 			CompilerErrorType.RobloxTSReservedIdentifier,
 		);
-	} else if (checkNamespace && LUA_RESERVED_NAMESPACES.indexOf(name) !== -1) {
+	} else if (checkNamespace && LUA_RESERVED_NAMESPACES.has(name)) {
 		throw new CompilerError(
 			`Cannot use '${name}' as identifier (reserved Lua namespace)`,
 			node,
@@ -141,7 +141,7 @@ export function checkReserved(name: string, node: ts.Node, checkNamespace: boole
 
 export function checkMethodReserved(name: string, node: ts.Node) {
 	checkReserved(name, node);
-	if (LUA_RESERVED_METAMETHODS.indexOf(name) !== -1) {
+	if (LUA_RESERVED_METAMETHODS.has(name)) {
 		throw new CompilerError(
 			`Cannot use '${name}' as a method name (reserved Lua metamethod)`,
 			node,

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -1,7 +1,7 @@
 import * as ts from "ts-morph";
 import { CompilerDirective, getCompilerDirective } from "./compiler";
 
-export const RBX_SERVICES: Array<string> = [
+export const RBX_SERVICES = new Set([
 	"AssetService",
 	"BadgeService",
 	"Chat",
@@ -44,10 +44,10 @@ export const RBX_SERVICES: Array<string> = [
 	"UserInputService",
 	"VRService",
 	"Workspace",
-];
+]);
 
 export function isRbxService(name: string) {
-	return RBX_SERVICES.indexOf(name) !== -1;
+	return RBX_SERVICES.has(name);
 }
 
 export function isTypeStatement(node: ts.Node) {


### PR DESCRIPTION
- Bans the use of the underscore being accessed as a variable, although it can be used as a dummy variable or in a function parameter.
- Converts Arrays/indexOf to Sets/has