### PR TITLE
Remove immediately invoked function expressions

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -901,7 +901,7 @@ TS.set_toString = toString
 function TS.iterableCache(iter)
 	local results = {}
 	local count = 0
-	for _0 in iter.next do
+	for _0 in iter do
 		if _0.done then break end
 		count = count + 1
 		results[count] = _0.value

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -901,10 +901,20 @@ TS.set_toString = toString
 function TS.iterableCache(iter)
 	local results = {}
 	local count = 0
-	for _0 in iter do
+	for _0 in iter.next do
 		if _0.done then break end
 		count = count + 1
 		results[count] = _0.value
+	end
+	return results
+end
+
+function TS.iterableFunctionCache(iter)
+	local results = {}
+	local count = 0
+	for _0 in iter do
+		count = count + 1
+		results[count] = _0
 	end
 	return results
 end

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -3,10 +3,6 @@ local Promise = require(script.Parent.Promise)
 local HttpService = game:GetService("HttpService")
 
 -- constants
-local TYPE_STRING = "string"
-local TYPE_TABLE = "table"
-local TYPE_FUNCTION = "function"
-
 local table_sort = table.sort
 local math_ceil = math.ceil
 local math_floor = math.floor
@@ -152,12 +148,12 @@ end
 -- general utility functions
 function TS.instanceof(obj, class)
 	-- custom Class.instanceof() check
-	if typeof(class) == TYPE_TABLE and typeof(class.instanceof) == TYPE_FUNCTION then
+	if type(class) == "table" and type(class.instanceof) == "function" then
 		return class.instanceof(obj)
 	end
 
 	-- metatable check
-	if typeof(obj) == TYPE_TABLE then
+	if type(obj) == "table" then
 		obj = getmetatable(obj)
 		while obj ~= nil do
 			if obj == class then
@@ -205,7 +201,7 @@ function TS.await(promise)
 end
 
 function TS.add(a, b)
-	if typeof(a) == TYPE_STRING or typeof(b) == TYPE_STRING then
+	if type(a) == "string" or type(b) == "string" then
 		return a .. b
 	else
 		return a + b
@@ -294,7 +290,7 @@ end
 local function deepCopy(object)
 	local result = {}
 	for k, v in pairs(object) do
-		if typeof(v) == TYPE_TABLE then
+		if type(v) == "table" then
 			result[k] = deepCopy(v)
 		else
 			result[k] = v
@@ -308,7 +304,7 @@ local function deepEquals(a, b)
 	for k in pairs(a) do
 		local av = a[k]
 		local bv = b[k]
-		if typeof(av) == TYPE_TABLE and typeof(bv) == TYPE_TABLE then
+		if type(av) == "table" and type(bv) == "table" then
 			local result = deepEquals(av, bv)
 			if not result then
 				return false
@@ -355,10 +351,10 @@ function TS.Object_entries(object)
 end
 
 function TS.Object_assign(toObj, ...)
-	local args = { ... }
-	for i = 1, #args do
-		if type(args[i]) == "table" then
-			for key, value in pairs(args[i]) do
+	for i = 1, select("#", ...) do
+		local arg = select(i, ...)
+		if type(arg) == "table" then
+			for key, value in pairs(arg) do
 				toObj[key] = value
 			end
 		end
@@ -668,7 +664,12 @@ local table_concat = table.concat
 function TS.array_join(list, separator)
 	local result = {}
 	for i = 1, #list do
-		result[i] = tostring(list[i])
+		local item = list[i]
+		if item == nil then
+			result[i] = ""
+		else
+			result[i] = tostring(list[i])
+		end
 	end
 	return table_concat(result, separator or ", ")
 end
@@ -796,12 +797,6 @@ function TS.map_clear(map)
 	end
 end
 
-function TS.map_delete(map, key)
-	local deleted = map[key] ~= nil
-	map[key] = nil
-	return deleted
-end
-
 local function getNumKeys(map)
 	local result = 0
 	for _ in pairs(map) do
@@ -821,11 +816,6 @@ end
 
 TS.map_keys = TS.Object_keys
 
-function TS.map_set(map, key, value)
-	map[key] = value
-	return map
-end
-
 TS.map_values = TS.Object_values
 TS.map_toString = toString
 
@@ -839,18 +829,7 @@ function TS.set_new(value)
 	return result
 end
 
-function TS.set_add(set, value)
-	set[value] = true
-	return set
-end
-
 TS.set_clear = TS.map_clear
-
-function TS.set_delete(set, value)
-	local result = set[value] == true
-	set[value] = nil
-	return result
-end
 
 function TS.set_forEach(set, callback)
 	for key in pairs(set) do

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -18,7 +18,7 @@ local Symbol do
 	setmetatable(Symbol, {
 		__call = function(_, description)
 			local self = setmetatable({}, Symbol)
-			self.description = description or ""
+			self.description = "Symbol(" .. (description or "") .. ")"
 			return self
 		end
 	})
@@ -30,13 +30,11 @@ local Symbol do
 		end
 	})
 
-	function Symbol:__tostring()
-		return "Symbol(" .. self.description .. ")"
+	function Symbol:toString()
+		return self.description
 	end
 
-	function Symbol:toString()
-		return tostring(self)
-	end
+	Symbol.__tostring = Symbol.toString
 
 	-- Symbol.for
 	function Symbol.getFor(key)
@@ -53,6 +51,7 @@ local Symbol do
 end
 
 TS.Symbol = Symbol
+TS.Symbol_iterator = Symbol("Symbol.iterator")
 
 -- module resolution
 local globalModules = script.Parent.Parent:FindFirstChild("Modules")
@@ -651,7 +650,7 @@ function TS.array_concat(...)
 	return result
 end
 
-function TS.array_push(list, list2)
+function TS.array_push_apply(list, list2)
 	local len = #list
 	local len2 = #list2
 	for i = 1, len2 do

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -651,12 +651,13 @@ function TS.array_concat(...)
 	return result
 end
 
-function TS.array_push(list, ...)
-	local args = { ... }
-	for i = 1, #args do
-		list[#list + 1] = args[i]
+function TS.array_push(list, list2)
+	local len = #list
+	local len2 = #list2
+	for i = 1, len2 do
+		list[len + i] = list2[i]
 	end
-	return #list
+	return len + len2
 end
 
 local table_concat = table.concat
@@ -946,9 +947,7 @@ end
 -- try catch utilities
 
 local function pack(...)
-	local result = { ... }
-	result.size = select("#", ...)
-	return result
+	return { size = select("#", ...), ... }
 end
 
 local throwStack = {}

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -671,7 +671,7 @@ function TS.array_join(list, separator)
 			result[i] = tostring(list[i])
 		end
 	end
-	return table_concat(result, separator or ", ")
+	return table_concat(result, separator or ",")
 end
 
 function TS.array_find(list, callback)

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -7,7 +7,7 @@ interface Partition {
 	target: string;
 }
 
-export type PrecedingStatementContext = Array<string> & { pushed: boolean };
+export type PrecedingStatementContext = Array<string> & { isPushed: boolean };
 
 export class CompilerState {
 	constructor(public readonly syncInfo: Array<Partition>, public readonly modulesDir?: ts.Directory) {}
@@ -24,7 +24,7 @@ export class CompilerState {
 			const kind = node.getKindName();
 
 			throw new CompilerError(
-				`Roblox-TS accidentally does not support using a ${kind} which requires preceding statements in a ${node
+				`roblox-ts accidentally does not support using a ${kind} which requires preceding statements in a ${node
 					.getAncestors()
 					.find(ancestor => ts.TypeGuards.isStatement(ancestor))!
 					.getKindName()}.` +
@@ -38,7 +38,7 @@ export class CompilerState {
 	}
 
 	public setCurrentContextAsPushed(node: ts.Node) {
-		this.getCurrentPrecedingStatementContext(node).pushed = true;
+		this.getCurrentPrecedingStatementContext(node).isPushed = true;
 	}
 	public currentPrecedingStatementContextHasStatements(node: ts.Node) {
 		return this.getCurrentPrecedingStatementContext(node).length > 0;
@@ -46,7 +46,7 @@ export class CompilerState {
 
 	public enterPrecedingStatementContext() {
 		const newContext = new Array<string>() as PrecedingStatementContext;
-		newContext.pushed = false;
+		newContext.isPushed = false;
 		// console.log("context:", this.precedingStatementContexts.length + 1, this.precedingStatementContexts);
 		return this.precedingStatementContexts.push(newContext as PrecedingStatementContext);
 	}
@@ -61,7 +61,7 @@ export class CompilerState {
 	}
 
 	public pushPrecedingStatements(node: ts.Node, ...statements: Array<string>) {
-		this.getCurrentPrecedingStatementContext(node).pushed = false;
+		this.getCurrentPrecedingStatementContext(node).isPushed = false;
 		return this.getCurrentPrecedingStatementContext(node).push(...statements);
 	}
 

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -26,7 +26,7 @@ export class CompilerState {
 			throw new CompilerError(
 				`roblox-ts accidentally does not support using a ${kind} which requires preceding statements in a ${node
 					.getAncestors()
-					.find(ancestor => ts.TypeGuards.isStatement(ancestor))!
+					.find(ancestor => ts.TypeGuards.isStatement(ancestor) || ts.TypeGuards.isStatementedNode(ancestor))!
 					.getKindName()}.` +
 					" Please submit an issue report to https://github.com/roblox-ts/roblox-ts/issues",
 				node,
@@ -71,6 +71,8 @@ export class CompilerState {
 			node,
 			this.indent + `local ${newIds.join(", ")}${statement ? ` = ${statement}` : ""};\n`,
 		);
+
+		this.getCurrentPrecedingStatementContext(node).isPushed = true;
 		return newIds;
 	}
 

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -37,6 +37,20 @@ export class CompilerState {
 		return currentContext;
 	}
 
+	public isTopPrecedingStatementPushed() {
+		for (let i = this.precedingStatementContexts.length - 1; 0 <= i; i--) {
+			const context = this.precedingStatementContexts[i];
+
+			if (context.isPushed) {
+				return true;
+			} else if (context.length > 0) {
+				console.log(context.length, context);
+				break;
+			}
+		}
+		return false;
+	}
+
 	public enterPrecedingStatementContext() {
 		const newContext = new Array<string>() as PrecedingStatementContext;
 		newContext.isPushed = false;

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -11,6 +11,7 @@ export type PrecedingStatementContext = Array<string> & { isPushed: boolean };
 
 export class CompilerState {
 	constructor(public readonly syncInfo: Array<Partition>, public readonly modulesDir?: ts.Directory) {}
+	public declarationContext = new Map<ts.Node, string>();
 
 	public currentConditionalContext: string = "";
 	private precedingStatementContexts = new Array<PrecedingStatementContext>();
@@ -44,7 +45,7 @@ export class CompilerState {
 			if (context.isPushed) {
 				return true;
 			} else if (context.length > 0) {
-				console.log(context.length, context);
+				// console.log(context.length, context);
 				break;
 			}
 		}

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -15,7 +15,7 @@ export class CompilerState {
 	public currentConditionalContext: string = "";
 	private precedingStatementContexts = new Array<PrecedingStatementContext>();
 
-	private getCurrentPrecedingStatementContext(node: ts.Node) {
+	public getCurrentPrecedingStatementContext(node: ts.Node) {
 		const currentContext = this.precedingStatementContexts[this.precedingStatementContexts.length - 1] as
 			| PrecedingStatementContext
 			| undefined;
@@ -37,9 +37,6 @@ export class CompilerState {
 		return currentContext;
 	}
 
-	public setCurrentContextAsPushed(node: ts.Node) {
-		this.getCurrentPrecedingStatementContext(node).isPushed = true;
-	}
 	public currentPrecedingStatementContextHasStatements(node: ts.Node) {
 		return this.getCurrentPrecedingStatementContext(node).length > 0;
 	}

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -37,10 +37,6 @@ export class CompilerState {
 		return currentContext;
 	}
 
-	public currentPrecedingStatementContextHasStatements(node: ts.Node) {
-		return this.getCurrentPrecedingStatementContext(node).length > 0;
-	}
-
 	public enterPrecedingStatementContext() {
 		const newContext = new Array<string>() as PrecedingStatementContext;
 		newContext.isPushed = false;

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -53,7 +53,6 @@ export class CompilerState {
 			if (context.isPushed) {
 				return true;
 			} else if (context.length > 0) {
-				// console.log(context.length, context);
 				break;
 			}
 		}
@@ -63,12 +62,10 @@ export class CompilerState {
 	public enterPrecedingStatementContext() {
 		const newContext = new Array<string>() as PrecedingStatementContext;
 		newContext.isPushed = false;
-		// console.log("context:", this.precedingStatementContexts.length + 1, this.precedingStatementContexts);
 		return this.precedingStatementContexts.push(newContext as PrecedingStatementContext);
 	}
 
 	public exitPrecedingStatementContext() {
-		// console.log("context:", this.precedingStatementContexts.length - 1, this.precedingStatementContexts);
 		return this.precedingStatementContexts.pop()!;
 	}
 

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -11,7 +11,15 @@ export type PrecedingStatementContext = Array<string> & { isPushed: boolean };
 
 export class CompilerState {
 	constructor(public readonly syncInfo: Array<Partition>, public readonly modulesDir?: ts.Directory) {}
-	public declarationContext = new Map<ts.Node, string>();
+	// string1 is the declaration string, string2 is the string to set it to
+	public declarationContext = new Map<
+		ts.Node,
+		{
+			isIdentifier: boolean;
+			needsLocalizing?: boolean;
+			set: string;
+		}
+	>();
 
 	public currentConditionalContext: string = "";
 	private precedingStatementContexts = new Array<PrecedingStatementContext>();

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -67,7 +67,10 @@ export class CompilerState {
 		for (let i = 0; i < numIds; i++) {
 			newIds[i] = this.getNewId();
 		}
-		this.pushPrecedingStatements(node, this.indent + `local ${newIds.join(", ")} = ${statement};\n`);
+		this.pushPrecedingStatements(
+			node,
+			this.indent + `local ${newIds.join(", ")}${statement ? ` = ${statement}` : ""};\n`,
+		);
 		return newIds;
 	}
 
@@ -102,8 +105,7 @@ export class CompilerState {
 			}
 		}
 
-		const newId = this.getNewId();
-		this.pushPrecedingStatements(node, this.indent + `local ${newId} = ${transpiledSource};\n`);
+		const [newId] = this.pushPrecedingStatementToNewIds(node, transpiledSource, 1);
 		return newId;
 	}
 

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -17,7 +17,6 @@ interface DeclarationContext {
 
 export class CompilerState {
 	constructor(public readonly syncInfo: Array<Partition>, public readonly modulesDir?: ts.Directory) {}
-	// string1 is the declaration string, string2 is the string to set it to
 	public declarationContext = new Map<ts.Node, DeclarationContext>();
 
 	public pushToDeclarationOrNewId(

--- a/src/compiler/array.ts
+++ b/src/compiler/array.ts
@@ -1,7 +1,8 @@
 import * as ts from "ts-morph";
-import { compileExpression, compileSpreadableList, compileSpreadExpression, shouldCompileAsSpreadableList } from ".";
+import { compileSpreadableList, compileSpreadExpression, shouldCompileAsSpreadableList } from ".";
 import { CompilerState } from "../CompilerState";
 import { isArrayType } from "../typeUtilities";
+import { compileList } from "./call";
 
 export function compileArrayLiteralExpression(state: CompilerState, node: ts.ArrayLiteralExpression) {
 	const elements = node.getElements();
@@ -27,7 +28,6 @@ export function compileArrayLiteralExpression(state: CompilerState, node: ts.Arr
 	if (shouldCompileAsSpreadableList(elements)) {
 		return compileSpreadableList(state, elements);
 	} else {
-		const elementsStr = elements.map(e => compileExpression(state, e)).join(", ");
-		return `{ ${elementsStr} }`;
+		return `{ ${compileList(state, elements).join(", ")} }`;
 	}
 }

--- a/src/compiler/array.ts
+++ b/src/compiler/array.ts
@@ -1,5 +1,5 @@
 import * as ts from "ts-morph";
-import { compileSpreadableList, compileSpreadExpression, shouldCompileAsSpreadableList } from ".";
+import { compileSpreadableListAndJoin, compileSpreadExpression, shouldCompileAsSpreadableList } from ".";
 import { CompilerState } from "../CompilerState";
 import { isArrayType } from "../typeUtilities";
 import { compileList } from "./call";
@@ -26,7 +26,7 @@ export function compileArrayLiteralExpression(state: CompilerState, node: ts.Arr
 	}
 
 	if (shouldCompileAsSpreadableList(elements)) {
-		return compileSpreadableList(state, elements);
+		return compileSpreadableListAndJoin(state, elements);
 	} else {
 		return `{ ${compileList(state, elements).join(", ")} }`;
 	}

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -176,7 +176,7 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 				names,
 				values,
 				false,
-				declaration => (result += "local " + declaration + ";\n"),
+				declaration => (result += declaration + ";\n"),
 				false,
 				false,
 			);

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -74,7 +74,7 @@ function compileBinaryLiteral(
 	const postStatements = new Array<string>();
 
 	let rootId: string;
-	if (ts.TypeGuards.isIdentifier(rhs)) {
+	if (ts.TypeGuards.isIdentifier(rhs) || ts.TypeGuards.isThisExpression(rhs)) {
 		rootId = compileExpression(state, rhs);
 	} else {
 		rootId = state.getNewId();

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -164,7 +164,6 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 						);
 						return rootId;
 					} else {
-						console.log(element.getKindName(), element.getText());
 						return compileExpression(state, element);
 					}
 				})

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -1,11 +1,11 @@
 import * as ts from "ts-morph";
 import { checkNonAny, compileCallExpression, compileExpression, concatNamesAndValues, getBindingData } from ".";
-import { CompilerState } from "../CompilerState";
+import { CompilerState, PrecedingStatementContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { isNumberType, isStringType, isTupleReturnTypeCall, shouldPushToPrecedingStatement } from "../typeUtilities";
-import { getNonNullExpression } from "../utility";
+import { getNonNullExpression, getNonNullUnParenthesizedExpression } from "../utility";
 import { getAccessorForBindingPatternType } from "./binding";
-import { getWritableOperandName, isIdentifierDefinedInExportLet } from "./indexed";
+import { isIdentifierDefinedInExportLet } from "./indexed";
 
 function getLuaBarExpression(state: CompilerState, node: ts.BinaryExpression, lhsStr: string, rhsStr: string) {
 	state.usesTSLibrary = true;
@@ -92,11 +92,7 @@ function compileBinaryLiteral(
 		getAccessorForBindingPatternType(rhs),
 	);
 
-	let parent = node.getParentOrThrow();
-
-	while (ts.TypeGuards.isParenthesizedExpression(parent)) {
-		parent = parent.getParent();
-	}
+	const parent = getNonNullUnParenthesizedExpression(node.getParentOrThrow());
 
 	if (ts.TypeGuards.isExpressionStatement(parent) || ts.TypeGuards.isForStatement(parent)) {
 		let result = "";
@@ -137,19 +133,64 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 			.every(v => ts.TypeGuards.isIdentifier(v.getChildAtIndex(0)));
 
 		if (isFlatBinding && rhs && ts.TypeGuards.isCallExpression(rhs) && isTupleReturnTypeCall(rhs)) {
-			const names = new Array<string>();
-			const values = new Array<string>();
-			let result = "";
+			// FIXME: Still broken for nested destructuring of non-arrays.
+			// BUT this change makes it LESS broken than before. (try nested destructuring a string here)
+			// e.g. [[[[[[[a]]]]]]] = func() where func() returns a LuaTuple<[string]>
 
-			for (const element of lhs.getElements()) {
-				if (ts.TypeGuards.isIdentifier(element)) {
-					names.push(compileExpression(state, element));
-				} else if (ts.TypeGuards.isOmittedExpression(element)) {
-					names.push("_");
-				}
+			let result = "";
+			const preStatements = new Array<string>();
+			const postStatements = new Array<string>();
+			const names = lhs
+				.getElements()
+				.map(element => {
+					if (ts.TypeGuards.isOmittedExpression(element)) {
+						return "_";
+					} else if (
+						ts.TypeGuards.isArrayLiteralExpression(element) ||
+						ts.TypeGuards.isObjectLiteralExpression(element)
+					) {
+						let rootId: string;
+						rootId = state.getNewId();
+
+						getBindingData(
+							state,
+							[],
+							[],
+							preStatements,
+							postStatements,
+							element,
+							rootId,
+							getAccessorForBindingPatternType(rhs),
+						);
+						return rootId;
+					} else {
+						console.log(element.getKindName(), element.getText());
+						return compileExpression(state, element);
+					}
+				})
+				.filter(s => s !== "");
+
+			const values = [compileCallExpression(state, rhs, true)];
+			concatNamesAndValues(
+				state,
+				names,
+				values,
+				false,
+				declaration => (result += "local " + declaration + ";\n"),
+				false,
+				false,
+			);
+			preStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
+			postStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
+			if (ts.TypeGuards.isExpressionStatement(getNonNullUnParenthesizedExpression(node.getParent()))) {
+				return result.replace(/;\n$/, ""); // terrible hack
+			} else {
+				throw new CompilerError(
+					"Cannot use a LuaTuple destructuring expression outside an ExpressionStatement!",
+					node,
+					CompilerErrorType.BadLuaTupleStatement,
+				);
 			}
-			values.push(compileCallExpression(state, rhs, true));
-			concatNamesAndValues(state, names, values, false, declaration => (result += declaration), false, false);
 		} else {
 			return compileBinaryLiteral(state, node, lhs, rhs);
 		}
@@ -158,32 +199,54 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 	}
 
 	if (isSetToken(opKind)) {
-		// const lhsStr = compileExpression(state, lhs);
-		// const isLhsIdentifier = !ts.TypeGuards.isIdentifier(lhs) || !isIdentifierDefinedInExportLet(lhs);
-		const isRhsIdentifier = !ts.TypeGuards.isIdentifier(rhs) || !isIdentifierDefinedInExportLet(rhs);
-
-		const lhsData = getWritableOperandName(state, lhs);
-		let isLhsIdentifier: boolean;
-		({ expStr: lhsStr, isIdentifier: isLhsIdentifier } = lhsData);
+		lhsStr = compileExpression(state, lhs);
+		const isLhsIdentifier = ts.TypeGuards.isIdentifier(lhs) && !isIdentifierDefinedInExportLet(lhs);
 
 		state.enterPrecedingStatementContext();
 		let rhsPushedStr: string = "";
+		let rhsStrContext: PrecedingStatementContext;
+		let hasOpenContext = false;
+
+		const parentKind = node.getParentOrThrow().getKind();
+		const isStatement =
+			parentKind === ts.SyntaxKind.ExpressionStatement || parentKind === ts.SyntaxKind.ForStatement;
 
 		if (isEqualsOperation) {
 			state.declarationContext.set(rhs, { isIdentifier: isLhsIdentifier, set: lhsStr });
+			hasOpenContext = true;
+
+			state.enterPrecedingStatementContext();
 			rhsStr = compileExpression(state, rhs);
-			rhsPushedStr = state.getCurrentPrecedingStatementContext(node).isPushed ? rhsStr : "";
+			const rhsSubContext = state.exitPrecedingStatementContext();
+			const { isPushed } = rhsSubContext;
+
+			if (isPushed) {
+				rhsPushedStr = rhsStr;
+			}
+
+			if (state.declarationContext.delete(rhs)) {
+				hasOpenContext = false;
+			} else if (
+				!isPushed &&
+				!isStatement &&
+				(!ts.TypeGuards.isIdentifier(lhs) || isIdentifierDefinedInExportLet(lhs))
+			) {
+				rhsPushedStr = rhsStr = state.pushPrecedingStatementToReuseableId(rhs, rhsStr);
+			}
+
+			state.pushPrecedingStatements(rhs, ...rhsSubContext);
 		} else {
 			rhsStr = compileExpression(state, rhs);
 		}
-		const rhsStrContext = state.exitPrecedingStatementContext();
+		rhsStrContext = state.exitPrecedingStatementContext();
+
 		let previouslhs: string;
-		console.log(rhsStrContext);
 
 		if (rhsStrContext.length > 0) {
 			previouslhs = isEqualsOperation
 				? ""
 				: state.pushPrecedingStatementToReuseableId(lhs, lhsStr, rhsStrContext);
+
 			state.pushPrecedingStatements(rhs, ...rhsStrContext);
 		} else {
 			previouslhs = lhsStr;
@@ -224,25 +287,22 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 			);
 		}
 
-		const parentKind = node.getParentOrThrow().getKind();
-		const unUsedStatement = !isEqualsOperation || state.declarationContext.delete(rhs);
-		if (parentKind === ts.SyntaxKind.ExpressionStatement || parentKind === ts.SyntaxKind.ForStatement) {
+		const unUsedStatement = !isEqualsOperation || !hasOpenContext;
+		if (isStatement) {
 			return unUsedStatement ? `${lhsStr} = ${rhsStr}` : "";
 		} else {
-			console.log(isLhsIdentifier, lhsStr, rhsStr, isRhsIdentifier, rhsPushedStr);
 			if (!isLhsIdentifier) {
 				const newId = rhsPushedStr || state.pushToDeclarationOrNewId(node.getParent(), rhsStr);
-
 				if (unUsedStatement) {
 					state.pushPrecedingStatements(node, state.indent + `${lhsStr} = ${newId};\n`);
 				}
-
 				state.getCurrentPrecedingStatementContext(node).isPushed = true;
 				return newId;
 			} else {
 				if (unUsedStatement) {
 					state.pushPrecedingStatements(node, state.indent + `${lhsStr} = ${rhsStr};\n`);
 				}
+
 				return lhsStr;
 			}
 		}

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -194,7 +194,6 @@ export function getBindingData(
 ) {
 	const strKeys = bindingPattern.getKind() === ts.SyntaxKind.ObjectBindingPattern;
 	let childIndex = 1;
-	// console.log(bindingPattern.getKindName(), bindingPattern.getText());
 
 	for (const item of bindingPattern.getFirstChildByKindOrThrow(ts.SyntaxKind.SyntaxList).getChildren()) {
 		/* istanbul ignore else */

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -194,7 +194,7 @@ export function getBindingData(
 ) {
 	const strKeys = bindingPattern.getKind() === ts.SyntaxKind.ObjectBindingPattern;
 	let childIndex = 1;
-	console.log(bindingPattern.getKindName(), bindingPattern.getText());
+	// console.log(bindingPattern.getKindName(), bindingPattern.getText());
 
 	for (const item of bindingPattern.getFirstChildByKindOrThrow(ts.SyntaxKind.SyntaxList).getChildren()) {
 		/* istanbul ignore else */

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -178,6 +178,7 @@ function iterAccessor(state: CompilerState, t: string, key: number) {
 }
 
 // FIXME: Currently broken is destructuring from TS.Symbol.Iterator more than a single value
+// (same for gmatch/IterableFunctions)
 // We are going to want a system which is aware of which values have already been destructured/used,
 // because we need to reuse them. With the other Accessors we could get away with just recomputing the
 // `next(t, next(t, next(t)))` etc but here we can't because these are stateful
@@ -194,6 +195,7 @@ function iterAccessor(state: CompilerState, t: string, key: number) {
 
 	const [a, b, c] = foo;
 */
+
 function objectIterAccessor(state: CompilerState, t: string, key: number, preStatements: Array<string>) {
 	state.usesTSLibrary = true;
 	const newId = state.getNewId();

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -104,7 +104,6 @@ function objectAccessor(
 	getAccessor: (state: CompilerState, t: string, key: number) => string,
 	nameNode: ts.Node = node,
 ) {
-	console.log(node.getKindName());
 	let name: string;
 
 	if (ts.TypeGuards.isIdentifier(nameNode)) {
@@ -362,7 +361,6 @@ export function getBindingData(
 			const nameNode = item.getNameNode();
 			if (item.hasInitializer()) {
 				const initializer = item.getInitializer()!;
-
 				if (ts.TypeGuards.isIdentifier(initializer)) {
 					alias = compileExpression(state, initializer);
 					preStatements.push(`${alias} = ${objectAccessor(state, parentId, item, getAccessor, nameNode)};`);

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -359,7 +359,6 @@ export function getBindingData(
 			preStatements.push(`local ${childId} = ${getAccessor(state, parentId, childIndex)};`);
 			getBindingData(state, names, values, preStatements, postStatements, item, childId);
 		} else if (ts.TypeGuards.isShorthandPropertyAssignment(item)) {
-			console.log(item.getName(), parentId);
 			preStatements.push(`${item.getName()} = ${objectAccessor(state, parentId, item, getAccessor)};`);
 		} else if (ts.TypeGuards.isPropertyAssignment(item)) {
 			let alias: string;

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -188,7 +188,7 @@ function objectIterAccessor(state: CompilerState, t: string, key: number) {
 	state.usesTSLibrary = true;
 	return iterAccessor(
 		state,
-		state.pushPrecedingStatementToNewId(({} as unknown) as ts.Node, t + "[TS.Symbol.iterator]()"),
+		state.pushPrecedingStatementToNewId(({} as unknown) as ts.Node, t + `[TS.Symbol_iterator](${t})`),
 		key,
 	);
 }

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -215,7 +215,6 @@ function iterableFunctionAccessor(state: CompilerState, t: string, key: number, 
 
 export function getAccessorForBindingPatternType(bindingPattern: ts.Node) {
 	const bindingPatternType = bindingPattern.getType();
-	console.log(">", bindingPatternType.getText(), isIterableFunction(bindingPatternType));
 	if (isArrayType(bindingPatternType)) {
 		return arrayAccessor;
 	} else if (isStringType(bindingPatternType)) {

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -104,7 +104,7 @@ function iterAccessor(t: string, key: number) {
 	return `(` + `${t}.next() and `.repeat(key).slice(0, -5) + `.value)`;
 }
 
-function getAccessorForBindingPatternType(bindingPattern: ts.Node, isObject: boolean) {
+export function getAccessorForBindingPatternType(bindingPattern: ts.Node) {
 	const bindingPatternType = bindingPattern.getType();
 	if (isArrayType(bindingPatternType)) {
 		return arrayAccessor;
@@ -117,7 +117,7 @@ function getAccessorForBindingPatternType(bindingPattern: ts.Node, isObject: boo
 	} else if (isIterableIterator(bindingPatternType, bindingPattern)) {
 		return iterAccessor;
 	} else {
-		if (isObject) {
+		if (bindingPattern.getKind() === ts.SyntaxKind.ObjectBindingPattern) {
 			return null as never;
 		} else {
 			throw new CompilerError(
@@ -156,9 +156,9 @@ export function getBindingData(
 	postStatements: Array<string>,
 	bindingPattern: ts.Node,
 	parentId: string,
+	getAccessor = getAccessorForBindingPatternType(bindingPattern),
 ) {
 	const strKeys = bindingPattern.getKind() === ts.SyntaxKind.ObjectBindingPattern;
-	const getAccessor = getAccessorForBindingPatternType(bindingPattern, strKeys);
 
 	const listItems = bindingPattern.getFirstChildByKindOrThrow(ts.SyntaxKind.SyntaxList).getChildren();
 	let childIndex = 1;

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -103,8 +103,12 @@ function objectAccessor(
 	node: ts.Node,
 	getAccessor: (state: CompilerState, t: string, key: number) => string,
 	nameNode: ts.Node = node,
-) {
+): string {
 	let name: string;
+
+	if (ts.TypeGuards.isShorthandPropertyAssignment(nameNode)) {
+		nameNode = nameNode.getNameNode();
+	}
 
 	if (ts.TypeGuards.isIdentifier(nameNode)) {
 		name = compileExpression(state, nameNode);
@@ -123,7 +127,7 @@ function objectAccessor(
 	} else {
 		throw new CompilerError(
 			`Cannot index an object with type ${nameNode.getKindName()}.` +
-				`Please report this at https://github.com/roblox-ts/roblox-ts/issues`,
+				` Please report this at https://github.com/roblox-ts/roblox-ts/issues`,
 			nameNode,
 			CompilerErrorType.BadExpression,
 		);
@@ -355,6 +359,7 @@ export function getBindingData(
 			preStatements.push(`local ${childId} = ${getAccessor(state, parentId, childIndex)};`);
 			getBindingData(state, names, values, preStatements, postStatements, item, childId);
 		} else if (ts.TypeGuards.isShorthandPropertyAssignment(item)) {
+			console.log(item.getName(), parentId);
 			preStatements.push(`${item.getName()} = ${objectAccessor(state, parentId, item, getAccessor)};`);
 		} else if (ts.TypeGuards.isPropertyAssignment(item)) {
 			let alias: string;

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -18,7 +18,7 @@ import {
 	shouldPushToPrecedingStatement,
 	typeConstraint,
 } from "../typeUtilities";
-import { getNonNullExpression } from "../utility";
+import { getNonNullExpressionDownwards } from "../utility";
 import { getReadableExpressionName, isIdentifierDefinedInConst } from "./indexed";
 
 const STRING_MACRO_METHODS = [
@@ -577,7 +577,7 @@ export function getPropertyAccessExpressionType(
 }
 
 export function compilePropertyCallExpression(state: CompilerState, node: ts.CallExpression) {
-	const expression = getNonNullExpression(node.getExpression());
+	const expression = getNonNullExpressionDownwards(node.getExpression());
 	if (!ts.TypeGuards.isPropertyAccessExpression(expression)) {
 		throw new CompilerError(
 			"Expected PropertyAccessExpression",
@@ -588,7 +588,7 @@ export function compilePropertyCallExpression(state: CompilerState, node: ts.Cal
 
 	checkApiAccess(state, expression.getNameNode());
 
-	const subExp = getNonNullExpression(expression.getExpression());
+	const subExp = getNonNullExpressionDownwards(expression.getExpression());
 	const property = expression.getName();
 	const params = node.getArguments() as Array<ts.Expression>;
 

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -18,7 +18,7 @@ import {
 	shouldPushToPrecedingStatement,
 	typeConstraint,
 } from "../typeUtilities";
-import { getNonNullExpression, getNonNullUnParenthesizedExpression } from "../utility";
+import { getNonNullExpression } from "../utility";
 import { getReadableExpressionName, isIdentifierDefinedInConst } from "./indexed";
 
 const STRING_MACRO_METHODS = [
@@ -70,7 +70,7 @@ function getLeftHandSideParent(subExp: ts.Node, climb: number = 3) {
 	let exp = subExp;
 
 	for (let i = 0; i < climb; i++) {
-		exp = getNonNullUnParenthesizedExpression(exp.getParent());
+		exp = exp.getParent();
 	}
 
 	return exp;
@@ -145,7 +145,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				const node = getLeftHandSideParent(subExp, 2);
 				const declaration = state.declarationContext.get(node);
 				let id: string;
-				if (declaration && declaration.isIdentifier) {
+				if (declaration && declaration.set !== "return") {
 					id = declaration.set;
 					state.pushPrecedingStatements(
 						subExp,

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -527,6 +527,9 @@ function compilePropertyMethod(
 		}
 	}
 
+	if (className === "Object") {
+		params = params.slice(1);
+	}
 	state.usesTSLibrary = true;
 	return `TS.${className}_${property}(${compileCallArgumentsAndJoin(state, params)})`;
 }

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -146,7 +146,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				const len = state.pushPrecedingStatementToReuseableId(subExp, `#${accessPath}`);
 				const place = `${accessPath}[${len}]`;
 				const nullSet = state.indent + `${place} = nil; -- ${subExp.getText()}.pop\n`;
-				id = state.pushToDeclarationOrNewId(node, place, false);
+				id = state.pushToDeclarationOrNewId(node, place);
 				state.pushPrecedingStatements(subExp, nullSet);
 				return id;
 			}
@@ -187,12 +187,12 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			if (isStatement && numParams === 1) {
 				return `${accessPath}[#${accessPath} + 1] = ${parameterStrs}`;
 			} else {
-				const declaration = state.declarationContext.get(node);
 				const returnVal = `#${accessPath}${numParams ? ` + ${numParams}` : ""}`;
-				const finalLength =
-					declaration && declaration.isIdentifier
-						? state.pushToDeclarationOrNewId(node, returnVal)
-						: state.pushPrecedingStatementToNewId(node, returnVal);
+				const finalLength = state.pushToDeclarationOrNewId(
+					node,
+					returnVal,
+					declaration => declaration.isIdentifier,
+				);
 
 				let lastStatement: string | undefined;
 

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -651,7 +651,7 @@ export function compilePropertyCallExpression(state: CompilerState, node: ts.Cal
 			return compilePropertyMethod(state, property, params, "Object", OBJECT_REPLACE_METHODS);
 		}
 		case PropertyCallExpType.BuiltInStringMethod: {
-			const [accessPath, compiledArgs] = compileCallArgumentsAndSeparateAndJoin(state, params);
+			const [accessPath, compiledArgs] = compileCallArgumentsAndSeparateAndJoinWrapped(state, params);
 			return `${accessPath}:${property}(${compiledArgs})`;
 		}
 		case PropertyCallExpType.PromiseThen: {

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -173,9 +173,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 					const context = state.exitPrecedingStatementContext();
 
 					if (context.length > 0) {
-						if (!context.isPushed) {
-							arrayStr = state.pushPrecedingStatementToNewId(subExp, arrayStr);
-						}
+						arrayStr = state.pushPrecedingStatementToNewId(subExp, arrayStr);
 						state.pushPrecedingStatements(subExp, ...context);
 					}
 

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -4,7 +4,7 @@ import {
 	checkApiAccess,
 	checkNonAny,
 	compileExpression,
-	compileSpreadableList,
+	compileSpreadableListAndJoin,
 	shouldCompileAsSpreadableList,
 } from ".";
 import { CompilerState, PrecedingStatementContext } from "../CompilerState";
@@ -164,7 +164,10 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			const node = getLeftHandSideParent(subExp, 2);
 
 			if (params.some(param => ts.TypeGuards.isSpreadElement(param))) {
-				return `TS.array_push(${compileExpression(state, subExp)}, ${compileSpreadableList(state, params)})`;
+				return `TS.array_push(${compileExpression(state, subExp)}, ${compileSpreadableListAndJoin(
+					state,
+					params,
+				)})`;
 			} else {
 			}
 
@@ -406,7 +409,7 @@ export function compileCallArguments(state: CompilerState, args: Array<ts.Expres
 	let argStrs: Array<string>;
 
 	if (shouldCompileAsSpreadableList(args)) {
-		argStrs = [`unpack(${compileSpreadableList(state, args)})`];
+		argStrs = [`unpack(${compileSpreadableListAndJoin(state, args)})`];
 	} else {
 		argStrs = compileList(state, args);
 	}

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -352,10 +352,9 @@ export function compileList(
 		state.enterPrecedingStatementContext();
 		const expStr = compile(state, arg);
 
-		const currentContextHasStatements = state.currentPrecedingStatementContextHasStatements(arg);
 		const currentContext = state.exitPrecedingStatementContext();
 
-		if (currentContextHasStatements) {
+		if (currentContext.length > 0) {
 			lastContextualIndex = i;
 			cached[i] = currentContext;
 		}

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -18,7 +18,7 @@ import {
 	shouldPushToPrecedingStatement,
 	typeConstraint,
 } from "../typeUtilities";
-import { isIdentifierDefinedInLet } from "./indexed";
+import { getReadableExpressionName, isIdentifierDefinedInLet } from "./indexed";
 
 const STRING_MACRO_METHODS = [
 	"byte",
@@ -158,7 +158,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 		const validTypes = arrayType.isUnion() ? arrayType.getUnionTypes() : [arrayType];
 
 		if (validTypes.every(validType => validType.isNumber() || validType.isString())) {
-			const paramStr = params[0] ? compileCallArguments(state, params)[0] : `", "`;
+			const paramStr = params[0] ? compileCallArguments(state, params)[0] : `","`;
 			const accessPath = compileExpression(state, subExp);
 			return `table.concat(${accessPath}, ${paramStr})`;
 		}
@@ -219,7 +219,7 @@ const MAP_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 	})
 
 	.set("set", (params, state, subExp) => {
-		const accessPath = compileExpression(state, subExp);
+		const accessPath = getReadableExpressionName(state, subExp, compileExpression(state, subExp));
 		const [key, value] = compileCallArguments(state, params);
 		const expStr = `${accessPath}[${key}] = ${value}`;
 
@@ -267,7 +267,7 @@ const MAP_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 
 const SET_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 	.set("add", (params, state, subExp) => {
-		const accessPath = compileExpression(state, subExp);
+		const accessPath = getReadableExpressionName(state, subExp, compileExpression(state, subExp));
 		const [key] = compileCallArguments(state, params);
 		const expStr = `${accessPath}[${key}] = true`;
 

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -18,7 +18,7 @@ import {
 	shouldPushToPrecedingStatement,
 	typeConstraint,
 } from "../typeUtilities";
-import { getReadableExpressionName, isIdentifierDefinedInLet } from "./indexed";
+import { getReadableExpressionName, isIdentifierDefinedInConst } from "./indexed";
 
 const STRING_MACRO_METHODS = [
 	"byte",
@@ -269,7 +269,8 @@ const setKeyOfMapOrSet: ReplaceFunction = (params, state, subExp) => {
 		const isPushed =
 			wasPushed ||
 			ts.TypeGuards.isNewExpression(root) ||
-			(ts.TypeGuards.isIdentifier(root) && !isIdentifierDefinedInLet(root));
+			(ts.TypeGuards.isIdentifier(root) && isIdentifierDefinedInConst(root));
+
 		state.pushPrecedingStatements(subExp, state.indent + expStr + `;\n`);
 		console.log(isPushed, accessPath);
 		state.getCurrentPrecedingStatementContext(subExp).isPushed = isPushed;

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -145,7 +145,6 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				const node = getLeftHandSideParent(subExp, 2);
 				const declaration = state.declarationContext.get(node);
 				let id: string;
-				console.log(8, node.getKindName(), node.getText());
 				if (declaration && declaration.isIdentifier) {
 					id = declaration.set;
 					state.pushPrecedingStatements(

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -121,18 +121,6 @@ const isMapOrSetOrArrayEmpty: ReplaceFunction = (params, state, subExp) =>
 		`(next(${compileExpression(state, subExp)}) == nil)`,
 	);
 
-// const accessPath = compileExpression(state, subExp);
-// const [key] = compileCallArguments(state, params);
-// const expStr = `${accessPath}[${key}] = nil`;
-// if (getPropertyCallParentIsExpressionStatement(subExp)) {
-// 			return expStr;
-// 		} else {
-// 			const [id] = state.pushPrecedingStatementToNewIds(subExp, `${accessPath}[${key}] ~= nil`, 1);
-// 			state.pushPrecedingStatements(subExp, state.indent + expStr + `;\n`);
-// 			state.getCurrentPrecedingStatementContext(subExp).isPushed = true;
-// 			return id;
-// 		}
-
 const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 	[
 		"pop",
@@ -525,15 +513,13 @@ export function getPropertyAccessExpressionType(
 	checkApiAccess(state, expression.getNameNode());
 
 	const expType = expression.getType();
-	const subExp = expression.getExpression();
-	const subExpType = subExp.getType();
 	const property = expression.getName();
 
 	if (isArrayMethodType(expType)) {
 		return PropertyCallExpType.Array;
 	}
 
-	if (isStringMethodType(subExpType)) {
+	if (isStringMethodType(expType)) {
 		if (STRING_MACRO_METHODS.indexOf(property) !== -1) {
 			return PropertyCallExpType.BuiltInStringMethod;
 		}
@@ -548,6 +534,8 @@ export function getPropertyAccessExpressionType(
 		return PropertyCallExpType.Map;
 	}
 
+	const subExp = expression.getExpression();
+	const subExpType = subExp.getType();
 	const subExpTypeSym = subExpType.getSymbol();
 	if (subExpTypeSym && ts.TypeGuards.isPropertyAccessExpression(expression)) {
 		const subExpTypeName = subExpTypeSym.getEscapedName();

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -267,6 +267,8 @@ const MAP_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 
 const SET_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 	.set("add", (params, state, subExp) => {
+		const context = state.getCurrentPrecedingStatementContext(subExp);
+		const wasPushed = state.isTopPrecedingStatementPushed();
 		const accessPath = getReadableExpressionName(state, subExp, compileExpression(state, subExp));
 		const [key] = compileCallArguments(state, params);
 		const expStr = `${accessPath}[${key}] = true`;
@@ -274,10 +276,7 @@ const SET_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>()
 		if (getPropertyCallParentIsExpressionStatement(subExp)) {
 			return expStr;
 		} else {
-			const context = state.getCurrentPrecedingStatementContext(subExp);
-			const isPushed =
-				context.isPushed || (ts.TypeGuards.isIdentifier(subExp) && !isIdentifierDefinedInLet(subExp));
-
+			const isPushed = wasPushed || (ts.TypeGuards.isIdentifier(subExp) && !isIdentifierDefinedInLet(subExp));
 			state.pushPrecedingStatements(subExp, state.indent + expStr + `;\n`);
 			context.isPushed = isPushed;
 			return accessPath;

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -103,15 +103,17 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 	const extendExp = node.getExtends();
 	let baseClassName = "";
 	let hasSuper = false;
+	let result = "";
 
 	if (extendExp) {
 		hasSuper = true;
+		state.enterPrecedingStatementContext();
 		baseClassName = compileExpression(state, extendExp.getExpression());
+		result += state.exitPrecedingStatementContextAndJoin();
 	}
 
 	const isExpression = ts.TypeGuards.isClassExpression(node);
 
-	let result = "";
 	if (isExpression) {
 		if (nameNode) {
 			expAlias = state.getNewId();

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -414,7 +414,7 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 		state.popIndent();
 		result += state.indent + `end;\n`;
 		state.pushPrecedingStatements(node, result);
-		state.getCurrentPrecedingStatementContext(node).isPushed = true;
+		// Do not classify this as isPushed here.
 		return expAlias || name;
 	} else {
 		state.popIndent();

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -103,6 +103,7 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 	const extendExp = node.getExtends();
 	let baseClassName = "";
 	let hasSuper = false;
+
 	if (extendExp) {
 		hasSuper = true;
 		baseClassName = compileExpression(state, extendExp.getExpression());

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -215,9 +215,16 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 				const initializer = prop.getInitializer();
 				if (initializer) {
 					state.enterPrecedingStatementContext();
+					state.declarationContext.set(initializer, {
+						isIdentifier: false,
+						set: `self${propStr}`,
+					});
 					const expStr = compileExpression(state, initializer);
 					extraInitializers.push(...state.exitPrecedingStatementContext());
-					extraInitializers.push(state.indent + `self${propStr} = ${expStr};\n`);
+					console.log(propStr, expStr);
+					if (state.declarationContext.delete(initializer)) {
+						extraInitializers.push(state.indent + `self${propStr} = ${expStr};\n`);
+					}
 				}
 			}
 		}

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -414,6 +414,7 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 		state.popIndent();
 		result += state.indent + `end;\n`;
 		state.pushPrecedingStatements(node, result);
+		state.getCurrentPrecedingStatementContext(node).isPushed = true;
 		return expAlias || name;
 	} else {
 		state.popIndent();

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -221,7 +221,6 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 					});
 					const expStr = compileExpression(state, initializer);
 					extraInitializers.push(...state.exitPrecedingStatementContext());
-					console.log(propStr, expStr);
 					if (state.declarationContext.delete(initializer)) {
 						extraInitializers.push(state.indent + `self${propStr} = ${expStr};\n`);
 					}

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -23,7 +23,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 		state.currentConditionalContext = id;
 	} else {
 		if (currentConditionalContext === "") {
-			[id] = state.pushPrecedingStatementToNewIds(node, "", 1);
+			id = state.pushPrecedingStatementToNewId(node, "");
 			state.currentConditionalContext = id;
 		} else {
 			id = currentConditionalContext;

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -53,5 +53,6 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	if (currentConditionalContext === "") {
 		state.currentConditionalContext = "";
 	}
+	state.setCurrentContextAsPushed(node);
 	return id;
 }

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -13,6 +13,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	const whenTrue = node.getWhenTrue();
 	const whenFalse = node.getWhenFalse();
 	let conditionStr: string;
+	let isPushed = false;
 
 	if (declaration) {
 		conditionStr = compileExpression(state, condition);
@@ -25,6 +26,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 		if (currentConditionalContext === "") {
 			id = state.pushPrecedingStatementToNewId(node, "");
 			state.currentConditionalContext = id;
+			isPushed = true;
 		} else {
 			id = currentConditionalContext;
 		}
@@ -58,7 +60,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	if (currentConditionalContext === "") {
 		state.currentConditionalContext = "";
 	}
-	state.getCurrentPrecedingStatementContext(node).isPushed = true;
 	state.declarationContext.delete(node);
+	state.getCurrentPrecedingStatementContext(node).isPushed = isPushed;
 	return id || "";
 }

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -53,6 +53,6 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	if (currentConditionalContext === "") {
 		state.currentConditionalContext = "";
 	}
-	state.setCurrentContextAsPushed(node);
+	state.getCurrentPrecedingStatementContext(node).isPushed = true;
 	return id;
 }

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -21,6 +21,12 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	let id: string;
 	const currentConditionalContext = state.currentConditionalContext;
 
+	// const parent = node.getParent();
+	console.log([...state.declarationContext.keys()].map(key => key.getKindName() + " " + key.getText()));
+	console.log(0, node.getKindName(), node.getText(), state.declarationContext.get(node));
+
+	const declaration = state.declarationContext.get(node);
+
 	if (currentConditionalContext === "") {
 		[id] = state.pushPrecedingStatementToNewIds(node, "", 1);
 		state.currentConditionalContext = id;
@@ -36,7 +42,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	const whenTrueStr = unwrapEndParens(compileExpression(state, whenTrue));
 
 	if (id !== whenTrueStr) {
-		state.pushPrecedingStatements(whenTrue, state.indent + `${id} = ${whenTrueStr};\n`);
+		state.pushPrecedingStatements(whenTrue, state.indent + `${declaration || `${id} = `}${whenTrueStr};\n`);
 	}
 
 	state.popIndent();
@@ -44,7 +50,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	state.pushIndent();
 	const whenFalseStr = unwrapEndParens(compileExpression(state, whenFalse));
 	if (id !== whenFalseStr) {
-		state.pushPrecedingStatements(whenFalse, state.indent + `${id} = ${whenFalseStr};\n`);
+		state.pushPrecedingStatements(whenFalse, state.indent + `${declaration || `${id} = `}${whenFalseStr};\n`);
 	}
 	state.popIndent();
 	state.pushPrecedingStatements(whenFalse, state.indent + `end;\n`);
@@ -53,5 +59,6 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 		state.currentConditionalContext = "";
 	}
 	state.getCurrentPrecedingStatementContext(node).isPushed = true;
+	state.declarationContext.delete(node);
 	return id;
 }

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -51,7 +51,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	state.declarationContext.set(whenTrue, { isIdentifier: declaration ? declaration.isIdentifier : true, set: id });
 
 	const whenTrueStr = unwrapEndParens(compileExpression(state, whenTrue));
-	if (state.declarationContext.delete(whenTrue)) {
+	if (state.declarationContext.delete(whenTrue) && id !== whenTrueStr) {
 		state.pushPrecedingStatements(whenTrue, state.indent + makeSetStatement(id, whenTrueStr) + ";\n");
 	}
 
@@ -61,7 +61,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 
 	state.declarationContext.set(whenFalse, { isIdentifier: declaration ? declaration.isIdentifier : true, set: id });
 	const whenFalseStr = unwrapEndParens(compileExpression(state, whenFalse));
-	if (state.declarationContext.delete(whenFalse)) {
+	if (state.declarationContext.delete(whenFalse) && id !== whenFalseStr) {
 		state.pushPrecedingStatements(whenFalse, state.indent + makeSetStatement(id, whenFalseStr) + ";\n");
 	}
 	state.popIndent();

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -22,9 +22,8 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	const currentConditionalContext = state.currentConditionalContext;
 
 	if (currentConditionalContext === "") {
-		id = state.getNewId();
+		[id] = state.pushPrecedingStatementToNewIds(node, "", 1);
 		state.currentConditionalContext = id;
-		state.pushPrecedingStatements(node, state.indent + `local ${id};\n`);
 	} else {
 		id = currentConditionalContext;
 	}

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -1,16 +1,52 @@
 import * as ts from "ts-morph";
 import { compileExpression } from ".";
 import { CompilerState } from "../CompilerState";
-import { isBooleanType, isNullableType } from "../typeUtilities";
+
+export function unwrapEndParens(str: string) {
+	// Not very sophisticated, but because we are only matching things of the form ((_N))
+	// and _N is blocked as an identifier in Roblox-TS
+	// This will always work for this case
+
+	const match = str.match(/^\(*(_\d+)\)*$/);
+
+	if (match) {
+		const [, innerStr] = match;
+		return innerStr;
+	} else {
+		return str;
+	}
+}
 
 export function compileConditionalExpression(state: CompilerState, node: ts.ConditionalExpression) {
-	const conditionStr = compileExpression(state, node.getCondition());
-	const trueStr = compileExpression(state, node.getWhenTrue());
-	const falseStr = compileExpression(state, node.getWhenFalse());
-	const trueType = node.getWhenTrue().getType();
-	if (isNullableType(trueType) || isBooleanType(trueType)) {
-		return `(${conditionStr} and function() return ${trueStr} end or function() return ${falseStr} end)()`;
+	let id: string;
+	const currentConditionalContext = state.currentConditionalContext;
+
+	if (currentConditionalContext === "") {
+		id = state.getNewId();
+		state.currentConditionalContext = id;
+		state.pushPrecedingStatements(state.indent + `local ${id};\n`);
 	} else {
-		return `(${conditionStr} and ${trueStr} or ${falseStr})`;
+		id = currentConditionalContext;
 	}
+	state.pushPrecedingStatements(state.indent + `if ${compileExpression(state, node.getCondition())} then\n`);
+	state.pushIndent();
+	const whenTrueStr = unwrapEndParens(compileExpression(state, node.getWhenTrue()));
+
+	if (id !== whenTrueStr) {
+		state.pushPrecedingStatements(state.indent + `${id} = ${whenTrueStr};\n`);
+	}
+	state.popIndent();
+	state.pushPrecedingStatements(state.indent + `else\n`);
+	state.pushIndent();
+	const whenFalseStr = unwrapEndParens(compileExpression(state, node.getWhenFalse()));
+	if (id !== whenFalseStr) {
+		state.pushPrecedingStatements(state.indent + `${id} = ${whenFalseStr};\n`);
+	}
+	state.popIndent();
+	state.pushPrecedingStatements(state.indent + `end;\n`);
+
+	if (currentConditionalContext === "") {
+		state.currentConditionalContext = "";
+	}
+	return id;
 }

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -52,7 +52,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 
 	const whenTrueStr = unwrapEndParens(compileExpression(state, whenTrue));
 	if (state.declarationContext.delete(whenTrue)) {
-		state.pushPrecedingStatements(whenTrue, state.indent + makeSetStatement(id, whenTrueStr) + "\n");
+		state.pushPrecedingStatements(whenTrue, state.indent + makeSetStatement(id, whenTrueStr) + ";\n");
 	}
 
 	state.popIndent();
@@ -62,7 +62,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	state.declarationContext.set(whenFalse, { isIdentifier: declaration ? declaration.isIdentifier : true, set: id });
 	const whenFalseStr = unwrapEndParens(compileExpression(state, whenFalse));
 	if (state.declarationContext.delete(whenFalse)) {
-		state.pushPrecedingStatements(whenFalse, state.indent + makeSetStatement(id, whenFalseStr) + "\n");
+		state.pushPrecedingStatements(whenFalse, state.indent + makeSetStatement(id, whenFalseStr) + ";\n");
 	}
 	state.popIndent();
 	state.pushPrecedingStatements(whenFalse, state.indent + `end;\n`);

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -35,21 +35,23 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	state.pushIndent();
 
 	state.declarationContext.set(whenTrue, { isIdentifier: declaration ? declaration.isIdentifier : true, set: id });
-
+	state.pushIdStack();
 	const whenTrueStr = removeBalancedParenthesisFromStringBorders(compileExpression(state, whenTrue));
 	if (state.declarationContext.delete(whenTrue) && id !== whenTrueStr) {
 		state.pushPrecedingStatements(whenTrue, state.indent + makeSetStatement(id, whenTrueStr) + ";\n");
 	}
-
+	state.popIdStack();
 	state.popIndent();
 	state.pushPrecedingStatements(whenFalse, state.indent + `else\n`);
 	state.pushIndent();
+	state.pushIdStack();
 
 	state.declarationContext.set(whenFalse, { isIdentifier: declaration ? declaration.isIdentifier : true, set: id });
 	const whenFalseStr = removeBalancedParenthesisFromStringBorders(compileExpression(state, whenFalse));
 	if (state.declarationContext.delete(whenFalse) && id !== whenFalseStr) {
 		state.pushPrecedingStatements(whenFalse, state.indent + makeSetStatement(id, whenFalseStr) + ";\n");
 	}
+	state.popIdStack();
 	state.popIndent();
 	state.pushPrecedingStatements(whenFalse, state.indent + `end;\n`);
 

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -24,26 +24,31 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	if (currentConditionalContext === "") {
 		id = state.getNewId();
 		state.currentConditionalContext = id;
-		state.pushPrecedingStatements(state.indent + `local ${id};\n`);
+		state.pushPrecedingStatements(node, state.indent + `local ${id};\n`);
 	} else {
 		id = currentConditionalContext;
 	}
-	state.pushPrecedingStatements(state.indent + `if ${compileExpression(state, node.getCondition())} then\n`);
+	const condition = node.getCondition();
+	const whenTrue = node.getWhenTrue();
+	const whenFalse = node.getWhenFalse();
+
+	state.pushPrecedingStatements(condition, state.indent + `if ${compileExpression(state, condition)} then\n`);
 	state.pushIndent();
-	const whenTrueStr = unwrapEndParens(compileExpression(state, node.getWhenTrue()));
+	const whenTrueStr = unwrapEndParens(compileExpression(state, whenTrue));
 
 	if (id !== whenTrueStr) {
-		state.pushPrecedingStatements(state.indent + `${id} = ${whenTrueStr};\n`);
+		state.pushPrecedingStatements(whenTrue, state.indent + `${id} = ${whenTrueStr};\n`);
 	}
+
 	state.popIndent();
-	state.pushPrecedingStatements(state.indent + `else\n`);
+	state.pushPrecedingStatements(whenFalse, state.indent + `else\n`);
 	state.pushIndent();
-	const whenFalseStr = unwrapEndParens(compileExpression(state, node.getWhenFalse()));
+	const whenFalseStr = unwrapEndParens(compileExpression(state, whenFalse));
 	if (id !== whenFalseStr) {
-		state.pushPrecedingStatements(state.indent + `${id} = ${whenFalseStr};\n`);
+		state.pushPrecedingStatements(whenFalse, state.indent + `${id} = ${whenFalseStr};\n`);
 	}
 	state.popIndent();
-	state.pushPrecedingStatements(state.indent + `end;\n`);
+	state.pushPrecedingStatements(whenFalse, state.indent + `end;\n`);
 
 	if (currentConditionalContext === "") {
 		state.currentConditionalContext = "";

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -22,10 +22,6 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	let id: string | undefined;
 	const currentConditionalContext = state.currentConditionalContext;
 
-	// const parent = node.getParent();
-	console.log([...state.declarationContext.keys()].map(key => key.getKindName() + " " + key.getText()));
-	console.log(0, node.getKindName(), node.getText(), state.declarationContext.get(node));
-
 	const declaration = state.declarationContext.get(node);
 
 	const condition = node.getCondition();

--- a/src/compiler/enum.ts
+++ b/src/compiler/enum.ts
@@ -4,7 +4,7 @@ import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { shouldHoist } from "../typeUtilities";
 import { safeLuaIndex } from "../utility";
-import { compileExpression } from "./expression";
+import { getReadableExpressionName } from "./indexed";
 
 export function compileEnumDeclaration(state: CompilerState, node: ts.EnumDeclaration) {
 	let result = "";
@@ -35,7 +35,7 @@ export function compileEnumDeclaration(state: CompilerState, node: ts.EnumDeclar
 		} else if (member.hasInitializer()) {
 			const initializer = member.getInitializer()!;
 			state.enterPrecedingStatementContext();
-			const expStr = compileExpression(state, initializer);
+			const expStr = getReadableExpressionName(state, initializer);
 			result += state.exitPrecedingStatementContextAndJoin();
 			result += state.indent + `${safeIndex} = ${expStr};\n`;
 			result += state.indent + `${name}[${expStr}] = "${memberName}";\n`;

--- a/src/compiler/enum.ts
+++ b/src/compiler/enum.ts
@@ -26,7 +26,7 @@ export function compileEnumDeclaration(state: CompilerState, node: ts.EnumDeclar
 		checkReserved(memberName, member.getNameNode());
 		const memberValue = member.getValue();
 		const safeIndex = safeLuaIndex(name, memberName);
-		console.log(typeof memberValue);
+		// console.log(typeof memberValue);
 		if (typeof memberValue === "string") {
 			result += state.indent + `${safeIndex} = "${memberValue}";\n`;
 		} else if (typeof memberValue === "number") {

--- a/src/compiler/enum.ts
+++ b/src/compiler/enum.ts
@@ -49,6 +49,6 @@ export function compileEnumDeclaration(state: CompilerState, node: ts.EnumDeclar
 		}
 	}
 	state.popIndent();
-	result += state.indent + `end\n`;
+	result += state.indent + `end;\n`;
 	return result;
 }

--- a/src/compiler/enum.ts
+++ b/src/compiler/enum.ts
@@ -26,7 +26,7 @@ export function compileEnumDeclaration(state: CompilerState, node: ts.EnumDeclar
 		checkReserved(memberName, member.getNameNode());
 		const memberValue = member.getValue();
 		const safeIndex = safeLuaIndex(name, memberName);
-		// console.log(typeof memberValue);
+
 		if (typeof memberValue === "string") {
 			result += state.indent + `${safeIndex} = "${memberValue}";\n`;
 		} else if (typeof memberValue === "number") {

--- a/src/compiler/expression.ts
+++ b/src/compiler/expression.ts
@@ -142,6 +142,7 @@ export function compileExpressionStatement(state: CompilerState, node: ts.Expres
 			expStr = `local _ = ${expStr}`;
 		}
 	}
+
 	return state.exitPrecedingStatementContextAndJoin() + state.indent + expStr + ";\n";
 }
 

--- a/src/compiler/expression.ts
+++ b/src/compiler/expression.ts
@@ -119,16 +119,11 @@ export function compileExpressionStatement(state: CompilerState, node: ts.Expres
 	state.enterPrecedingStatementContext();
 
 	let expStr: string;
-	let expression = node.getExpression();
+	const expression = node.getExpression();
 
 	if (ts.TypeGuards.isCallExpression(expression)) {
 		expStr = compileCallExpression(state, expression, true);
 	} else {
-		while (ts.TypeGuards.isParenthesizedExpression(expression)) {
-			expression = expression.getExpression();
-		}
-
-		// console.log(expression.getKindName(), expression.getText());
 		expStr = compileExpression(state, expression);
 
 		// big set of rules for expression statements

--- a/src/compiler/expression.ts
+++ b/src/compiler/expression.ts
@@ -128,7 +128,7 @@ export function compileExpressionStatement(state: CompilerState, node: ts.Expres
 			expression = expression.getExpression();
 		}
 
-		console.log(expression.getKindName(), expression.getText());
+		// console.log(expression.getKindName(), expression.getText());
 		expStr = compileExpression(state, expression);
 
 		// big set of rules for expression statements

--- a/src/compiler/expression.ts
+++ b/src/compiler/expression.ts
@@ -128,6 +128,7 @@ export function compileExpressionStatement(state: CompilerState, node: ts.Expres
 			expression = expression.getExpression();
 		}
 
+		console.log(expression.getKindName(), expression.getText());
 		expStr = compileExpression(state, expression);
 
 		// big set of rules for expression statements
@@ -181,7 +182,7 @@ export function appendDeclarationIfMissing(
 	possibleExpressionStatement: ts.Node,
 	compiledNode: string,
 ) {
-	if (ts.TypeGuards.isExpressionStatement(possibleExpressionStatement)) {
+	if (compiledNode.match(/^_d+$/) || ts.TypeGuards.isExpressionStatement(possibleExpressionStatement)) {
 		return "local _ = " + compiledNode;
 	} else {
 		return compiledNode;

--- a/src/compiler/expression.ts
+++ b/src/compiler/expression.ts
@@ -119,11 +119,15 @@ export function compileExpressionStatement(state: CompilerState, node: ts.Expres
 	state.enterPrecedingStatementContext();
 
 	let expStr: string;
-	const expression = node.getExpression();
+	let expression = node.getExpression();
 
 	if (ts.TypeGuards.isCallExpression(expression)) {
 		expStr = compileCallExpression(state, expression, true);
 	} else {
+		while (ts.TypeGuards.isParenthesizedExpression(expression)) {
+			expression = expression.getExpression();
+		}
+
 		expStr = compileExpression(state, expression);
 
 		// big set of rules for expression statements
@@ -143,7 +147,8 @@ export function compileExpressionStatement(state: CompilerState, node: ts.Expres
 		}
 	}
 
-	return state.exitPrecedingStatementContextAndJoin() + state.indent + expStr + ";\n";
+	const result = state.exitPrecedingStatementContextAndJoin();
+	return expStr ? result + state.indent + expStr + ";\n" : result;
 }
 
 export function expressionModifiesVariable(

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -173,7 +173,7 @@ function compileFunction(state: CompilerState, node: HasParameters, name: string
 		state.pushIndent();
 		result += state.indent + `next = coroutine.wrap(function()`;
 		result += compileFunctionBody(state, body, node, initializers);
-		result += `\trepeat coroutine.yield({ done = true }) until false;\n`;
+		result += `\twhile true do coroutine.yield({ done = true }) end;\n`;
 		result += state.indent + `end);\n`;
 		state.popIndent();
 		result += state.indent + `};\n`;

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -12,6 +12,7 @@ import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { HasParameters } from "../types";
 import { isIterableIterator, isTupleReturnType, isTupleReturnTypeCall, shouldHoist } from "../typeUtilities";
+import { getNonNullUnParenthesizedExpression } from "../utility";
 
 export function getFirstMemberWithParameters(nodes: Array<ts.Node<ts.ts.Node>>): HasParameters | undefined {
 	for (const node of nodes) {
@@ -31,10 +32,7 @@ export function getFirstMemberWithParameters(nodes: Array<ts.Node<ts.ts.Node>>):
 }
 
 function getReturnStrFromExpression(state: CompilerState, exp: ts.Expression, func?: HasParameters) {
-	while (ts.TypeGuards.isParenthesizedExpression(exp) || ts.TypeGuards.isNonNullExpression(exp)) {
-		exp = exp.getExpression();
-	}
-
+	exp = getNonNullUnParenthesizedExpression(exp);
 	// TODO: An optimization I would like to perform looks like this:
 	/*
 	local _0;

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -338,8 +338,7 @@ export function compileFunctionExpression(state: CompilerState, node: ts.Functio
 
 	if (ts.TypeGuards.isFunctionExpression(node) && ts.TypeGuards.isIdentifier(potentialNameNode)) {
 		const name = compileExpression(state, potentialNameNode);
-		const id = state.getNewId();
-		state.pushPrecedingStatements(node, state.indent + `local ${id};\n`);
+		const [id] = state.pushPrecedingStatementToNewIds(node, "", 1);
 		state.pushPrecedingStatements(node, state.indent + `do\n`);
 		state.pushIndent();
 		state.pushPrecedingStatements(node, compileFunction(state, node, `local ${name}`, node.getBody()));

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -218,8 +218,13 @@ export function compileFunctionDeclaration(state: CompilerState, node: ts.Functi
 }
 
 export function compileMethodDeclaration(state: CompilerState, node: ts.MethodDeclaration) {
-	const name = node.getName();
-	checkReserved(name, node);
+	const nameNode = node.getNameNode();
+	const name = nameNode.getText();
+
+	if (!ts.TypeGuards.isComputedPropertyName(nameNode)) {
+		checkReserved(name, node);
+	}
+
 	return compileFunction(state, node, name, node.getBodyOrThrow());
 }
 

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -346,6 +346,7 @@ export function compileFunctionExpression(state: CompilerState, node: ts.Functio
 		state.pushPrecedingStatements(node, state.indent + `${id} = ${name};\n`);
 		state.popIndent();
 		state.pushPrecedingStatements(node, state.indent + `end;\n`);
+		// this should not be classified as isPushed.
 		return id;
 	} else {
 		return compileFunction(state, node, "", node.getBody());

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -218,10 +218,13 @@ export function compileFunctionDeclaration(state: CompilerState, node: ts.Functi
 }
 
 export function compileMethodDeclaration(state: CompilerState, node: ts.MethodDeclaration) {
-	const nameNode = node.getNameNode();
-	const name = nameNode.getText();
+	const nameNode: ts.PropertyName = node.getNameNode();
+	let name: string;
 
-	if (!ts.TypeGuards.isComputedPropertyName(nameNode)) {
+	if (ts.TypeGuards.isComputedPropertyName(nameNode)) {
+		name = `[${compileExpression(state, nameNode.getExpression())}]`;
+	} else {
+		name = compileExpression(state, nameNode);
 		checkReserved(name, node);
 	}
 

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -346,7 +346,7 @@ export function compileFunctionExpression(state: CompilerState, node: ts.Functio
 		potentialNameNode.findReferences()[0].getReferences().length > 1
 	) {
 		const name = compileExpression(state, potentialNameNode);
-		const [id] = state.pushPrecedingStatementToNewIds(node, "", 1);
+		const id = state.pushPrecedingStatementToNewId(node, "");
 		state.pushPrecedingStatements(node, state.indent + `do\n`);
 		state.pushIndent();
 		state.pushPrecedingStatements(node, state.indent + `local ${name};\n`);

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -12,7 +12,7 @@ import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { HasParameters } from "../types";
 import { isIterableIterator, isTupleReturnType, isTupleReturnTypeCall, shouldHoist } from "../typeUtilities";
-import { getNonNullUnParenthesizedExpression } from "../utility";
+import { getNonNullUnParenthesizedExpressionDownwards } from "../utility";
 
 export function getFirstMemberWithParameters(nodes: Array<ts.Node<ts.ts.Node>>): HasParameters | undefined {
 	for (const node of nodes) {
@@ -32,26 +32,8 @@ export function getFirstMemberWithParameters(nodes: Array<ts.Node<ts.ts.Node>>):
 }
 
 function getReturnStrFromExpression(state: CompilerState, exp: ts.Expression, func?: HasParameters) {
-	exp = getNonNullUnParenthesizedExpression(exp);
-	// TODO: An optimization I would like to perform looks like this:
-	/*
-	local _0;
-	if true then
-		_0 = 1
-	else
-		_0 = 2;
-	end
+	exp = getNonNullUnParenthesizedExpressionDownwards(exp);
 
-	-- either of these ending statements could be replaced in-line:
-	let i = _0;
-	return _0;
-
-	example:
-		return 1;
-		i = 1; -- (of course, `i` would be hoisted instead of `_0`)
-
-	We should be able to easily implement this on the new flag object.
-	*/
 	if (func && isTupleReturnType(func)) {
 		if (ts.TypeGuards.isArrayLiteralExpression(exp)) {
 			let expStr = compileExpression(state, exp);

--- a/src/compiler/if.ts
+++ b/src/compiler/if.ts
@@ -1,6 +1,7 @@
 import * as ts from "ts-morph";
 import { compileExpression, compileStatement } from ".";
 import { CompilerState } from "../CompilerState";
+import { joinIndentedLines } from "../utility";
 
 export function compileIfStatement(state: CompilerState, node: ts.IfStatement) {
 	let result = "";
@@ -19,17 +20,18 @@ export function compileIfStatement(state: CompilerState, node: ts.IfStatement) {
 		state.pushIndent();
 		const exp = elseStatement.getExpression();
 		const elseIfExpression = compileExpression(state, exp);
+		const context = state.exitPrecedingStatementContext();
 
-		if (state.currentPrecedingStatementContextHasStatements(exp)) {
+		if (context.length > 0) {
 			state.popIndent();
 			result += state.indent + `else\n`;
 			state.pushIndent();
 			numBlocks++;
-			result += state.exitPrecedingStatementContextAndJoin();
+			result += joinIndentedLines(context);
 			result += state.indent + `if ${elseIfExpression} then\n`;
 		} else {
 			state.popIndent();
-			state.exitPrecedingStatementContext();
+
 			result += state.indent + `elseif ${elseIfExpression} then\n`;
 		}
 

--- a/src/compiler/if.ts
+++ b/src/compiler/if.ts
@@ -4,26 +4,53 @@ import { CompilerState } from "../CompilerState";
 
 export function compileIfStatement(state: CompilerState, node: ts.IfStatement) {
 	let result = "";
+	state.enterPrecedingStatementContext();
 	const expStr = compileExpression(state, node.getExpression());
+	result += state.exitPrecedingStatementContextAndJoin();
 	result += state.indent + `if ${expStr} then\n`;
 	state.pushIndent();
 	result += compileStatement(state, node.getThenStatement());
 	state.popIndent();
 	let elseStatement = node.getElseStatement();
+	let numBlocks = 1;
+
 	while (elseStatement && ts.TypeGuards.isIfStatement(elseStatement)) {
-		const elseIfExpression = compileExpression(state, elseStatement.getExpression());
-		result += state.indent + `elseif ${elseIfExpression} then\n`;
+		state.enterPrecedingStatementContext();
+		state.pushIndent();
+		const exp = elseStatement.getExpression();
+		const elseIfExpression = compileExpression(state, exp);
+
+		if (state.currentPrecedingStatementContextHasStatements(exp)) {
+			state.popIndent();
+			result += state.indent + `else\n`;
+			state.pushIndent();
+			numBlocks++;
+			result += state.exitPrecedingStatementContextAndJoin();
+			result += state.indent + `if ${elseIfExpression} then\n`;
+		} else {
+			state.popIndent();
+			state.exitPrecedingStatementContext();
+			result += state.indent + `elseif ${elseIfExpression} then\n`;
+		}
+
 		state.pushIndent();
 		result += compileStatement(state, elseStatement.getThenStatement());
 		state.popIndent();
 		elseStatement = elseStatement.getElseStatement();
 	}
+
 	if (elseStatement) {
 		result += state.indent + "else\n";
 		state.pushIndent();
 		result += compileStatement(state, elseStatement);
 		state.popIndent();
 	}
+
 	result += state.indent + `end;\n`;
+
+	for (let i = 1; i < numBlocks; i++) {
+		state.popIndent();
+		result += state.indent + `end;\n`;
+	}
 	return result;
 }

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -47,6 +47,7 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 			return `${id}.${propertyStr}`;
 		}
 	}
+
 	return compileExpression(state, operand);
 }
 

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -13,7 +13,7 @@ import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { inheritsFrom, isArrayType, isNumberType, isTupleReturnTypeCall } from "../typeUtilities";
 import { safeLuaIndex } from "../utility";
 
-export function isExpressionDefinedInExportLet(state: CompilerState, exp: ts.Identifier) {
+export function isIdentifierDefinedInExportLet(state: CompilerState, exp: ts.Identifier) {
 	// I have no idea why, but getDefinitionNodes() cannot replace this
 	for (const def of exp.getDefinitions()) {
 		const definition = def.getNode().getFirstAncestorByKind(ts.SyntaxKind.VariableStatement);
@@ -38,7 +38,7 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 
 		if (
 			ts.TypeGuards.isPropertyAccessExpression(child) ||
-			(ts.TypeGuards.isIdentifier(child) && isExpressionDefinedInExportLet(state, child))
+			(ts.TypeGuards.isIdentifier(child) && isIdentifierDefinedInExportLet(state, child))
 		) {
 			const expression = operand.getExpression();
 			const opExpStr = compileExpression(state, expression);
@@ -55,7 +55,7 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
  * Similar to getWritableOperandName, but should push anything with any depth. This includes export let vars.
  */
 export function getReadableExpressionName(state: CompilerState, exp: ts.Expression, expStr: string) {
-	if (ts.TypeGuards.isIdentifier(exp) && !isExpressionDefinedInExportLet(state, exp)) {
+	if (ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(state, exp)) {
 		return expStr;
 	} else {
 		return state.pushPrecedingStatementToNextId(exp, expStr);

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -54,7 +54,7 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 			const expression = operand.getExpression();
 			const opExpStr = compileExpression(state, expression);
 			const propertyStr = operand.getName();
-			const id = state.pushPrecedingStatementToNextId(operand, opExpStr);
+			const id = state.pushPrecedingStatementToReuseableId(operand, opExpStr);
 			return { expStr: `${id}.${propertyStr}`, isIdentifier: false };
 		}
 	}
@@ -72,7 +72,7 @@ export function getReadableExpressionName(state: CompilerState, exp: ts.Expressi
 	if (expStr.match(/^_\d+$/) || (ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(exp))) {
 		return expStr;
 	} else {
-		return state.pushPrecedingStatementToNextId(exp, expStr);
+		return state.pushPrecedingStatementToReuseableId(exp, expStr);
 	}
 }
 

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -68,7 +68,11 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 /**
  * Similar to getWritableOperandName, but should push anything with any depth. This includes export let vars.
  */
-export function getReadableExpressionName(state: CompilerState, exp: ts.Expression, expStr: string) {
+export function getReadableExpressionName(
+	state: CompilerState,
+	exp: ts.Expression,
+	expStr = compileExpression(state, exp),
+) {
 	if (expStr.match(/^_\d+$/) || (ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(exp))) {
 		return expStr;
 	} else {
@@ -141,7 +145,7 @@ export function compilePropertyAccessExpression(state: CompilerState, node: ts.P
 		}
 	}
 
-	return `${expStr}.${propertyStr}`;
+	return expStr === "TS.Symbol" ? `${expStr}_${propertyStr}` : `${expStr}.${propertyStr}`;
 }
 
 export function compileElementAccessExpression(state: CompilerState, node: ts.ElementAccessExpression) {

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -39,16 +39,6 @@ export function isIdentifierDefinedInExportLet(exp: ts.Identifier) {
 	return false;
 }
 
-export function isFlatIdentifier(state: CompilerState, identifier: ts.Node) {
-	console.log(
-		identifier.getKindName(),
-		identifier.getText(),
-		identifier.getParent()!.getKindName(),
-		identifier.getParent()!.getText(),
-		ts.TypeGuards.isIdentifier(identifier),
-	);
-}
-
 /**
  * Gets the writable operand name, meaning the code should be able to do `returnValue = x;`
  * The rule in this case is that if there is a depth of 3 or more, e.g. `Foo.Bar.i`, we push `Foo.Bar`

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -82,7 +82,7 @@ export function getReadableExpressionName(
 	expStr = compileExpression(state, exp),
 ) {
 	if (
-		expStr.match(/^_\d+$/) ||
+		expStr.match(/^\(*_\d+\)*$/) ||
 		(ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(exp)) ||
 		// We know that new Sets and Maps are already ALWAYS pushed
 		(ts.TypeGuards.isNewExpression(exp) && (isSetType(exp.getType()) || isMapType(exp.getType())))

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -66,7 +66,7 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
  * Similar to getWritableOperandName, but should push anything with any depth. This includes export let vars.
  */
 export function getReadableExpressionName(state: CompilerState, exp: ts.Expression, expStr: string) {
-	if (ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(exp)) {
+	if (expStr.match(/^_\d+$/) || (ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(exp))) {
 		return expStr;
 	} else {
 		return state.pushPrecedingStatementToNextId(exp, expStr);

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -10,7 +10,15 @@ import {
 } from ".";
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
-import { inheritsFrom, isArrayType, isNumberType, isStringType, isTupleReturnTypeCall } from "../typeUtilities";
+import {
+	inheritsFrom,
+	isArrayType,
+	isMapType,
+	isNumberType,
+	isSetType,
+	isStringType,
+	isTupleReturnTypeCall,
+} from "../typeUtilities";
 import { removeBalancedParenthesisFromStringBorders, safeLuaIndex } from "../utility";
 
 export function isIdentifierDefinedInConst(exp: ts.Identifier) {
@@ -73,7 +81,12 @@ export function getReadableExpressionName(
 	exp: ts.Expression,
 	expStr = compileExpression(state, exp),
 ) {
-	if (expStr.match(/^_\d+$/) || (ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(exp))) {
+	if (
+		expStr.match(/^_\d+$/) ||
+		(ts.TypeGuards.isIdentifier(exp) && !isIdentifierDefinedInExportLet(exp)) ||
+		// We know that new Sets and Maps are already ALWAYS pushed
+		(ts.TypeGuards.isNewExpression(exp) && (isSetType(exp.getType()) || isMapType(exp.getType())))
+	) {
 		return expStr;
 	} else {
 		return state.pushPrecedingStatementToReuseableId(exp, expStr);

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -13,11 +13,11 @@ import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { inheritsFrom, isArrayType, isNumberType, isTupleReturnTypeCall } from "../typeUtilities";
 import { safeLuaIndex } from "../utility";
 
-export function isIdentifierDefinedInLet(exp: ts.Identifier) {
+export function isIdentifierDefinedInConst(exp: ts.Identifier) {
 	// I have no idea why, but getDefinitionNodes() cannot replace this
 	for (const def of exp.getDefinitions()) {
 		const definition = def.getNode().getFirstAncestorByKind(ts.SyntaxKind.VariableStatement);
-		if (definition && definition.getDeclarationKind() === ts.VariableDeclarationKind.Let) {
+		if (definition && definition.getDeclarationKind() === ts.VariableDeclarationKind.Const) {
 			return true;
 		}
 	}

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -55,11 +55,14 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 			const opExpStr = compileExpression(state, expression);
 			const propertyStr = operand.getName();
 			const id = state.pushPrecedingStatementToNextId(operand, opExpStr);
-			return `${id}.${propertyStr}`;
+			return { expStr: `${id}.${propertyStr}`, isIdentifier: false };
 		}
 	}
 
-	return compileExpression(state, operand);
+	return {
+		expStr: compileExpression(state, operand),
+		isIdentifier: !ts.TypeGuards.isIdentifier(operand) || !isIdentifierDefinedInExportLet(operand),
+	};
 }
 
 /**

--- a/src/compiler/literal.ts
+++ b/src/compiler/literal.ts
@@ -67,7 +67,7 @@ export function compileTemplateExpression(state: CompilerState, node: ts.Templat
 			}),
 		(_, exp) => {
 			const expStr = compileExpression(state, exp);
-			return isStringType(exp.getType()) ? expStr : `tostring(${expStr})` + (followingStrs.get(exp) || "");
+			return (isStringType(exp.getType()) ? expStr : `tostring(${expStr})`) + (followingStrs.get(exp) || "");
 		},
 	);
 

--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -12,7 +12,7 @@ import {
 } from ".";
 import { CompilerState, PrecedingStatementContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
-import { isArrayType, isIterableIterator, isMapType, isNumberType, isSetType, isStringType } from "../typeUtilities";
+import { isArrayType, isIterableFunction, isMapType, isNumberType, isSetType, isStringType } from "../typeUtilities";
 import { isIdentifierWhoseDefinitionMatchesNode, joinIndentedLines } from "../utility";
 import { getReadableExpressionName } from "./indexed";
 
@@ -245,15 +245,15 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 			} else if (isSetType(expType)) {
 				result += state.indent + `for ${varName} in pairs(${expStr}) do\n`;
 				state.pushIndent();
-			} else if (isIterableIterator(expType, exp)) {
+			} else if (isIterableFunction(expType)) {
+				result += state.indent + `for ${varName} in ${expStr} do\n`;
+				state.pushIndent();
+			} else {
 				const loopVar = state.getNewId();
 				result += state.indent + `for ${loopVar} in ${expStr}.next do\n`;
 				state.pushIndent();
 				result += state.indent + `if ${loopVar}.done then break end;\n`;
 				result += state.indent + `local ${varName} = ${loopVar}.value;\n`;
-			} else {
-				result += state.indent + `for ${varName} in ${expStr} do\n`;
-				state.pushIndent();
 			}
 		}
 

--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -426,7 +426,7 @@ function safelyHandleExpressionsInForStatement(
 	context: PrecedingStatementContext,
 	indentation: number,
 ) {
-	console.log(context.isPushed, ":", incrementorStr);
+	// console.log(context.isPushed, ":", incrementorStr);
 	return (
 		joinIndentedLines(context, indentation) +
 		state.indent +

--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -10,10 +10,11 @@ import {
 	getFirstMemberWithParameters,
 	placeIncrementorInStatementIfExpression,
 } from ".";
-import { CompilerState } from "../CompilerState";
+import { CompilerState, PrecedingStatementContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { isArrayType, isIterableIterator, isMapType, isNumberType, isSetType, isStringType } from "../typeUtilities";
 import { isIdentifierWhoseDefinitionMatchesNode, joinIndentedLines } from "../utility";
+import { getReadableExpressionName } from "./indexed";
 
 function hasContinueDescendant(node: ts.Node) {
 	for (const child of node.getChildren()) {
@@ -79,7 +80,7 @@ export function compileLoopBody(state: CompilerState, node: ts.Statement) {
 		state.pushIndent();
 		result += state.indent + `break;\n`;
 		state.popIndent();
-		result += state.indent + `end\n`;
+		result += state.indent + `end;\n`;
 		state.continueId--;
 	}
 
@@ -87,17 +88,20 @@ export function compileLoopBody(state: CompilerState, node: ts.Statement) {
 }
 
 export function compileDoStatement(state: CompilerState, node: ts.DoStatement) {
-	const condition = compileExpression(state, node.getExpression());
-	let result = "";
-	result += state.indent + "repeat\n";
+	state.pushIdStack();
+	let result = state.indent + "repeat\n";
 	state.pushIndent();
 	result += state.indent + "do\n";
 	state.pushIndent();
 	result += compileLoopBody(state, node.getStatement());
 	state.popIndent();
-	result += state.indent + "end\n";
+	result += state.indent + "end;\n";
+	state.enterPrecedingStatementContext();
+	const condition = compileExpression(state, node.getExpression());
+	result += state.exitPrecedingStatementContextAndJoin();
 	state.popIndent();
 	result += state.indent + `until not (${condition});\n`;
+	state.popIdStack();
 	return result;
 }
 
@@ -224,11 +228,9 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 			if (isArrayType(expType)) {
 				let varValue: string;
 
-				if (!ts.TypeGuards.isIdentifier(exp)) {
-					const arrayName = state.getNewId();
-					result += state.indent + `local ${arrayName} = ${expStr};\n`;
-					expStr = arrayName;
-				}
+				state.enterPrecedingStatementContext();
+				expStr = getReadableExpressionName(state, exp, expStr);
+				result += state.exitPrecedingStatementContextAndJoin();
 				const myInt = state.getNewId();
 				result += state.indent + `for ${myInt} = 1, #${expStr} do\n`;
 				state.pushIndent();
@@ -278,17 +280,6 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 		);
 	}
 }
-
-export function checkLoopClassExp(node?: ts.Expression<ts.ts.Expression>) {
-	if (node && ts.TypeGuards.isClassExpression(node)) {
-		throw new CompilerError(
-			"Loops cannot contain class expressions as their condition/init/incrementor!",
-			node,
-			CompilerErrorType.ClassyLoop,
-		);
-	}
-}
-
 function isExpressionConstantNumbers(node: ts.Node): boolean {
 	const children = node.getChildren();
 	return (
@@ -432,15 +423,16 @@ function safelyHandleExpressionsInForStatement(
 	state: CompilerState,
 	incrementor: ts.Expression<ts.ts.Expression>,
 	incrementorStr: string,
-	context: Array<string>,
+	context: PrecedingStatementContext,
+	indentation: number,
 ) {
-	if (ts.TypeGuards.isExpression(incrementor)) {
-		checkLoopClassExp(incrementor);
-	}
+	console.log(context.isPushed, ":", incrementorStr);
 	return (
-		joinIndentedLines(context, 2) +
+		joinIndentedLines(context, indentation) +
 		state.indent +
-		placeIncrementorInStatementIfExpression(state, incrementor, incrementorStr)
+		(context.isPushed
+			? incrementorStr
+			: placeIncrementorInStatementIfExpression(state, incrementor, incrementorStr))
 	);
 }
 
@@ -487,85 +479,80 @@ export function compileForStatement(state: CompilerState, node: ts.ForStatement)
 	state.pushIdStack();
 	const statement = node.getStatement();
 	const condition = node.getCondition();
-	checkLoopClassExp(condition);
 	const incrementor = node.getIncrementor();
-	checkLoopClassExp(incrementor);
 
-	let result = "";
 	let localizations = "";
 	const cleanups = new Array<() => void>();
-	result += state.indent + "do\n";
+	let result = state.indent + "do\n";
 	state.pushIndent();
 	const initializer = node.getInitializer();
 	let conditionStr: string | undefined;
 	let incrementorStr: string | undefined;
 
-	let conditionContext: Array<string> | undefined;
-	let incrementorContext: Array<string> | undefined;
-	let initializerContext: Array<string> | undefined;
+	let conditionContext: PrecedingStatementContext | undefined;
+	let incrementorContext: PrecedingStatementContext | undefined;
+	let initializerContext: PrecedingStatementContext | undefined;
 
 	if (initializer) {
-		if (
-			ts.TypeGuards.isVariableDeclarationList(initializer) &&
-			initializer.getDeclarationKind() === ts.VariableDeclarationKind.Let
-		) {
+		if (ts.TypeGuards.isVariableDeclarationList(initializer)) {
 			const declarations = initializer.getDeclarations();
 			const statementDescendants = statement.getDescendants();
+			if (initializer.getDeclarationKind() === ts.VariableDeclarationKind.Let) {
+				if (declarations.length === 1) {
+					const lhs = declarations[0].getChildAtIndex(0);
+					if (ts.TypeGuards.isIdentifier(lhs)) {
+						const nextSibling = lhs.getNextSibling();
 
-			if (declarations.length === 1) {
-				const lhs = declarations[0].getChildAtIndex(0);
-				if (ts.TypeGuards.isIdentifier(lhs)) {
-					const nextSibling = lhs.getNextSibling();
+						if (
+							!statementDescendants.some(statementDescendant =>
+								expressionModifiesVariable(statementDescendant, lhs),
+							) &&
+							incrementor &&
+							nextSibling &&
+							condition
+						) {
+							// check if we can convert to a simple for loop
+							// IF there aren't any in-loop modifications to the let variable
+							// AND the let variable is a single numeric variable
+							// AND the incrementor is a simple +/- expression of the let var
+							// AND the conditional expression is a binary expression
+							// with one of these operators: <= >= < >
+							// AND the conditional expression compares the let var to a numeric literal
+							// OR the conditional expression compares the let var to an unchanging number
 
-					if (
-						!statementDescendants.some(statementDescendant =>
-							expressionModifiesVariable(statementDescendant, lhs),
-						) &&
-						incrementor &&
-						nextSibling &&
-						condition
-					) {
-						// check if we can convert to a simple for loop
-						// IF there aren't any in-loop modifications to the let variable
-						// AND the let variable is a single numeric variable
-						// AND the incrementor is a simple +/- expression of the let var
-						// AND the conditional expression is a binary expression
-						// with one of these operators: <= >= < >
-						// AND the conditional expression compares the let var to a numeric literal
-						// OR the conditional expression compares the let var to an unchanging number
-
-						const rhs = nextSibling.getNextSibling();
-						if (rhs) {
-							const rhsType = rhs.getType();
-							if (isNumberType(rhsType)) {
-								if (expressionModifiesVariable(incrementor, lhs)) {
-									const [incrSign, incrValue] = getSignAndIncrementorForStatement(
-										state,
-										incrementor,
-										lhs,
-									);
-									if (incrSign && incrValue) {
-										const [condSign, condValue] = getLimitInForStatement(state, condition, lhs);
-										// numeric literals, or constant number identifiers are safe
-										if (
-											condValue &&
-											ts.TypeGuards.isExpression(condValue) &&
-											(isConstantNumberVariableOrLiteral(condValue) ||
-												isExpressionConstantNumbers(condValue))
-										) {
+							const rhs = nextSibling.getNextSibling();
+							if (rhs) {
+								const rhsType = rhs.getType();
+								if (isNumberType(rhsType)) {
+									if (expressionModifiesVariable(incrementor, lhs)) {
+										const [incrSign, incrValue] = getSignAndIncrementorForStatement(
+											state,
+											incrementor,
+											lhs,
+										);
+										if (incrSign && incrValue) {
+											const [condSign, condValue] = getLimitInForStatement(state, condition, lhs);
+											// numeric literals, or constant number identifiers are safe
 											if (
-												(incrSign === "+" && condSign === "<=") ||
-												(incrSign === "-" && condSign === ">=")
+												condValue &&
+												ts.TypeGuards.isExpression(condValue) &&
+												(isConstantNumberVariableOrLiteral(condValue) ||
+													isExpressionConstantNumbers(condValue))
 											) {
-												const incrStr = incrSign === "-" ? incrSign + incrValue : incrValue;
+												if (
+													(incrSign === "+" && condSign === "<=") ||
+													(incrSign === "-" && condSign === ">=")
+												) {
+													const incrStr = incrSign === "-" ? incrSign + incrValue : incrValue;
 
-												return getSimpleForLoopString(
-													state,
-													initializer,
-													compileExpression(state, condValue) +
-														(incrStr === "1" ? "" : ", " + incrStr),
-													statement,
-												);
+													return getSimpleForLoopString(
+														state,
+														initializer,
+														compileExpression(state, condValue) +
+															(incrStr === "1" ? "" : ", " + incrStr),
+														statement,
+													);
+												}
 											}
 										}
 									}
@@ -575,6 +562,11 @@ export function compileForStatement(state: CompilerState, node: ts.ForStatement)
 					}
 				}
 			}
+
+			state.enterPrecedingStatementContext();
+			const expStr = compileVariableDeclarationList(state, initializer);
+			result += state.exitPrecedingStatementContextAndJoin() + expStr; // + ";\n";
+
 			// if we can't convert to a simple for loop:
 			// if it has any internal function declarations, make sure to locally scope variables
 			if (getFirstMemberWithParameters(statementDescendants)) {
@@ -617,15 +609,11 @@ export function compileForStatement(state: CompilerState, node: ts.ForStatement)
 					}
 				});
 			}
-
-			state.enterPrecedingStatementContext();
-			result += compileVariableDeclarationList(state, initializer);
-			initializerContext = state.exitPrecedingStatementContext();
 		} else if (ts.TypeGuards.isExpression(initializer)) {
 			state.enterPrecedingStatementContext();
 			const expStr = compileExpression(state, initializer);
 			initializerContext = state.exitPrecedingStatementContext();
-			result += safelyHandleExpressionsInForStatement(state, initializer, expStr, initializerContext) + ";\n";
+			result += safelyHandleExpressionsInForStatement(state, initializer, expStr, initializerContext, 0) + ";\n";
 		}
 	}
 	// order matters
@@ -652,7 +640,7 @@ export function compileForStatement(state: CompilerState, node: ts.ForStatement)
 		cleanups.forEach(cleanup => cleanup());
 		if (incrementor && incrementorStr) {
 			console.log(`"${incrementorStr}"`, incrementorContext);
-			result += safelyHandleExpressionsInForStatement(state, incrementor, incrementorStr, incrementorContext!);
+			result += safelyHandleExpressionsInForStatement(state, incrementor, incrementorStr, incrementorContext!, 2);
 		}
 		state.popIndent();
 		result += state.indent + `end;\n`;
@@ -665,7 +653,7 @@ export function compileForStatement(state: CompilerState, node: ts.ForStatement)
 		result += compileLoopBody(state, statement);
 		cleanups.forEach(cleanup => cleanup());
 		if (incrementor && incrementorStr) {
-			result += safelyHandleExpressionsInForStatement(state, incrementor, incrementorStr, incrementorContext!);
+			result += safelyHandleExpressionsInForStatement(state, incrementor, incrementorStr, incrementorContext!, 1);
 		}
 		state.popIndent();
 		result += state.indent + "end;\n";
@@ -679,7 +667,7 @@ export function compileForStatement(state: CompilerState, node: ts.ForStatement)
 
 export function compileWhileStatement(state: CompilerState, node: ts.WhileStatement) {
 	const exp = node.getExpression();
-	checkLoopClassExp(exp);
+	state.pushIdStack();
 	state.enterPrecedingStatementContext();
 	const expStr = compileExpression(state, exp);
 	let result = "";
@@ -703,5 +691,6 @@ export function compileWhileStatement(state: CompilerState, node: ts.WhileStatem
 		state.popIndent();
 		result += state.indent + `end;\n`;
 	}
+	state.popIdStack();
 	return result;
 }

--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -130,8 +130,9 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 	const statement = node.getStatement();
 	const exp = node.getExpression();
 	const expType = exp.getType();
-	let result = "";
+	state.enterPrecedingStatementContext();
 	let expStr = compileExpression(state, exp);
+	let result = state.exitPrecedingStatementContextAndJoin();
 
 	if (ts.TypeGuards.isVariableDeclarationList(init)) {
 		const declarations = init.getDeclarations();

--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -426,7 +426,6 @@ function safelyHandleExpressionsInForStatement(
 	context: PrecedingStatementContext,
 	indentation: number,
 ) {
-	// console.log(context.isPushed, ":", incrementorStr);
 	return (
 		joinIndentedLines(context, indentation) +
 		state.indent +

--- a/src/compiler/module.ts
+++ b/src/compiler/module.ts
@@ -412,20 +412,22 @@ export function compileExportDeclaration(state: CompilerState, node: ts.ExportDe
 }
 
 export function compileExportAssignment(state: CompilerState, node: ts.ExportAssignment) {
-	let result = state.indent;
 	const exp = node.getExpression();
 	if (node.isExportEquals() && (!ts.TypeGuards.isIdentifier(exp) || !isUsedAsType(exp))) {
 		state.isModule = true;
+		state.enterPrecedingStatementContext();
 		const expStr = compileExpression(state, exp);
-		result += `_exports = ${expStr};\n`;
+		return state.exitPrecedingStatementContextAndJoin() + `_exports = ${expStr};\n`;
 	} else {
 		const symbol = node.getSymbol();
 		if (symbol) {
 			if (symbol.getName() === "default") {
 				state.isModule = true;
-				result += "_exports._default = " + compileExpression(state, exp) + ";\n";
+				state.enterPrecedingStatementContext();
+				const expStr = compileExpression(state, exp);
+				return state.exitPrecedingStatementContextAndJoin() + "_exports._default = " + expStr + ";\n";
 			}
 		}
 	}
-	return result;
+	return "";
 }

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -66,6 +66,8 @@ function compileSetMapConstructorHelper(
 				1,
 			);
 		}
+
+		state.getCurrentPrecedingStatementContext(node).isPushed = true;
 		return id;
 	}
 }

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -71,9 +71,6 @@ function compileSetMapConstructorHelper(
 					const context = state.exitPrecedingStatementContext();
 					if (context.length > 0) {
 						hasContext = true;
-
-						// console.log(state.declarationContext.get(node));
-
 						id = state.pushPrecedingStatementToNewIds(node, "{}", 1)[0];
 						state.pushPrecedingStatements(node, ...lines.map(current => id + current));
 						state.pushPrecedingStatements(node, ...context);

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -85,7 +85,7 @@ function compileSetMapConstructorHelper(
 					const context = state.exitPrecedingStatementContext();
 					if (context.length > 0) {
 						hasContext = true;
-						id = state.pushToDeclarationOrNewId(exp, "{}");
+						id = state.pushToDeclarationOrNewId(exp, "{}", declaration => declaration.isIdentifier);
 						state.pushPrecedingStatements(
 							exp,
 							...lines.map(current => id + current),
@@ -105,7 +105,7 @@ function compileSetMapConstructorHelper(
 				lines.reduce((result, line) => result + state.indent + "\t" + line, lines.length > 0 ? "{\n" : "{") +
 					state.indent +
 					"}",
-				() => true,
+				ts.TypeGuards.isNewExpression(exp) ? () => true : declaration => declaration.isIdentifier,
 			);
 		}
 

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -66,7 +66,6 @@ function compileSetMapConstructorHelper(
 				1,
 			);
 		}
-
 		return id;
 	}
 }

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -105,7 +105,7 @@ function compileSetMapConstructorHelper(
 				lines.reduce((result, line) => result + state.indent + "\t" + line, lines.length > 0 ? "{\n" : "{") +
 					state.indent +
 					"}",
-				true,
+				() => true,
 			);
 		}
 

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -109,6 +109,7 @@ function compileSetMapConstructorHelper(
 			);
 		}
 
+		state.getCurrentPrecedingStatementContext(node).isPushed = true;
 		return id;
 	}
 }

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -1,14 +1,8 @@
 import * as ts from "ts-morph";
-import {
-	checkReserved,
-	compileExpression,
-	compileIdentifier,
-	compileMethodDeclaration,
-	compileNumericLiteral,
-	compileStringLiteral,
-} from ".";
+import { compileExpression, compileMethodDeclaration } from ".";
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
+import { joinIndentedLines } from "../utility";
 
 export function compileObjectLiteralExpression(state: CompilerState, node: ts.ObjectLiteralExpression) {
 	const properties = node.getProperties();
@@ -26,27 +20,22 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 				firstIsObj = true;
 			}
 
-			let lhs: string;
+			let lhs: ts.Expression;
 
 			let n = 0;
 			let child = prop.getChildAtIndex(n);
 			while (ts.TypeGuards.isJSDoc(child)) {
-				n++;
-				child = prop.getChildAtIndex(n);
+				child = prop.getChildAtIndex(++n);
 			}
 
 			if (ts.TypeGuards.isComputedPropertyName(child)) {
-				const expStr = compileExpression(state, child.getExpression());
-				lhs = `[${expStr}]`;
-			} else if (ts.TypeGuards.isStringLiteral(child)) {
-				const expStr = compileStringLiteral(state, child);
-				lhs = `[${expStr}]`;
-			} else if (ts.TypeGuards.isIdentifier(child)) {
-				lhs = child.getText();
-				checkReserved(lhs, child);
-			} else if (ts.TypeGuards.isNumericLiteral(child)) {
-				const expStr = compileNumericLiteral(state, child);
-				lhs = `[${expStr}]`;
+				lhs = child.getExpression();
+			} else if (
+				ts.TypeGuards.isIdentifier(child) ||
+				ts.TypeGuards.isStringLiteral(child) ||
+				ts.TypeGuards.isNumericLiteral(child)
+			) {
+				lhs = child;
 			} else {
 				throw new CompilerError(
 					`Unexpected type of object index! (${child.getKindName()})`,
@@ -60,16 +49,35 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 				state.pushIndent();
 			}
 
-			let rhs: string; // You may want to move this around
+			let rhs: ts.Expression; // You may want to move this around
 			if (ts.TypeGuards.isShorthandPropertyAssignment(prop) && ts.TypeGuards.isIdentifier(child)) {
-				lhs = prop.getName();
-				rhs = compileIdentifier(state, child);
-				checkReserved(lhs, child);
+				lhs = prop.getNameNode();
+				rhs = child;
 			} else {
-				rhs = compileExpression(state, prop.getInitializerOrThrow());
+				rhs = prop.getInitializerOrThrow();
 			}
 
-			parts[parts.length - 1] += state.indent + `${lhs} = ${rhs};\n`;
+			state.enterPrecedingStatementContext();
+			let lhsStr = compileExpression(state, lhs);
+			const lhsContext = state.exitPrecedingStatementContext();
+			state.enterPrecedingStatementContext();
+			let rhsStr = compileExpression(state, rhs);
+			const rhsContext = state.exitPrecedingStatementContext();
+
+			if (lhsContext.length > 0) {
+				lhsContext.push(state.indent + `return ${lhsStr};\n`);
+				lhsStr = "(function()\n" + joinIndentedLines(lhsContext, 1) + state.indent + "end)()";
+			}
+
+			if (rhsContext.length > 0) {
+				rhsContext.push(state.indent + `return ${rhsStr};\n`);
+				rhsStr = "(function()\n" + joinIndentedLines(rhsContext, 1) + state.indent + "end)()";
+			}
+
+			if (!ts.TypeGuards.isIdentifier(lhs)) {
+				lhsStr = `[${lhsStr}]`;
+			}
+			parts[parts.length - 1] += state.indent + `${lhsStr} = ${rhsStr};\n`;
 			isInObject = true;
 		} else if (ts.TypeGuards.isMethodDeclaration(prop)) {
 			if (first) {
@@ -93,6 +101,7 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 			parts.push(expStr);
 			isInObject = false;
 		}
+
 		if (first) {
 			first = false;
 		}

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -14,6 +14,7 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 	let firstIsObj = false;
 	const parts = new Array<string>();
 	for (const prop of properties) {
+		console.log(prop.getKindName(), prop.getText());
 		if (ts.TypeGuards.isPropertyAssignment(prop) || ts.TypeGuards.isShorthandPropertyAssignment(prop)) {
 			if (first) {
 				firstIsObj = true;

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -60,14 +60,15 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 			state.enterPrecedingStatementContext();
 			let lhsStr = compileExpression(state, lhs);
 			const lhsContext = state.exitPrecedingStatementContext();
-			state.enterPrecedingStatementContext();
-			let rhsStr = compileExpression(state, rhs);
-			const rhsContext = state.exitPrecedingStatementContext();
 
 			if (lhsContext.length > 0) {
 				lhsContext.push(state.indent + `return ${lhsStr};\n`);
 				lhsStr = "(function()\n" + joinIndentedLines(lhsContext, 1) + state.indent + "end)()";
 			}
+
+			state.enterPrecedingStatementContext();
+			let rhsStr = compileExpression(state, rhs);
+			const rhsContext = state.exitPrecedingStatementContext();
 
 			if (rhsContext.length > 0) {
 				rhsContext.push(state.indent + `return ${rhsStr};\n`);

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -9,7 +9,6 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 	if (properties.length === 0) {
 		return "{}";
 	}
-
 	let isInObject = false;
 	let first = true;
 	let firstIsObj = false;

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -14,7 +14,6 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 	let firstIsObj = false;
 	const parts = new Array<string>();
 	for (const prop of properties) {
-		console.log(prop.getKindName(), prop.getText());
 		if (ts.TypeGuards.isPropertyAssignment(prop) || ts.TypeGuards.isShorthandPropertyAssignment(prop)) {
 			if (first) {
 				firstIsObj = true;

--- a/src/compiler/parenthesized.ts
+++ b/src/compiler/parenthesized.ts
@@ -1,8 +1,11 @@
 import * as ts from "ts-morph";
 import { compileExpression } from ".";
 import { CompilerState } from "../CompilerState";
+import { getNonNullUnParenthesizedExpression } from "../utility";
 
 export function compileParenthesizedExpression(state: CompilerState, node: ts.ParenthesizedExpression) {
 	const expStr = compileExpression(state, node.getExpression());
-	return `(${expStr})`;
+	return ts.TypeGuards.isExpressionStatement(getNonNullUnParenthesizedExpression(node.getParent()))
+		? expStr
+		: `(${expStr})`;
 }

--- a/src/compiler/parenthesized.ts
+++ b/src/compiler/parenthesized.ts
@@ -1,11 +1,11 @@
 import * as ts from "ts-morph";
 import { compileExpression } from ".";
 import { CompilerState } from "../CompilerState";
-import { getNonNullUnParenthesizedExpression } from "../utility";
+import { getNonNullUnParenthesizedExpressionUpwards } from "../utility";
 
 export function compileParenthesizedExpression(state: CompilerState, node: ts.ParenthesizedExpression) {
 	const expStr = compileExpression(state, node.getExpression());
-	return ts.TypeGuards.isExpressionStatement(getNonNullUnParenthesizedExpression(node.getParent()))
+	return ts.TypeGuards.isExpressionStatement(getNonNullUnParenthesizedExpressionUpwards(node.getParent()))
 		? expStr
 		: `(${expStr})`;
 }

--- a/src/compiler/security.ts
+++ b/src/compiler/security.ts
@@ -124,7 +124,7 @@ export function checkReserved(name: string, node: ts.Node, checkNamespace: boole
 			node,
 			CompilerErrorType.InvalidIdentifier,
 		);
-	} else if (name === "_exports" || name === "undefined" || name.match(/^_[0-9]+$/)) {
+	} else if (name === "_exports" || name === "undefined" || name === "TS" || name.match(/^_[0-9]+$/)) {
 		throw new CompilerError(
 			`Cannot use '${name}' as identifier (reserved for Roblox-ts)`,
 			node,

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -184,6 +184,10 @@ export function compileSpreadExpression(state: CompilerState, expression: ts.Exp
 	} else if (isIterableIterator(expType, expression)) {
 		state.usesTSLibrary = true;
 		return `TS.iterableCache(${compileExpression(state, expression)})`;
+	} else {
+		state.usesTSLibrary = true;
+		const arrName = compileExpression(state, expression);
+		return `TS.iterableCache(${arrName}[TS.Symbol_iterator](${arrName}))`;
 	}
 }
 

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -10,6 +10,7 @@ import {
 	isStringType,
 	isTupleReturnTypeCall,
 } from "../typeUtilities";
+import { joinIndentedLines } from "../utility";
 
 export function shouldCompileAsSpreadableList(elements: Array<ts.Expression>) {
 	const { length } = elements;
@@ -40,7 +41,17 @@ export function compileSpreadableList(state: CompilerState, elements: Array<ts.E
 				last = new Array<string>();
 				parts.push(last);
 			}
-			last.push(compileExpression(state, element));
+			// lhsContext.push(state.indent + `return ${lhsStr};\n`);
+			// lhsStr = "(function()\n" + joinIndentedLines(lhsContext, 1) + state.indent + "end)()";
+			state.enterPrecedingStatementContext();
+			let expStr = compileExpression(state, element);
+			const context = state.exitPrecedingStatementContext();
+
+			if (context.length > 0) {
+				context.push(state.indent + `return ${expStr};\n`);
+				expStr = "(function()\n" + joinIndentedLines(context, 1) + state.indent + "end)()";
+			}
+			last.push(expStr);
 			isInArray = true;
 		}
 	}

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -12,13 +12,10 @@ import {
 } from "../typeUtilities";
 
 export function shouldCompileAsSpreadableList(elements: Array<ts.Expression>) {
-	let foundSpread = false;
-	for (const element of elements) {
-		if (foundSpread) {
-			return true;
-		}
-		if (ts.TypeGuards.isSpreadElement(element)) {
-			foundSpread = true;
+	const { length } = elements;
+	for (let i = 0; i < length; i++) {
+		if (ts.TypeGuards.isSpreadElement(elements[i])) {
+			return i + 1 !== length;
 		}
 	}
 	return false;

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -4,6 +4,7 @@ import { CompilerState, PrecedingStatementContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import {
 	isArrayType,
+	isIterableFunction,
 	isIterableIterator,
 	isMapType,
 	isSetType,
@@ -181,13 +182,16 @@ export function compileSpreadExpression(state: CompilerState, expression: ts.Exp
 		return compileExpression(state, expression);
 	} else if (isStringType(expType)) {
 		return `string.split(${compileExpression(state, expression)}, "")`;
-	} else if (isIterableIterator(expType, expression)) {
+	} else if (isIterableFunction(expType)) {
 		state.usesTSLibrary = true;
 		return `TS.iterableCache(${compileExpression(state, expression)})`;
+	} else if (isIterableIterator(expType, expression)) {
+		state.usesTSLibrary = true;
+		return `TS.iterableCache(${compileExpression(state, expression)}.next)`;
 	} else {
 		state.usesTSLibrary = true;
 		const arrName = compileExpression(state, expression);
-		return `TS.iterableCache(${arrName}[TS.Symbol_iterator](${arrName}))`;
+		return `TS.iterableCache(${arrName}[TS.Symbol_iterator](${arrName}).next)`;
 	}
 }
 

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -184,14 +184,14 @@ export function compileSpreadExpression(state: CompilerState, expression: ts.Exp
 		return `string.split(${compileExpression(state, expression)}, "")`;
 	} else if (isIterableFunction(expType)) {
 		state.usesTSLibrary = true;
-		return `TS.iterableCache(${compileExpression(state, expression)})`;
+		return `TS.iterableFunctionCache(${compileExpression(state, expression)})`;
 	} else if (isIterableIterator(expType, expression)) {
 		state.usesTSLibrary = true;
-		return `TS.iterableCache(${compileExpression(state, expression)}.next)`;
+		return `TS.iterableCache(${compileExpression(state, expression)})`;
 	} else {
 		state.usesTSLibrary = true;
 		const arrName = compileExpression(state, expression);
-		return `TS.iterableCache(${arrName}[TS.Symbol_iterator](${arrName}).next)`;
+		return `TS.iterableCache(${arrName}[TS.Symbol_iterator](${arrName}))`;
 	}
 }
 

--- a/src/compiler/statement.ts
+++ b/src/compiler/statement.ts
@@ -52,7 +52,7 @@ export function compileStatement(state: CompilerState, node: ts.Statement): stri
 	} else if (ts.TypeGuards.isBreakStatement(node)) {
 		return compileBreakStatement(state, node);
 	} else if (ts.TypeGuards.isExpressionStatement(node)) {
-		return compileExpressionStatement(state, node); // HERE
+		return compileExpressionStatement(state, node);
 	} else if (ts.TypeGuards.isContinueStatement(node)) {
 		return compileContinueStatement(state, node);
 	} else if (ts.TypeGuards.isForInStatement(node)) {

--- a/src/compiler/statement.ts
+++ b/src/compiler/statement.ts
@@ -52,7 +52,7 @@ export function compileStatement(state: CompilerState, node: ts.Statement): stri
 	} else if (ts.TypeGuards.isBreakStatement(node)) {
 		return compileBreakStatement(state, node);
 	} else if (ts.TypeGuards.isExpressionStatement(node)) {
-		return compileExpressionStatement(state, node);
+		return compileExpressionStatement(state, node); // HERE
 	} else if (ts.TypeGuards.isContinueStatement(node)) {
 		return compileContinueStatement(state, node);
 	} else if (ts.TypeGuards.isForInStatement(node)) {

--- a/src/compiler/switch.ts
+++ b/src/compiler/switch.ts
@@ -8,9 +8,16 @@ export function compileSwitchStatement(state: CompilerState, node: ts.SwitchStat
 	let expStr: string;
 
 	const expression = node.getExpression();
+	state.enterPrecedingStatementContext();
 	const rawExpStr = compileExpression(state, expression);
+	const hasStatements = state.currentPrecedingStatementContextHasStatements(expression);
+	const expressionContext = state.exitPrecedingStatementContext();
 
-	if (ts.TypeGuards.isIdentifier(expression)) {
+	if (hasStatements) {
+		preResult += expressionContext.join("");
+	}
+
+	if (ts.TypeGuards.isIdentifier(expression) || (hasStatements && expressionContext.pushed)) {
 		expStr = rawExpStr;
 	} else {
 		expStr = state.getNewId();

--- a/src/compiler/switch.ts
+++ b/src/compiler/switch.ts
@@ -17,7 +17,7 @@ export function compileSwitchStatement(state: CompilerState, node: ts.SwitchStat
 		preResult += expressionContext.join("");
 	}
 
-	if (hasStatements && expressionContext.pushed) {
+	if (hasStatements && expressionContext.isPushed) {
 		expStr = rawExpStr;
 	} else {
 		expStr = state.getNewId();

--- a/src/compiler/switch.ts
+++ b/src/compiler/switch.ts
@@ -10,8 +10,8 @@ export function compileSwitchStatement(state: CompilerState, node: ts.SwitchStat
 	const expression = node.getExpression();
 	state.enterPrecedingStatementContext();
 	const rawExpStr = compileExpression(state, expression);
-	const hasStatements = state.currentPrecedingStatementContextHasStatements(expression);
 	const expressionContext = state.exitPrecedingStatementContext();
+	const hasStatements = expressionContext.length > 0;
 
 	if (hasStatements) {
 		preResult += expressionContext.join("");

--- a/src/compiler/switch.ts
+++ b/src/compiler/switch.ts
@@ -17,7 +17,7 @@ export function compileSwitchStatement(state: CompilerState, node: ts.SwitchStat
 		preResult += expressionContext.join("");
 	}
 
-	if (ts.TypeGuards.isIdentifier(expression) || (hasStatements && expressionContext.pushed)) {
+	if (hasStatements && expressionContext.pushed) {
 		expStr = rawExpStr;
 	} else {
 		expStr = state.getNewId();
@@ -45,8 +45,10 @@ export function compileSwitchStatement(state: CompilerState, node: ts.SwitchStat
 		let isNonDefault = false;
 		if (ts.TypeGuards.isCaseClause(clause)) {
 			isNonDefault = true;
+			state.enterPrecedingStatementContext();
 			const clauseExpStr = compileExpression(state, clause.getExpression());
 			const fallThroughVarOr = previousCaseFallsThrough ? `${fallThroughVar!} or ` : "";
+			result += state.exitPrecedingStatementContextAndJoin();
 			result += state.indent + `if ${fallThroughVarOr}${expStr} == ( ${clauseExpStr} ) then\n`;
 			state.pushIndent();
 		} else if (i !== lastClauseIndex) {

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -109,7 +109,7 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 					state.indent + `${declaration.needsLocalizing ? "local " : ""}${declaration.set} = ${expStr};\n`,
 				);
 
-				id = declaration.isIdentifier ? declaration.set : expStr;
+				id = expData.isIdentifier ? expStr : declaration.set;
 				state.declarationContext.delete(node);
 			} else {
 				id = state.pushPrecedingStatementToNextId(node, expStr);

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -47,9 +47,10 @@ export function compilePrefixUnaryExpression(state: CompilerState, node: ts.Pref
 					getIncrementString(opKind, expStr, node, ""),
 					declaration => declaration.isIdentifier,
 				);
-
+				const context = state.getCurrentPrecedingStatementContext(node);
+				const isPushed = context.isPushed;
 				state.pushPrecedingStatements(node, state.indent + `${expStr} = ${id};\n`);
-				state.getCurrentPrecedingStatementContext(node).isPushed = true;
+				context.isPushed = isPushed;
 				return id;
 			} else {
 				const incrStr = getIncrementString(opKind, expStr, node, expStr);

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -2,7 +2,7 @@ import * as ts from "ts-morph";
 import { compileExpression } from ".";
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
-import { getWritableOperandName, isExpressionDefinedInExportLet } from "./indexed";
+import { getWritableOperandName, isIdentifierDefinedInExportLet } from "./indexed";
 
 function isUnaryExpressionNonStatement(
 	parent: ts.Node<ts.ts.Node>,
@@ -39,12 +39,10 @@ export function compilePrefixUnaryExpression(state: CompilerState, node: ts.Pref
 		const expStr = getWritableOperandName(state, operand);
 
 		if (isNonStatement) {
-			if (!ts.TypeGuards.isIdentifier(operand) || isExpressionDefinedInExportLet(state, operand)) {
+			if (!ts.TypeGuards.isIdentifier(operand) || isIdentifierDefinedInExportLet(state, operand)) {
 				const id = state.getNewId();
-				state.pushPrecedingStatements(
-					node,
-					state.indent + `${getIncrementString(opKind, expStr, node, `local ${id}`)};\n`,
-				);
+				const incrStr = getIncrementString(opKind, expStr, node, `local ${id}`);
+				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
 				state.pushPrecedingStatements(node, state.indent + `${expStr} = ${id};\n`);
 				state.getCurrentPrecedingStatementContext(node).isPushed = true;
 				return id;

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -92,14 +92,18 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 		if (isNonStatement) {
 			const declaration = state.declarationContext.get(node);
 			let id: string;
-			if (declaration && (declaration.isIdentifier || expData.isIdentifier) && declaration.set !== "return") {
+			if (
+				declaration &&
+				(declaration.isIdentifier || expData.isIdentifier) &&
+				declaration.set !== "return" &&
+				declaration.set !== expStr
+			) {
 				state.declarationContext.delete(node);
 				state.pushPrecedingStatements(
 					node,
 					state.indent + `${declaration.needsLocalizing ? "local " : ""}${declaration.set} = ${expStr};\n`,
 				);
-
-				// due to this optimization here, this shouldn't be shortened
+				// due to this optimization here, this shouldn't be shortened with `state.pushToDeclarationOrNewId
 				id = expData.isIdentifier ? expStr : declaration.set;
 				const incrStr = getIncrementString(opKind, id, node, expStr);
 				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -39,7 +39,7 @@ export function compilePrefixUnaryExpression(state: CompilerState, node: ts.Pref
 		const expStr = getWritableOperandName(state, operand);
 
 		if (isNonStatement) {
-			if (!ts.TypeGuards.isIdentifier(node) || isExpressionDefinedInExportLet(state, node)) {
+			if (!ts.TypeGuards.isIdentifier(operand) || isExpressionDefinedInExportLet(state, operand)) {
 				const id = state.getNewId();
 				state.pushPrecedingStatements(
 					node,

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -98,9 +98,6 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 		const { expStr } = expData;
 
 		if (isNonStatement) {
-			console.log([...state.declarationContext.keys()].map(key => key.getKindName() + " " + key.getText()));
-			console.log(1, node.getKindName(), node.getText(), state.declarationContext.get(node));
-
 			const declaration = state.declarationContext.get(node);
 			let id: string;
 			if (declaration && (declaration.isIdentifier || expData.isIdentifier) && declaration.set !== "return") {

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -18,7 +18,7 @@ function getUnaryExpressionString(state: CompilerState, operand: ts.UnaryExpress
 		const expression = operand.getExpression();
 		const opExpStr = compileExpression(state, expression);
 		const propertyStr = operand.getName();
-		const id = state.pushPrecedingStatementToNextId(opExpStr);
+		const id = state.pushPrecedingStatementToNextId(operand, opExpStr);
 		return `${id}.${propertyStr}`;
 	} else {
 		return compileExpression(state, operand);
@@ -47,11 +47,11 @@ export function compilePrefixUnaryExpression(state: CompilerState, node: ts.Pref
 		const incrStr = getIncrementString(opKind, expStr, node);
 
 		if (isNonStatement) {
-			state.pushPrecedingStatements(state.indent + incrStr + ";\n");
-			state.pushPrecedingStatements(...state.exitPrecedingStatementContext());
+			state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
+			state.pushPrecedingStatements(node, ...state.exitPrecedingStatementContext());
 			return expStr;
 		} else {
-			state.pushPrecedingStatements(incrStr);
+			state.pushPrecedingStatements(node, incrStr);
 			return state.exitPrecedingStatementContextAndJoin();
 		}
 	} else {
@@ -86,12 +86,12 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 		const incrStr = getIncrementString(opKind, expStr, node);
 
 		if (isNonStatement) {
-			const id = state.pushPrecedingStatementToNextId(expStr);
-			state.pushPrecedingStatements(state.indent + incrStr + ";\n");
-			state.pushPrecedingStatements(...state.exitPrecedingStatementContext());
+			const id = state.pushPrecedingStatementToNextId(node, expStr);
+			state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
+			state.pushPrecedingStatements(node, ...state.exitPrecedingStatementContext());
 			return id;
 		} else {
-			state.pushPrecedingStatements(incrStr);
+			state.pushPrecedingStatements(node, incrStr);
 			return state.exitPrecedingStatementContextAndJoin();
 		}
 	} else {

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -103,7 +103,7 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 					node,
 					state.indent + `${declaration.needsLocalizing ? "local " : ""}${declaration.set} = ${expStr};\n`,
 				);
-				// due to this optimization here, this shouldn't be shortened with `state.pushToDeclarationOrNewId
+				// due to this optimization here, this shouldn't be shortened with `state.pushToDeclarationOrNewId`
 				id = expData.isIdentifier ? expStr : declaration.set;
 				const incrStr = getIncrementString(opKind, id, node, expStr);
 				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -101,28 +101,22 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 			const declaration = state.declarationContext.get(node);
 			let id: string;
 			if (declaration && (declaration.isIdentifier || expData.isIdentifier) && declaration.set !== "return") {
+				state.declarationContext.delete(node);
 				state.pushPrecedingStatements(
 					node,
 					state.indent + `${declaration.needsLocalizing ? "local " : ""}${declaration.set} = ${expStr};\n`,
 				);
 
-				id = expData.isIdentifier
-					? declaration.isIdentifier
-						? expStr
-						: state.pushPrecedingStatementToReuseableId(node, expStr)
-					: declaration.set;
-				state.declarationContext.delete(node);
-
+				id = expData.isIdentifier ? expStr : declaration.set;
 				const incrStr = getIncrementString(opKind, id, node, expStr);
 				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
-				state.getCurrentPrecedingStatementContext(node).isPushed =
-					expData.isIdentifier && !declaration.isIdentifier;
 			} else {
 				id = state.pushPrecedingStatementToReuseableId(node, expStr);
 				const incrStr = getIncrementString(opKind, id, node, expStr);
 				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
 				state.getCurrentPrecedingStatementContext(node).isPushed = true;
 			}
+
 			return id;
 		} else {
 			return getIncrementString(opKind, expStr, node);

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -39,7 +39,7 @@ export function compilePrefixUnaryExpression(state: CompilerState, node: ts.Pref
 		const expStr = getWritableOperandName(state, operand);
 
 		if (isNonStatement) {
-			if (!ts.TypeGuards.isIdentifier(operand) || isIdentifierDefinedInExportLet(state, operand)) {
+			if (!ts.TypeGuards.isIdentifier(operand) || isIdentifierDefinedInExportLet(operand)) {
 				const id = state.getNewId();
 				const incrStr = getIncrementString(opKind, expStr, node, `local ${id}`);
 				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -89,6 +89,7 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 			const id = state.pushPrecedingStatementToNextId(node, expStr);
 			state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
 			state.pushPrecedingStatements(node, ...state.exitPrecedingStatementContext());
+			state.setCurrentContextAsPushed(node);
 			return id;
 		} else {
 			state.pushPrecedingStatements(node, incrStr);

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -18,11 +18,6 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 		decKind = parent.getDeclarationKind();
 	}
 
-	let parentName = "";
-	if (isExported) {
-		parentName = state.getExportContextName(grandParent);
-	}
-
 	if (ts.TypeGuards.isArrayBindingPattern(lhs)) {
 		const isFlatBinding = lhs
 			.getElements()
@@ -64,6 +59,7 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 		if (rhs) {
 			const value = compileExpression(state, rhs);
 			if (isExported && decKind === ts.VariableDeclarationKind.Let) {
+				const parentName = state.getExportContextName(grandParent);
 				result += state.indent + `${parentName}.${name} = ${value};\n`;
 			} else {
 				if (isExported && ts.TypeGuards.isVariableStatement(grandParent)) {
@@ -124,11 +120,9 @@ export function compileVariableDeclarationList(state: CompilerState, node: ts.Va
 		);
 	}
 
-	let result = "";
-	for (const declaration of node.getDeclarations()) {
-		result += compileVariableDeclaration(state, declaration);
-	}
-	return result;
+	return node
+		.getDeclarations()
+		.reduce((result, declaration) => result + compileVariableDeclaration(state, declaration), "");
 }
 
 export function compileVariableStatement(state: CompilerState, node: ts.VariableStatement) {

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -57,6 +57,7 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 		const name = lhs.getText();
 		checkReserved(name, lhs, true);
 		if (rhs) {
+			state.declarationContext.set(rhs, `${name} = `);
 			const value = compileExpression(state, rhs);
 			if (isExported && decKind === ts.VariableDeclarationKind.Let) {
 				const parentName = state.getExportContextName(grandParent);

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -104,14 +104,14 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 		const values = new Array<string>();
 		const preStatements = new Array<string>();
 		const postStatements = new Array<string>();
-		if (ts.TypeGuards.isIdentifier(rhs)) {
-			getBindingData(state, names, values, preStatements, postStatements, lhs, compileExpression(state, rhs));
-		} else {
-			const rootId = state.getNewId();
-			const rhsStr = compileExpression(state, rhs);
-			preStatements.push(`local ${rootId} = ${rhsStr};`);
-			getBindingData(state, names, values, preStatements, postStatements, lhs, rootId);
+		let rhsStr = compileExpression(state, rhs);
+
+		if (!ts.TypeGuards.isIdentifier(rhs) && ts.TypeGuards.isThisExpression(rhs)) {
+			rhsStr = state.getNewId();
+			preStatements.push(`local ${rhsStr} = ${rhsStr};`);
 		}
+
+		getBindingData(state, names, values, preStatements, postStatements, lhs, rhsStr);
 		preStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
 		if (values.length > 0) {
 			if (isExported && decKind === ts.VariableDeclarationKind.Let) {

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -106,9 +106,10 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 		const postStatements = new Array<string>();
 		let rhsStr = compileExpression(state, rhs);
 
-		if (!ts.TypeGuards.isIdentifier(rhs) && ts.TypeGuards.isThisExpression(rhs)) {
-			rhsStr = state.getNewId();
-			preStatements.push(`local ${rhsStr} = ${rhsStr};`);
+		if (!ts.TypeGuards.isIdentifier(rhs) && !ts.TypeGuards.isThisExpression(rhs)) {
+			const id = state.getNewId();
+			preStatements.push(`local ${id} = ${rhsStr};`);
+			rhsStr = id;
 		}
 
 		getBindingData(state, names, values, preStatements, postStatements, lhs, rhsStr);

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -3,12 +3,12 @@ import { checkReserved, compileCallExpression, compileExpression, concatNamesAnd
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { isTupleReturnTypeCall, shouldHoist } from "../typeUtilities";
-import { getNonNullExpression } from "../utility";
+import { getNonNullExpressionDownwards } from "../utility";
 
 export function compileVariableDeclaration(state: CompilerState, node: ts.VariableDeclaration) {
 	state.enterPrecedingStatementContext();
 	const lhs = node.getNameNode();
-	const rhs = getNonNullExpression(node.getInitializer());
+	const rhs = getNonNullExpressionDownwards(node.getInitializer());
 
 	const parent = node.getParent();
 	const grandParent = parent.getParent();

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -45,14 +45,14 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 			if (isExported && decKind === ts.VariableDeclarationKind.Let) {
 				let returnValue: string | undefined;
 				concatNamesAndValues(state, names, values, false, str => (returnValue = str));
-				return returnValue || "";
+				return state.exitPrecedingStatementContextAndJoin() + returnValue || "";
 			} else {
 				if (isExported && ts.TypeGuards.isVariableStatement(grandParent)) {
 					names.forEach(name => state.pushExport(name, grandParent));
 				}
 				let returnValue: string | undefined;
 				concatNamesAndValues(state, names, values, true, str => (returnValue = str));
-				return returnValue || "";
+				return state.exitPrecedingStatementContextAndJoin() + returnValue || "";
 			}
 		}
 	}

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -3,11 +3,12 @@ import { checkReserved, compileCallExpression, compileExpression, concatNamesAnd
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { isTupleReturnTypeCall, shouldHoist } from "../typeUtilities";
+import { getNonNullExpression } from "../utility";
 
 export function compileVariableDeclaration(state: CompilerState, node: ts.VariableDeclaration) {
 	state.enterPrecedingStatementContext();
 	const lhs = node.getNameNode();
-	const rhs = node.getInitializer();
+	const rhs = getNonNullExpression(node.getInitializer());
 
 	const parent = node.getParent();
 	const grandParent = parent.getParent();
@@ -60,8 +61,8 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 			if (isExported && decKind === ts.VariableDeclarationKind.Let) {
 				const parentName = state.getExportContextName(grandParent);
 				state.declarationContext.set(rhs, {
-					set: `${parentName}.${name}`,
 					isIdentifier: false,
+					set: `${parentName}.${name}`,
 				});
 				const value = compileExpression(state, rhs);
 				if (state.declarationContext.delete(rhs)) {

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -5,6 +5,7 @@ import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { isTupleReturnTypeCall, shouldHoist } from "../typeUtilities";
 
 export function compileVariableDeclaration(state: CompilerState, node: ts.VariableDeclaration) {
+	state.enterPrecedingStatementContext();
 	const lhs = node.getNameNode();
 	const rhs = node.getInitializer();
 
@@ -110,7 +111,7 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 		postStatements.forEach(statementStr => (result += state.indent + statementStr + "\n"));
 	}
 
-	return result;
+	return state.exitPrecedingStatementContextAndJoin() + result;
 }
 
 export function compileVariableDeclarationList(state: CompilerState, node: ts.VariableDeclarationList) {

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -67,6 +67,7 @@ export enum CompilerErrorType {
 	NonStringThrow,
 	TryReturn,
 	BadSwitchDefaultPosition,
+	BadEnum,
 }
 
 export class CompilerError extends Error {

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -67,6 +67,7 @@ export enum CompilerErrorType {
 	TryReturn,
 	BadSwitchDefaultPosition,
 	BadEnum,
+	BadLuaTupleStatement,
 }
 
 export class CompilerError extends Error {

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -50,7 +50,6 @@ export enum CompilerErrorType {
 	InvalidIdentifier,
 	RobloxTSReservedIdentifier,
 	BadContext,
-	ClassyLoop,
 	MixedMethodCall,
 	InvalidService,
 	ReservedNamespace,

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -1,5 +1,5 @@
 import * as ts from "ts-morph";
-import { CompilerDirective, getCompilerDirective } from "./compiler";
+import { CompilerDirective, getCompilerDirective, isIdentifierDefinedInLet } from "./compiler";
 import { PrecedingStatementContext } from "./CompilerState";
 
 export const RBX_SERVICES: Array<string> = [
@@ -299,7 +299,12 @@ export function shouldPushToPrecedingStatement(
 	argStr: string,
 	argContext: PrecedingStatementContext,
 ) {
-	return !argContext.isPushed && !isNumericLiteralExpression(arg);
+	return (
+		!argContext.isPushed &&
+		!isNumericLiteralExpression(arg) &&
+		!ts.TypeGuards.isStringLiteral(arg) &&
+		(!ts.TypeGuards.isIdentifier(arg) || isIdentifierDefinedInLet(arg))
+	);
 }
 
 /** Returns whether or not the given expression is a Binary expression containing only numeric literals */

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -1,5 +1,5 @@
 import * as ts from "ts-morph";
-import { CompilerDirective, getCompilerDirective, isIdentifierDefinedInLet } from "./compiler";
+import { CompilerDirective, getCompilerDirective, isIdentifierDefinedInConst } from "./compiler";
 import { PrecedingStatementContext } from "./CompilerState";
 
 export const RBX_SERVICES: Array<string> = [
@@ -307,7 +307,7 @@ export function shouldPushToPrecedingStatement(
 		!argContext.isPushed &&
 		!isNumericLiteralExpression(arg) &&
 		!ts.TypeGuards.isStringLiteral(arg) &&
-		(!ts.TypeGuards.isIdentifier(arg) || isIdentifierDefinedInLet(arg))
+		(!ts.TypeGuards.isIdentifier(arg) || !isIdentifierDefinedInConst(arg))
 	);
 }
 

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -159,6 +159,10 @@ export function isEnumType(type: ts.Type) {
 	});
 }
 
+export function isObjectType(type: ts.Type) {
+	return typeConstraint(type, t => t.isObject());
+}
+
 export function isIterableIterator(type: ts.Type, node: ts.Node) {
 	return typeConstraint(type, t => {
 		const symbol = t.getSymbol();
@@ -177,12 +181,20 @@ export function getCompilerDirectiveWithConstraint(
 	});
 }
 
+export function isStringMethodType(type: ts.Type) {
+	return getCompilerDirectiveWithConstraint(type, CompilerDirective.String);
+}
+
 export function isArrayType(type: ts.Type) {
 	return getCompilerDirectiveWithConstraint(type, CompilerDirective.Array, t => t.isArray() || t.isTuple());
 }
 
-export function isStringMethodType(type: ts.Type) {
-	return getCompilerDirectiveWithConstraint(type, CompilerDirective.String);
+export function isMapType(type: ts.Type) {
+	return getCompilerDirectiveWithConstraint(type, CompilerDirective.Map);
+}
+
+export function isSetType(type: ts.Type) {
+	return getCompilerDirectiveWithConstraint(type, CompilerDirective.Set);
 }
 
 export function isMethodType(type: ts.Type) {
@@ -199,14 +211,6 @@ export function isMapMethodType(type: ts.Type) {
 
 export function isSetMethodType(type: ts.Type) {
 	return isMethodType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.Set);
-}
-
-export function isMapType(type: ts.Type) {
-	return getCompilerDirectiveWithConstraint(type, CompilerDirective.Map);
-}
-
-export function isSetType(type: ts.Type) {
-	return getCompilerDirectiveWithConstraint(type, CompilerDirective.Set);
 }
 
 const LUA_TUPLE_REGEX = /^LuaTuple<[^]+>$/;

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -292,3 +292,13 @@ export function shouldHoist(ancestor: ts.Node, id: ts.Identifier) {
 
 	return false;
 }
+
+/** Returns whether or not the given expression is a Binary expression containing only numeric literals */
+export function isNumericLiteralExpression(node: ts.Expression): boolean {
+	return (
+		ts.TypeGuards.isNumericLiteral(node) ||
+		(ts.TypeGuards.isBinaryExpression(node) &&
+			isNumericLiteralExpression(node.getLeft()) &&
+			isNumericLiteralExpression(node.getRight()))
+	);
+}

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -1,5 +1,6 @@
 import * as ts from "ts-morph";
 import { CompilerDirective, getCompilerDirective } from "./compiler";
+import { PrecedingStatementContext } from "./CompilerState";
 
 export const RBX_SERVICES: Array<string> = [
 	"AssetService",
@@ -291,6 +292,14 @@ export function shouldHoist(ancestor: ts.Node, id: ts.Identifier) {
 	}
 
 	return false;
+}
+
+export function shouldPushToPrecedingStatement(
+	arg: ts.Expression,
+	argStr: string,
+	argContext: PrecedingStatementContext,
+) {
+	return !argContext.pushed && !isNumericLiteralExpression(arg);
 }
 
 /** Returns whether or not the given expression is a Binary expression containing only numeric literals */

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -132,6 +132,16 @@ export function typeConstraint(type: ts.Type, cb: (type: ts.Type) => boolean): b
 	}
 }
 
+export function strictTypeConstraint(type: ts.Type, cb: (type: ts.Type) => boolean): boolean {
+	if (type.isUnion()) {
+		return type.getUnionTypes().every(t => typeConstraint(t, cb));
+	} else if (type.isIntersection()) {
+		return type.getIntersectionTypes().every(t => typeConstraint(t, cb));
+	} else {
+		return cb(type);
+	}
+}
+
 export function isAnyType(type: ts.Type) {
 	return type.getText() === "any";
 }

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -134,9 +134,9 @@ export function typeConstraint(type: ts.Type, cb: (type: ts.Type) => boolean): b
 
 export function strictTypeConstraint(type: ts.Type, cb: (type: ts.Type) => boolean): boolean {
 	if (type.isUnion()) {
-		return type.getUnionTypes().every(t => typeConstraint(t, cb));
+		return type.getUnionTypes().every(t => strictTypeConstraint(t, cb));
 	} else if (type.isIntersection()) {
-		return type.getIntersectionTypes().every(t => typeConstraint(t, cb));
+		return type.getIntersectionTypes().every(t => strictTypeConstraint(t, cb));
 	} else {
 		return cb(type);
 	}
@@ -177,6 +177,20 @@ export function isIterableIterator(type: ts.Type, node: ts.Node) {
 	return typeConstraint(type, t => {
 		const symbol = t.getSymbol();
 		return symbol ? symbol.getEscapedName() === "IterableIterator" : false;
+	});
+}
+
+export function isIterableFunction(type: ts.Type) {
+	let i = 0;
+
+	return typeConstraint(type, t => {
+		if (i++ % 2 === 0) {
+			const symbol = t.getAliasSymbol();
+			return symbol ? symbol.getEscapedName() === "Iterable" : false;
+		} else {
+			const callSignatures = t.getCallSignatures();
+			return callSignatures ? callSignatures.length > 0 : false;
+		}
 	});
 }
 

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -181,17 +181,8 @@ export function isIterableIterator(type: ts.Type, node: ts.Node) {
 }
 
 export function isIterableFunction(type: ts.Type) {
-	let i = 0;
-
-	return typeConstraint(type, t => {
-		if (i++ % 2 === 0) {
-			const symbol = t.getAliasSymbol();
-			return symbol ? symbol.getEscapedName() === "Iterable" : false;
-		} else {
-			const callSignatures = t.getCallSignatures();
-			return callSignatures ? callSignatures.length > 0 : false;
-		}
-	});
+	const symbol = type.getAliasSymbol();
+	return symbol ? symbol.getEscapedName() === "IterableFunction" : false;
 }
 
 export function getCompilerDirectiveWithConstraint(

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -299,7 +299,7 @@ export function shouldPushToPrecedingStatement(
 	argStr: string,
 	argContext: PrecedingStatementContext,
 ) {
-	return !argContext.pushed && !isNumericLiteralExpression(arg);
+	return !argContext.isPushed && !isNumericLiteralExpression(arg);
 }
 
 /** Returns whether or not the given expression is a Binary expression containing only numeric literals */

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -186,9 +186,9 @@ export function isIdentifierWhoseDefinitionMatchesNode(
 }
 
 /** Skips over Null expressions */
-export function getNonNullExpression<T extends ts.Node>(exp: T): T;
-export function getNonNullExpression<T extends ts.Node>(exp?: T): T | undefined;
-export function getNonNullExpression<T extends ts.Node>(exp?: T) {
+export function getNonNullExpressionDownwards<T extends ts.Node>(exp: T): T;
+export function getNonNullExpressionDownwards<T extends ts.Node>(exp?: T): T | undefined;
+export function getNonNullExpressionDownwards<T extends ts.Node>(exp?: T) {
 	if (exp) {
 		while (ts.TypeGuards.isNonNullExpression(exp)) {
 			exp = (exp.getExpression() as unknown) as T;
@@ -199,12 +199,37 @@ export function getNonNullExpression<T extends ts.Node>(exp?: T) {
 }
 
 /** Skips over Null/Parenthesis expressions */
-export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp: T): T;
-export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp?: T): T | undefined;
-export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp?: T) {
+export function getNonNullUnParenthesizedExpressionDownwards<T extends ts.Node>(exp: T): T;
+export function getNonNullUnParenthesizedExpressionDownwards<T extends ts.Node>(exp?: T): T | undefined;
+export function getNonNullUnParenthesizedExpressionDownwards<T extends ts.Node>(exp?: T) {
 	if (exp) {
 		while (ts.TypeGuards.isParenthesizedExpression(exp) || ts.TypeGuards.isNonNullExpression(exp)) {
 			exp = (exp.getExpression() as unknown) as T;
+		}
+		return exp;
+	}
+}
+
+/** Skips over Null expressions */
+export function getNonNullExpressionUpwards<T extends ts.Node>(exp: T): T;
+export function getNonNullExpressionUpwards<T extends ts.Node>(exp?: T): T | undefined;
+export function getNonNullExpressionUpwards<T extends ts.Node>(exp?: T) {
+	if (exp) {
+		while (ts.TypeGuards.isNonNullExpression(exp)) {
+			exp = (exp.getParent() as unknown) as T;
+		}
+
+		return exp;
+	}
+}
+
+/** Skips over Null/Parenthesis expressions */
+export function getNonNullUnParenthesizedExpressionUpwards<T extends ts.Node>(exp: T): T;
+export function getNonNullUnParenthesizedExpressionUpwards<T extends ts.Node>(exp?: T): T | undefined;
+export function getNonNullUnParenthesizedExpressionUpwards<T extends ts.Node>(exp?: T) {
+	if (exp) {
+		while (ts.TypeGuards.isParenthesizedExpression(exp) || ts.TypeGuards.isNonNullExpression(exp)) {
+			exp = (exp.getParent() as unknown) as T;
 		}
 		return exp;
 	}

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -47,15 +47,17 @@ export function removeBalancedParenthesisFromStringBorders(str: string) {
 	return index === 0 ? str : str.slice(index, -index);
 }
 
-// console.log(removeBalancedParenthesisFromStringBorders("x"));
-// console.log(removeBalancedParenthesisFromStringBorders("(x)"));
-// console.log(removeBalancedParenthesisFromStringBorders("((x))"));
-// console.log(removeBalancedParenthesisFromStringBorders("(x + 5)"));
-// console.log(removeBalancedParenthesisFromStringBorders("(x) + 5"));
-// console.log(removeBalancedParenthesisFromStringBorders("5 + (x)"));
-// console.log(removeBalancedParenthesisFromStringBorders("((x) + 5)"));
-// console.log(removeBalancedParenthesisFromStringBorders("(5 + (x))"));
-// console.log(removeBalancedParenthesisFromStringBorders("()()"));
+// console.log(`"${removeBalancedParenthesisFromStringBorders("")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("x")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("(x)")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("((x))")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("(x + 5)")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("(x) + 5")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("5 + (x)")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("((x) + 5)")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("(5 + (x))")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("()()")}"`);
+// console.log(`"${removeBalancedParenthesisFromStringBorders("(()())")}"`);
 
 export function joinIndentedLines(lines: Array<string>, numTabs: number = 0) {
 	if (lines.length > 0) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -43,7 +43,6 @@ export function removeBalancedParenthesisFromStringBorders(str: string) {
 			inOpenParens = parenDepth;
 		}
 	}
-
 	const index = Math.min(inOpenParens || 0, outCloseParens || 0);
 	return index === 0 ? str : str.slice(index, -index);
 }
@@ -184,4 +183,21 @@ export function isIdentifierWhoseDefinitionMatchesNode(
 		}
 	}
 	return false;
+}
+
+/** Skips over Null expressions */
+export function getNonNullExpression<T extends ts.Node>(exp: T): T {
+	while (ts.TypeGuards.isNonNullExpression(exp)) {
+		exp = (exp.getExpression() as unknown) as T;
+	}
+
+	return exp;
+}
+
+/** Skips over Null/Parenthesis expressions */
+export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp: T): T {
+	while (ts.TypeGuards.isParenthesizedExpression(exp) || ts.TypeGuards.isNonNullExpression(exp)) {
+		exp = (exp.getExpression() as unknown) as T;
+	}
+	return exp;
 }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -201,3 +201,11 @@ export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp: T): 
 	}
 	return exp;
 }
+
+export function makeSetStatement(varToSet: string, value: string) {
+	if (varToSet === "return") {
+		return `return ${value}`;
+	} else {
+		return `${varToSet} = ${value}`;
+	}
+}

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -62,10 +62,7 @@ export function removeBalancedParenthesisFromStringBorders(str: string) {
 export function joinIndentedLines(lines: Array<string>, numTabs: number = 0) {
 	if (lines.length > 0) {
 		const sep = "\t".repeat(numTabs);
-		return lines.join("").replace(/.+/g, a => {
-			console.log(`"${a}"`);
-			return sep + a;
-		});
+		return lines.join("").replace(/.+/g, a => sep + a);
 	} else {
 		return "";
 	}

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -62,7 +62,10 @@ export function removeBalancedParenthesisFromStringBorders(str: string) {
 export function joinIndentedLines(lines: Array<string>, numTabs: number = 0) {
 	if (lines.length > 0) {
 		const sep = "\t".repeat(numTabs);
-		return sep + lines.join(sep);
+		return lines.join("").replace(/.+/g, a => {
+			console.log(`"${a}"`);
+			return sep + a;
+		});
 	} else {
 		return "";
 	}

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -186,20 +186,28 @@ export function isIdentifierWhoseDefinitionMatchesNode(
 }
 
 /** Skips over Null expressions */
-export function getNonNullExpression<T extends ts.Node>(exp: T): T {
-	while (ts.TypeGuards.isNonNullExpression(exp)) {
-		exp = (exp.getExpression() as unknown) as T;
-	}
+export function getNonNullExpression<T extends ts.Node>(exp: T): T;
+export function getNonNullExpression<T extends ts.Node>(exp?: T): T | undefined;
+export function getNonNullExpression<T extends ts.Node>(exp?: T) {
+	if (exp) {
+		while (ts.TypeGuards.isNonNullExpression(exp)) {
+			exp = (exp.getExpression() as unknown) as T;
+		}
 
-	return exp;
+		return exp;
+	}
 }
 
 /** Skips over Null/Parenthesis expressions */
-export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp: T): T {
-	while (ts.TypeGuards.isParenthesizedExpression(exp) || ts.TypeGuards.isNonNullExpression(exp)) {
-		exp = (exp.getExpression() as unknown) as T;
+export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp: T): T;
+export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp?: T): T | undefined;
+export function getNonNullUnParenthesizedExpression<T extends ts.Node>(exp?: T) {
+	if (exp) {
+		while (ts.TypeGuards.isParenthesizedExpression(exp) || ts.TypeGuards.isNonNullExpression(exp)) {
+			exp = (exp.getExpression() as unknown) as T;
+		}
+		return exp;
 	}
-	return exp;
 }
 
 export function makeSetStatement(varToSet: string, value: string) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -15,6 +15,58 @@ export function safeLuaIndex(parent: string, child: string) {
 	}
 }
 
+export function removeBalancedParenthesisFromStringBorders(str: string) {
+	let parenDepth = 0;
+	let inOpenParens: number | undefined;
+	let outCloseParens: number | undefined;
+
+	for (const char of str) {
+		if (char === ")") {
+			if (outCloseParens === undefined) {
+				outCloseParens = parenDepth;
+			}
+
+			parenDepth--;
+		} else if (outCloseParens !== undefined) {
+			outCloseParens = undefined;
+
+			if (inOpenParens !== undefined) {
+				if (parenDepth < inOpenParens) {
+					inOpenParens = parenDepth;
+				}
+			}
+		}
+
+		if (char === "(") {
+			parenDepth++;
+		} else if (inOpenParens === undefined) {
+			inOpenParens = parenDepth;
+		}
+	}
+
+	const index = Math.min(inOpenParens || 0, outCloseParens || 0);
+	return index === 0 ? str : str.slice(index, -index);
+}
+
+// console.log(removeBalancedParenthesisFromStringBorders("x"));
+// console.log(removeBalancedParenthesisFromStringBorders("(x)"));
+// console.log(removeBalancedParenthesisFromStringBorders("((x))"));
+// console.log(removeBalancedParenthesisFromStringBorders("(x + 5)"));
+// console.log(removeBalancedParenthesisFromStringBorders("(x) + 5"));
+// console.log(removeBalancedParenthesisFromStringBorders("5 + (x)"));
+// console.log(removeBalancedParenthesisFromStringBorders("((x) + 5)"));
+// console.log(removeBalancedParenthesisFromStringBorders("(5 + (x))"));
+// console.log(removeBalancedParenthesisFromStringBorders("()()"));
+
+export function joinIndentedLines(lines: Array<string>, numTabs: number = 0) {
+	if (lines.length > 0) {
+		const sep = "\t".repeat(numTabs);
+		return sep + lines.join(sep);
+	} else {
+		return "";
+	}
+}
+
 export function stripExtensions(fileName: string): string {
 	const ext = path.extname(fileName);
 	if (ext.length > 0) {

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -207,9 +207,22 @@ export = () => {
 		expect(bar()[2]).to.equal(6);
 	});
 
+	it("should support destructuring the length property", () => {
+		const { length: len } = [1, 2, 3];
+		expect(len).to.equal(3);
+	});
+
 	it("should destructure properly into already declared variables", () => {
 		let a: number;
 		[a] = new Set([4]);
 		expect(a).to.equal(4);
+
+		let len: number;
+		({ length: len } = [1, 2, 3]);
+		expect(len).to.equal(3);
+
+		let y = 0;
+		({ x: y } = { x: 1 });
+		expect(y).to.equal(1);
 	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -132,7 +132,7 @@ export = () => {
 		function b(arg1?: number, arg2?: number): [number, number] {
 			return [arg1 || 1, arg2 || 1];
 		}
-		function a(...args: number[]): [number, number] {
+		function a(...args: Array<number>): [number, number] {
 			const x = () => {
 				return b(...args);
 			};
@@ -205,5 +205,11 @@ export = () => {
 		expect(bar()[0]).to.equal(4);
 		expect(bar()[1]).to.equal(5);
 		expect(bar()[2]).to.equal(6);
+	});
+
+	it("should destructure properly into already declared variables", () => {
+		let a: number;
+		[a] = new Set([4]);
+		expect(a).to.equal(4);
 	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -241,4 +241,30 @@ export = () => {
 		expect(f(2)).to.equal(3);
 		expect(f(3)).to.equal(4);
 	});
+
+	it("should properly destruct objects with a Symbol.iterator method", () => {
+		const k = { o: 1, b: 2 };
+		const o = {
+			o: 3,
+			...k,
+			b: 4,
+			*[Symbol.iterator]() {
+				const values = Object.values(this).filter(a => typeIs(a, "number")) as Array<number>;
+				for (const value of values) {
+					yield value;
+				}
+			},
+		};
+
+		const arr = [...o].filter(i => typeIs(i, "number")) as Array<number>;
+		const set1 = new Set(arr);
+		const set2 = new Set([1, 4]);
+
+		expect(
+			set1
+				.difference(set2)
+				.union(set2.difference(set1))
+				.isEmpty(),
+		).to.equal(true);
+	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -267,4 +267,14 @@ export = () => {
 				.isEmpty(),
 		).to.equal(true);
 	});
+
+	it("should properly destruct gmatch", () => {
+		function catchLetters(...strs: Array<string>) {
+			expect(strs[0]).to.equal("a");
+			expect(strs[1]).to.equal("b");
+			expect(strs[2]).to.equal("c");
+			expect(strs[3]).to.equal("d");
+		}
+		catchLetters(..."abcd".gmatch("."));
+	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -225,4 +225,20 @@ export = () => {
 		({ x: y } = { x: 1 });
 		expect(y).to.equal(1);
 	});
+
+	it("should destructure computed property types as well (number-only)", () => {
+		const array = new Array<number>();
+		array.push(1, 2, 3, 4);
+
+		function f(i: number) {
+			let num: number;
+			({ [i]: num } = array);
+			return num;
+		}
+
+		expect(f(0)).to.equal(1);
+		expect(f(1)).to.equal(2);
+		expect(f(2)).to.equal(3);
+		expect(f(3)).to.equal(4);
+	});
 };

--- a/tests/src/function.spec.ts
+++ b/tests/src/function.spec.ts
@@ -68,6 +68,27 @@ export = () => {
 		).to.equal(123);
 	});
 
+	it("should support named function expressions", () => {
+		const nums = new Array<number>();
+		const start = 10;
+		const last = 0;
+
+		expect(
+			(function Recurse(num: number): string {
+				nums.push(num);
+				if (num === last) {
+					return "Done!";
+				} else {
+					return Recurse(num - 1);
+				}
+			})(start),
+		).to.equal("Done!");
+
+		for (let i = start; i >= last; i--) {
+			expect(nums[-i + start]).to.equal(i);
+		}
+	});
+
 	it("should support arrow functions", () => {
 		expect(
 			(() => {

--- a/tests/src/loop.spec.ts
+++ b/tests/src/loop.spec.ts
@@ -311,4 +311,6 @@ export = () => {
 			expect(a).to.equal("H");
 		}
 	});
+
+	it("should support using Symbol.iterator on every other kind of object", () => {});
 };

--- a/tests/src/loop.spec.ts
+++ b/tests/src/loop.spec.ts
@@ -312,5 +312,27 @@ export = () => {
 		}
 	});
 
-	it("should support using Symbol.iterator on every other kind of object", () => {});
+	it("should support using Symbol.iterator on every other kind of object", () => {
+		const fee = {
+			*[Symbol.iterator]() {
+				yield 1;
+				yield 2;
+				yield 3;
+			},
+			*values() {
+				yield 4;
+				yield 5;
+				yield 6;
+			},
+		};
+
+		let i = 0;
+		for (const f of fee) {
+			expect(f).to.equal(++i);
+		}
+
+		for (const f of fee.values()) {
+			expect(f).to.equal(++i);
+		}
+	});
 };

--- a/tests/src/spread.spec.ts
+++ b/tests/src/spread.spec.ts
@@ -1,0 +1,18 @@
+export = () => {
+	it("should work with prestatements and spreadable lists", () => {
+		let i = 0;
+		const a1: [number, number] = [1, 2];
+
+		const check = (...nums: Array<number>) => {
+			expect(nums[0]).to.equal(1);
+			expect(nums[1]).to.equal(2);
+			expect(nums[2]).to.equal(1);
+			expect(nums[3]).to.equal(2);
+			expect(nums[4]).to.equal(1);
+			expect(nums[5]).to.equal(2);
+			expect(nums[6]).to.equal(3);
+			expect(nums[7]).to.equal(4);
+		};
+		check(...a1, ...a1, ++i, ++i, ++i, ++i);
+	});
+};


### PR DESCRIPTION
### Fixes:
- These kinds of statements now compile properly:
	```ts
	let a: number;
	[a] = new Set([4]);
	```
- Computed Enum indeces now work.

- We now *mostly* support using `Symbol.iterator`. The only exception I know of is [described in the comment here](https://github.com/roblox-ts/roblox-ts/blob/8540cc9db4a049e605b751814528cee6b5b47613/src/compiler/binding.ts#L170). The described system will have to be implemented in a subsequent PR.

- Destructuring and spreading `gmatch` calls now work, with the only exception being the same as the aforementioned problem with `Symbol.iterator`.

- Switch statements now compile the value which is compared to cases properly. They will also no longer crash the compiler without any cases.

- Because this adds better logic for determining whether something is a flat identifier or not (export let identifiers are not), this fixes cases like this:
```ts
namespace Foo {
	export let arr = new Array<string>();
	arr.push("Hello!", "Soup!")
	for (const foo of arr) { // arr is no longer _0.arr, but pushed to _1
		arr = ["Yo!"];
		print(foo, arr.join(", "));
	}

	print(arr.join(", "));
}
```

- Fixes const declarations in for statements.
- Fixes complicated destructuring the compiler previously couldn't handle (A LOT OF FIXES).
- `join` now has `","` as the default separator, instead of `", "`.

### New compilation behavior:

- We now compile conditional ternary operators and unary increment/decrement operators in-line (as well as binary expressions invalid in Lua).
    - This will dramatically increase performance for these operators when used in expressions and will enable developers to use all of TS's features at their disposal, without needing to think about whether using an operator in an expression will be less performant than using it in a statement.
		```ts
		let i = 0;
		const x = i++ === 1 ? "Hello" : "World";
		```
		Previously compiled to:
		```lua
		local i = 0;
		local x = ((function() local _0 = i; i = i + 1; return _0; end)() == 1 and "Hello" or "World");
		```
		Now compiles to:
		```lua
		local i = 0;
		local _0 = i;
		i = _0 + 1;
		local x;
		if _0 == 1 then
			x = "Hello";
		else
			x = "World";
		end;
		```

- To preserve program order and to prevent contaminating values, all arguments in a list which come after an argument which required preceding statements are pushed onto the preceding statement array beforehand. For example:
	```ts
	let i = 0;
	print(i, ++i);
	```
	```lua
	local i = 0;
	local _0 = i; -- this is the first argument, pushed onto the precedingStatementContext
	i = i + 1; -- because of this
	print(_0, i);
	```

### Other changes

- As a consequence of this system, the macro functions are **significantly** better. The macros now consistently output similar code (with exceptions for things like array.unshift, which can only be optimized to a `table.insert` call if there is only a single value passed in).

- Changed a few minor mistakes in the code which wouldn't lead to bugs, like not pushing/popping the `idStack` sometimes, and not having a `;` at the end sometimes.

- Introduced a minor optimization to cases in switch statements which only fall-through:
	```ts
	let i = 0;
	switch (++i) {
		case 0: // this line now compiles to `_1 = _0 == ( 0 )`
		case 1:
			print(i);
	}
	```

### Notes
- Added a [FIXME here](https://github.com/roblox-ts/roblox-ts/blob/fa9220f95b6da1ef7a3469352e9eda5e26c06ebf/src/compiler/binary.ts#L136)

- Object literals are for now using IIFE's, unlike almost every other part of the codebase. This is because 1) this PR is already massive enough and 2) I want to get on the same page about how it should compile before writing it.

- The name `array_push_apply` comes from [this TypeScript compilation behavior](https://www.typescriptlang.org/play/#src=const%20arr%20%3D%20new%20Array%3Cnumber%3E()%3B%0Aarr.push(...%5B1%5D)).

Closes https://github.com/roblox-ts/roblox-ts/issues/342