### PR TITLE
Remove IIFE stability upgrade

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -4,6 +4,7 @@ local HttpService = game:GetService("HttpService")
 
 -- constants
 local table_sort = table.sort
+local table_concat = table.concat
 local math_ceil = math.ceil
 local math_floor = math.floor
 
@@ -374,6 +375,15 @@ end
 TS.Object_toString = toString
 
 -- array macro functions
+local function array_copy(list)
+	local result = {}
+	for i = 1, #list do
+		result[i] = list[i]
+	end
+	return result
+end
+
+TS.array_copy = array_copy
 
 function TS.array_forEach(list, callback)
 	for i = 1, #list do
@@ -411,10 +421,7 @@ local function sortFallback(a, b)
 end
 
 function TS.array_sort(list, callback)
-	local sorted = {}
-	for i = 1, #list do
-		sorted[i] = list[i]
-	end
+	local sorted = array_copy(list)
 
 	if callback then
 		table_sort(sorted, function(a, b)
@@ -624,42 +631,37 @@ function TS.array_reduceRight(list, callback, initialValue)
 end
 
 function TS.array_unshift(list, ...)
-	local args = { ... }
-	local argsLength = #args
-	for i = #list, 1, -1 do
+	local n = #list
+	local argsLength = select("#", ...)
+	for i = n, 1, -1 do
 		list[i + argsLength] = list[i]
 	end
 	for i = 1, argsLength do
-		list[i] = args[i]
+		list[i] = select(i, ...)
 	end
-	return #list
+	return n + argsLength
 end
+
+local function array_push_apply(list, ...)
+	local len = #list
+	for i = 1, select("#", ...) do
+		local list2 = select(i, ...)
+		local len2 = #list2
+		for j = 1, len2 do
+			list[len + j] = list2[j]
+		end
+		len = len + len2
+	end
+	return len
+end
+
+TS.array_push_apply = array_push_apply
 
 function TS.array_concat(...)
-	local count = 0
 	local result = {}
-
-	for i = 1, select("#", ...) do
-		local value = select(i, ...)
-		for j = 1, #value do
-			count = count + 1
-			result[count] = value[j]
-		end
-	end
-
+	array_push_apply(result, ...)
 	return result
 end
-
-function TS.array_push_apply(list, list2)
-	local len = #list
-	local len2 = #list2
-	for i = 1, len2 do
-		list[len + i] = list2[i]
-	end
-	return len + len2
-end
-
-local table_concat = table.concat
 
 function TS.array_join(list, separator)
 	local result = {}
@@ -775,17 +777,16 @@ function TS.array_copyWithin(list, target, from, to)
 	return list
 end
 
-TS.array_copy = copy
-
 TS.array_deepCopy = deepCopy
 
 TS.array_deepEquals = deepEquals
 
 -- map macro functions
 
-function TS.map_new(value)
+function TS.map_new(pairs)
 	local result = {}
-	for _, pair in pairs(value) do
+	for i = 1, #pairs do
+		local pair = pairs[i]
 		result[pair[1]] = pair[2]
 	end
 	return result
@@ -821,10 +822,10 @@ TS.map_toString = toString
 
 -- set macro functions
 
-function TS.set_new(value)
+function TS.set_new(values)
 	local result = {}
-	for _, v in pairs(value) do
-		result[v] = true
+	for i = 1, #values do
+		result[values[i]] = true
 	end
 	return result
 end

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -73,7 +73,8 @@ export class CompilerState {
 	public enterPrecedingStatementContext() {
 		const newContext = new Array<string>() as PrecedingStatementContext;
 		newContext.isPushed = false;
-		return this.precedingStatementContexts.push(newContext as PrecedingStatementContext);
+		this.precedingStatementContexts.push(newContext as PrecedingStatementContext);
+		return newContext;
 	}
 
 	public exitPrecedingStatementContext() {

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -211,7 +211,6 @@ function objectIterAccessor(state: CompilerState, t: string, key: number, preSta
 }
 
 function iterableFunctionAccessor(state: CompilerState, t: string, key: number, preStatements: Array<string>) {
-	console.log(t);
 	return `(` + `${t}() and `.repeat(key).slice(0, -5) + `)`;
 }
 

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -16,7 +16,11 @@ import {
 	isStringType,
 	strictTypeConstraint,
 } from "../typeUtilities";
-import { getNonNullUnParenthesizedExpressionDownwards, joinIndentedLines, removeBalancedParenthesisFromStringBorders } from "../utility";
+import {
+	getNonNullUnParenthesizedExpressionDownwards,
+	joinIndentedLines,
+	removeBalancedParenthesisFromStringBorders,
+} from "../utility";
 import { isIdentifierDefinedInExportLet } from "./indexed";
 
 function compileParamDefault(state: CompilerState, initial: ts.Expression, name: string) {

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -174,7 +174,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				} else {
 					let arrayStr = compileExpression(state, subExp);
 					state.enterPrecedingStatementContext();
-					const listStr = compileSpreadableListAndJoin(state, params.slice(1));
+					const listStr = compileSpreadableListAndJoin(state, params.slice(1), false);
 					const context = state.exitPrecedingStatementContext();
 
 					if (context.length > 0) {

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -218,14 +218,11 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 				const initializer = prop.getInitializer();
 				if (initializer) {
 					state.enterPrecedingStatementContext();
-					const fullInitializer = getNonNullUnParenthesizedExpressionDownwards(initializer)
-					state.declarationContext.set(
-						fullInitializer,
-						{
-							isIdentifier: false,
-							set: `self${propStr}`,
-						},
-					);
+					const fullInitializer = getNonNullUnParenthesizedExpressionDownwards(initializer);
+					state.declarationContext.set(fullInitializer, {
+						isIdentifier: false,
+						set: `self${propStr}`,
+					});
 					const expStr = compileExpression(state, initializer);
 					extraInitializers.push(...state.exitPrecedingStatementContext());
 					if (state.declarationContext.delete(fullInitializer)) {

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -1,7 +1,11 @@
 import * as ts from "ts-morph";
 import { compileExpression } from ".";
 import { CompilerState } from "../CompilerState";
-import { makeSetStatement, removeBalancedParenthesisFromStringBorders } from "../utility";
+import {
+	getNonNullUnParenthesizedExpressionDownwards,
+	makeSetStatement,
+	removeBalancedParenthesisFromStringBorders,
+} from "../utility";
 
 export function compileConditionalExpression(state: CompilerState, node: ts.ConditionalExpression) {
 	let id: string | undefined;
@@ -10,8 +14,8 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	const declaration = state.declarationContext.get(node);
 
 	const condition = node.getCondition();
-	const whenTrue = node.getWhenTrue();
-	const whenFalse = node.getWhenFalse();
+	const whenTrue = getNonNullUnParenthesizedExpressionDownwards(node.getWhenTrue());
+	const whenFalse = getNonNullUnParenthesizedExpressionDownwards(node.getWhenFalse());
 	let conditionStr: string;
 	let isPushed = false;
 

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -160,7 +160,7 @@ export function compileSpreadableListAndJoin(
 	elements: Array<ts.Expression>,
 	shouldWrapInConcat: boolean = true,
 ) {
-	const params = compileSpreadableList(state, elements)
+	let params = compileSpreadableList(state, elements)
 		.map(v => {
 			if (typeof v === "string") {
 				return v;
@@ -172,10 +172,10 @@ export function compileSpreadableListAndJoin(
 
 	if (shouldWrapInConcat) {
 		state.usesTSLibrary = true;
-		return `TS.array_concat(${params})`;
-	} else {
-		return params;
+		params = `TS.array_concat(${params})`;
 	}
+
+	return params;
 }
 
 export function compileSpreadExpression(state: CompilerState, expression: ts.Expression) {

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -155,7 +155,11 @@ export function compileSpreadableList(state: CompilerState, elements: Array<ts.E
 	return parts;
 }
 
-export function compileSpreadableListAndJoin(state: CompilerState, elements: Array<ts.Expression>) {
+export function compileSpreadableListAndJoin(
+	state: CompilerState,
+	elements: Array<ts.Expression>,
+	shouldWrapInConcat: boolean = true,
+) {
 	const params = compileSpreadableList(state, elements)
 		.map(v => {
 			if (typeof v === "string") {
@@ -166,8 +170,12 @@ export function compileSpreadableListAndJoin(state: CompilerState, elements: Arr
 		})
 		.join(", ");
 
-	state.usesTSLibrary = true;
-	return `TS.array_concat(${params})`;
+	if (shouldWrapInConcat) {
+		state.usesTSLibrary = true;
+		return `TS.array_concat(${params})`;
+	} else {
+		return params;
+	}
 }
 
 export function compileSpreadExpression(state: CompilerState, expression: ts.Expression) {

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -327,22 +327,32 @@ export function shouldPushToPrecedingStatement(
  * - unary/binary/ternary expressions
  */
 export function isConstantExpression(node: ts.Expression, maxDepth: number = 1 / 0): boolean {
-	if (maxDepth < 0) {
-		return false;
-	} else {
-		return (
-			ts.TypeGuards.isStringLiteral(node) ||
-			ts.TypeGuards.isNumericLiteral(node) ||
-			(ts.TypeGuards.isIdentifier(node) && isIdentifierDefinedInConst(node)) ||
-			(ts.TypeGuards.isBinaryExpression(node) &&
-				isConstantExpression(node.getLeft(), maxDepth - 1) &&
-				isConstantExpression(node.getRight(), maxDepth - 1)) ||
-			((ts.TypeGuards.isPrefixUnaryExpression(node) || ts.TypeGuards.isPostfixUnaryExpression(node)) &&
-				isConstantExpression(node.getOperand(), maxDepth)) ||
-			(ts.TypeGuards.isConditionalExpression(node) &&
-				isConstantExpression(node.getCondition(), maxDepth - 1) &&
-				isConstantExpression(node.getWhenTrue(), maxDepth - 1) &&
-				isConstantExpression(node.getWhenFalse(), maxDepth - 1))
-		);
+	if (maxDepth >= 0) {
+		if (ts.TypeGuards.isStringLiteral(node)) {
+			return true;
+		} else if (ts.TypeGuards.isNumericLiteral(node)) {
+			return true;
+		} else if (ts.TypeGuards.isIdentifier(node) && isIdentifierDefinedInConst(node)) {
+			return true;
+		} else if (
+			ts.TypeGuards.isBinaryExpression(node) &&
+			isConstantExpression(node.getLeft(), maxDepth - 1) &&
+			isConstantExpression(node.getRight(), maxDepth - 1)
+		) {
+			return true;
+		} else if (
+			(ts.TypeGuards.isPrefixUnaryExpression(node) || ts.TypeGuards.isPostfixUnaryExpression(node)) &&
+			isConstantExpression(node.getOperand(), maxDepth)
+		) {
+			return true;
+		} else if (
+			ts.TypeGuards.isConditionalExpression(node) &&
+			isConstantExpression(node.getCondition(), maxDepth - 1) &&
+			isConstantExpression(node.getWhenTrue(), maxDepth - 1) &&
+			isConstantExpression(node.getWhenFalse(), maxDepth - 1)
+		) {
+			return true;
+		}
 	}
+	return false;
 }

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -326,7 +326,7 @@ export function shouldPushToPrecedingStatement(
  * - numeric/string literals
  * - unary/binary/ternary expressions
  */
-export function isConstantExpression(node: ts.Expression, maxDepth: number = 1 / 0): boolean {
+export function isConstantExpression(node: ts.Expression, maxDepth: number = Number.MAX_VALUE): boolean {
 	if (maxDepth >= 0) {
 		if (ts.TypeGuards.isStringLiteral(node)) {
 			return true;

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -327,18 +327,22 @@ export function shouldPushToPrecedingStatement(
  * - unary/binary/ternary expressions
  */
 export function isConstantExpression(node: ts.Expression, maxDepth: number = 1 / 0): boolean {
-	return maxDepth < 0
-		? false
-		: ts.TypeGuards.isStringLiteral(node) ||
-				ts.TypeGuards.isNumericLiteral(node) ||
-				(ts.TypeGuards.isIdentifier(node) && isIdentifierDefinedInConst(node)) ||
-				(ts.TypeGuards.isBinaryExpression(node) &&
-					isConstantExpression(node.getLeft(), maxDepth - 1) &&
-					isConstantExpression(node.getRight(), maxDepth - 1)) ||
-				((ts.TypeGuards.isPrefixUnaryExpression(node) || ts.TypeGuards.isPostfixUnaryExpression(node)) &&
-					isConstantExpression(node.getOperand(), maxDepth)) ||
-				(ts.TypeGuards.isConditionalExpression(node) &&
-					isConstantExpression(node.getCondition(), maxDepth - 1) &&
-					isConstantExpression(node.getWhenTrue(), maxDepth - 1) &&
-					isConstantExpression(node.getWhenFalse(), maxDepth - 1));
+	if (maxDepth < 0) {
+		return false;
+	} else {
+		return (
+			ts.TypeGuards.isStringLiteral(node) ||
+			ts.TypeGuards.isNumericLiteral(node) ||
+			(ts.TypeGuards.isIdentifier(node) && isIdentifierDefinedInConst(node)) ||
+			(ts.TypeGuards.isBinaryExpression(node) &&
+				isConstantExpression(node.getLeft(), maxDepth - 1) &&
+				isConstantExpression(node.getRight(), maxDepth - 1)) ||
+			((ts.TypeGuards.isPrefixUnaryExpression(node) || ts.TypeGuards.isPostfixUnaryExpression(node)) &&
+				isConstantExpression(node.getOperand(), maxDepth)) ||
+			(ts.TypeGuards.isConditionalExpression(node) &&
+				isConstantExpression(node.getCondition(), maxDepth - 1) &&
+				isConstantExpression(node.getWhenTrue(), maxDepth - 1) &&
+				isConstantExpression(node.getWhenFalse(), maxDepth - 1))
+		);
+	}
 }


### PR DESCRIPTION
Made a few changes to the runtime library:
- Made `array_push_apply` accept any number of subsequent tables, to reduce the number of necessary middle-steps
- Made `array_push_apply` and `array_copy` used internally (by `array_concat` and `array_sort` respectively)
- Made `set_new`/`map_new` iterate numerically

Made a number of changes to the IIFE implementation:
- Fixed cases where a computed property index would be computed multiple times, especially if it involves a function call. In my defense, this was broken before PR #340 .
```ts
const arr = [1, 2, 3, 4, 5];

function f() {
	return 0;
}

// previously, this could call f() twice
arr[f()] *= 2;
```
- Optimized `array_push` to no longer need to call `array_concat` internally anymore on spreadable indexes.
- Made some adjustments to how the compiler decides when to push expressions up when compiling settable BinaryExpressions.
- Fixed some cases where the NonNull/NonParenthesis functions would climb up instead of down and vice versa. Made it so the number of Null/Parenthesis won't affect the declarationContext code.