### PR TITLE
[WIP] Add unorderedRemove/make strings start at 0

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -374,6 +374,13 @@ end
 
 TS.Object_toString = toString
 
+-- string macro functions
+function TS.string_find_wrap(a, b, ...)
+	if a then
+		return a + 1, b + 1, ...
+	end
+end
+
 -- array macro functions
 local function array_copy(list)
 	local result = {}
@@ -438,24 +445,19 @@ TS.array_toString = toString
 
 function TS.array_slice(list, startI, endI)
 	local length = #list
-	if startI == nil then
-		startI = 0
-	end
-	if endI == nil then
-		endI = length
-	end
-	if startI < 0 then
-		startI = length + startI
-	end
-	if endI < 0 then
-		endI = length + endI
-	end
-	startI = startI + 1
-	endI = endI + 1
+
+	if startI == nil then startI = 0 end
+	if endI == nil then endI = length end
+
+	if startI < 0 then startI = length + startI end
+	if endI < 0 then endI = length + endI end
+
 	local result = {}
-	for i = startI, endI - 1 do
-		result[i - startI + 1] = list[i]
+
+	for i = startI + 1, endI do
+		result[i - startI] = list[i]
 	end
+
 	return result
 end
 

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -21,7 +21,7 @@ import {
 	joinIndentedLines,
 	removeBalancedParenthesisFromStringBorders,
 } from "../utility";
-import { isIdentifierDefinedInExportLet } from "./indexed";
+import { addOneToArrayIndex, isIdentifierDefinedInExportLet } from "./indexed";
 
 function compileParamDefault(state: CompilerState, initial: ts.Expression, name: string) {
 	state.enterPrecedingStatementContext();
@@ -132,7 +132,7 @@ function objectAccessor(
 		const exp = nameNode.getExpression();
 		const expType = exp.getType();
 		if (strictTypeConstraint(expType, r => r.isNumber() || r.isNumberLiteral())) {
-			return `${t}[${compileExpression(state, exp)} + 1]`;
+			return `${t}[${addOneToArrayIndex(compileExpression(state, exp))}]`;
 		} else {
 			throw new CompilerError(
 				`Cannot index an object with type ${exp.getType().getText()}.`,
@@ -337,7 +337,7 @@ export function getBindingData(
 				const exp = child.getExpression();
 				const expType = exp.getType();
 				if (strictTypeConstraint(expType, r => r.isNumber() || r.isNumberLiteral())) {
-					const accessor = `${parentId}[${compileExpression(state, exp)} + 1]`;
+					const accessor = `${parentId}[${addOneToArrayIndex(compileExpression(state, exp))}]`;
 					const childId: string = compileExpression(state, pattern as ts.Expression);
 					preStatements.push(`local ${childId} = ${accessor};`);
 				} else {

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -158,10 +158,6 @@ function objectAccessor(
 				CompilerErrorType.BadDestructuringType,
 			);
 		}
-
-		if (name === "length") {
-			return `#${t}`;
-		}
 	}
 
 	return `${t}.${name}`;

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -204,17 +204,16 @@ function padAmbiguous(state: CompilerState, params: Array<ts.Expression>) {
 		fillString = `(" ")`;
 		fillStringLength = "1";
 	} else {
-		if (ts.TypeGuards.isStringLiteral(fillStringParam)) {
-			fillStringLength = `${fillStringParam.getLiteralText().length}`;
-		} else {
-			fillStringLength = `#${fillString}`;
-		}
-
-		console.log(isNullableType(fillStringParam.getType()), fillStringParam.getType().getText());
 		if (isNullableType(fillStringParam.getType())) {
 			fillString = `(${fillString} or " ")`;
 		} else if (!fillString.match(/^\(*_\d+\)*$/) && shouldWrapExpression(fillStringParam, true)) {
 			fillString = `(${fillString})`;
+		}
+
+		if (ts.TypeGuards.isStringLiteral(fillStringParam)) {
+			fillStringLength = `${fillStringParam.getLiteralText().length}`;
+		} else {
+			fillStringLength = `#${fillString}`;
 		}
 	}
 

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -306,7 +306,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 		"insert",
 		(state, params) => {
 			const [accessPath, indexParamStr, valueParamStr] = compileCallArguments(state, params);
-			return `table.insert(${accessPath}, ${indexParamStr} + 1, ${valueParamStr})`;
+			return `table.insert(${accessPath}, ${addOneToArrayIndex(indexParamStr)}, ${valueParamStr})`;
 		},
 	],
 
@@ -314,7 +314,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 		"remove",
 		(state, params) => {
 			const [accessPath, indexParamStr] = compileCallArguments(state, params);
-			return `table.remove(${accessPath}, ${indexParamStr} + 1)`;
+			return `table.remove(${accessPath}, ${addOneToArrayIndex(indexParamStr)})`;
 		},
 	],
 

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -99,9 +99,7 @@ export function compilePropertyAccessExpression(state: CompilerState, node: ts.P
 	const expType = exp.getType();
 	const propertyAccessExpressionType = getPropertyAccessExpressionType(state, node);
 
-	if ((isArrayType(expType) || isStringType(expType)) && propertyStr === "length") {
-		return `#(${removeBalancedParenthesisFromStringBorders(expStr)})`;
-	} else if (propertyAccessExpressionType !== PropertyCallExpType.None) {
+	if (propertyAccessExpressionType !== PropertyCallExpType.None) {
 		throw new CompilerError(
 			`Invalid property access! Cannot index non-member "${propertyStr}" (a roblox-ts macro function)`,
 			node,

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -23,7 +23,11 @@ export function shouldCompileAsSpreadableList(elements: Array<ts.Expression>) {
 	return false;
 }
 
-export function compileSpreadableList(state: CompilerState, elements: Array<ts.Expression>) {
+export function compileSpreadableList(
+	state: CompilerState,
+	elements: Array<ts.Expression>,
+	compile: (state: CompilerState, expression: ts.Expression) => string = compileExpression,
+) {
 	// The logic here is equivalent to the compileList logic, although it looks a bit more complicated
 	let isInArray = false;
 	const parts = new Array<Array<string> | string>();
@@ -67,7 +71,7 @@ export function compileSpreadableList(state: CompilerState, elements: Array<ts.E
 				args.push(lastElement);
 			}
 			state.enterPrecedingStatementContext();
-			const expStr = compileExpression(state, element);
+			const expStr = compile(state, element);
 			const context = state.exitPrecedingStatementContext() as PrecedingStatementContext;
 
 			if (context.length > 0) {
@@ -159,8 +163,9 @@ export function compileSpreadableListAndJoin(
 	state: CompilerState,
 	elements: Array<ts.Expression>,
 	shouldWrapInConcat: boolean = true,
+	compile: (state: CompilerState, expression: ts.Expression) => string = compileExpression,
 ) {
-	let params = compileSpreadableList(state, elements)
+	let params = compileSpreadableList(state, elements, compile)
 		.map(v => {
 			if (typeof v === "string") {
 				return v;

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -132,6 +132,16 @@ export function typeConstraint(type: ts.Type, cb: (type: ts.Type) => boolean): b
 	}
 }
 
+export function laxTypeConstraint(type: ts.Type, cb: (type: ts.Type) => boolean): boolean {
+	if (type.isUnion()) {
+		return type.getUnionTypes().some(t => strictTypeConstraint(t, cb));
+	} else if (type.isIntersection()) {
+		return type.getIntersectionTypes().some(t => strictTypeConstraint(t, cb));
+	} else {
+		return cb(type);
+	}
+}
+
 export function strictTypeConstraint(type: ts.Type, cb: (type: ts.Type) => boolean): boolean {
 	if (type.isUnion()) {
 		return type.getUnionTypes().every(t => strictTypeConstraint(t, cb));
@@ -147,7 +157,7 @@ export function isAnyType(type: ts.Type) {
 }
 
 export function isNullableType(type: ts.Type) {
-	return typeConstraint(type, t => t.isNullable() || t.isUndefined());
+	return laxTypeConstraint(type, t => t.isNullable() || t.isUndefined());
 }
 
 export function isBooleanType(type: ts.Type) {

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -17,11 +17,11 @@ export = () => {
 		expect(foo()[2]).to.equal(3);
 	});
 
-	it("should support length", () => {
-		expect([].length).to.equal(0);
-		expect([1].length).to.equal(1);
-		expect([1, 2].length).to.equal(2);
-		expect([1, 2, 3].length).to.equal(3);
+	it("should support.length()", () => {
+		expect([].length()).to.equal(0);
+		expect([1].length()).to.equal(1);
+		expect([1, 2].length()).to.equal(2);
+		expect([1, 2, 3].length()).to.equal(3);
 	});
 
 	it("should support push", () => {
@@ -52,7 +52,7 @@ export = () => {
 		const a = [456];
 		const b = a.pop();
 		expect(b).to.equal(456);
-		expect(a.length).to.equal(0);
+		expect(a.length()).to.equal(0);
 		expect(a[0]).never.to.be.ok();
 	});
 
@@ -89,7 +89,7 @@ export = () => {
 		const a = [1, 2, 3];
 		const b = a.shift();
 		expect(b).to.equal(1);
-		expect(a.length).to.equal(2);
+		expect(a.length()).to.equal(2);
 		expect(a[0]).to.equal(2);
 		expect(a[1]).to.equal(3);
 	});
@@ -99,32 +99,32 @@ export = () => {
 
 		const b = a.slice();
 		expect(b).never.to.equal(a);
-		expect(b.length).to.equal(3);
+		expect(b.length()).to.equal(3);
 		expect(b[0]).to.equal(1);
 		expect(b[1]).to.equal(2);
 		expect(b[2]).to.equal(3);
 
 		const c = a.slice(0, 1);
 		expect(c).never.to.equal(a);
-		expect(c.length).to.equal(1);
+		expect(c.length()).to.equal(1);
 		expect(c[0]).to.equal(1);
 
 		const d = a.slice(-2);
 		expect(d).never.to.equal(a);
-		expect(d.length).to.equal(2);
+		expect(d.length()).to.equal(2);
 		expect(d[0]).to.equal(2);
 		expect(d[1]).to.equal(3);
 
 		const e = a.slice();
 		expect(e).never.to.equal(a);
-		expect(e.length).to.equal(3);
+		expect(e.length()).to.equal(3);
 		expect(e[0]).to.equal(1);
 		expect(e[1]).to.equal(2);
 		expect(e[2]).to.equal(3);
 
 		const f = a.slice(0, -1);
 		expect(f).never.to.equal(a);
-		expect(f.length).to.equal(2);
+		expect(f.length()).to.equal(2);
 		expect(f[0]).to.equal(1);
 		expect(f[1]).to.equal(2);
 	});
@@ -134,10 +134,10 @@ export = () => {
 
 	it("should support splice", () => {
 		function equal<T>(a: Array<T>, b: Array<T>) {
-			if (a.length !== b.length) {
+			if (a.length() !== b.length()) {
 				return false;
 			}
-			for (let i = 0; i < a.length; i++) {
+			for (let i = 0; i < a.length(); i++) {
 				if (a[i] !== b[i]) {
 					return false;
 				}
@@ -226,7 +226,7 @@ export = () => {
 		const a = [1, 2, 3, 4, 5];
 		const b = a.filter(v => v % 2 === 0);
 		expect(b).never.to.equal(a);
-		expect(b.length).to.equal(2);
+		expect(b.length()).to.equal(2);
 		expect(b[0]).to.equal(2);
 		expect(b[1]).to.equal(4);
 	});
@@ -279,7 +279,7 @@ export = () => {
 		expect(b[3]).to.equal(4);
 		expect(b[4]).to.equal(5);
 		expect(b[5]).to.equal(6);
-		expect(b.length).to.equal(6);
+		expect(b.length()).to.equal(6);
 		const c = [...[1], ...[2]];
 		expect(c[0]).to.equal(1);
 		expect(c[1]).to.equal(2);
@@ -289,8 +289,8 @@ export = () => {
 		const a = [1, 2, 3];
 		const b = [...a];
 		expect(a).never.to.equal(b);
-		expect(a.length).to.equal(b.length);
-		for (let i = 0; i < a.length; i++) {
+		expect(a.length()).to.equal(b.length());
+		for (let i = 0; i < a.length(); i++) {
 			expect(b[i]).to.equal(a[i]);
 		}
 	});
@@ -458,11 +458,11 @@ export = () => {
 
 	it("should support unorderedRemove", () => {
 		const arr = [0, 1, 2, 3, 4, 5, 6, 7];
-		let i = 2;
+		const i = 2;
 		let value: number;
 
 		// expect(arr.unorderedRemove((i *= 2))).to.equal(4);
-		// expect(arr.length).to.equal(7);
+		// expect(arr.length()).to.equal(7);
 		// expect(arr[4]).to.equal(7);
 		// expect(arr[6]).to.equal(6);
 	});

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -449,4 +449,16 @@ export = () => {
 		arr.push("Nope");
 		expect(arr.isEmpty()).to.equal(false);
 	});
+
+	it("should support unorderedRemove", () => {
+		const arr = [0, 1, 2, 3, 4, 5, 6, 7];
+		let i = 2;
+		let value: number;
+
+		expect(arr.unorderedRemove((i *= 2))).to.equal(4);
+		expect(arr.length).to.equal(7);
+		expect(arr[4]).to.equal(7);
+		expect(arr[6]).to.equal(6);
+		expect;
+	});
 };

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -121,6 +121,12 @@ export = () => {
 		expect(e[0]).to.equal(1);
 		expect(e[1]).to.equal(2);
 		expect(e[2]).to.equal(3);
+
+		const f = a.slice(0, -1);
+		expect(f).never.to.equal(a);
+		expect(f.length).to.equal(2);
+		expect(f[0]).to.equal(1);
+		expect(f[1]).to.equal(2);
 	});
 
 	// TODO issue #98
@@ -455,10 +461,9 @@ export = () => {
 		let i = 2;
 		let value: number;
 
-		expect(arr.unorderedRemove((i *= 2))).to.equal(4);
-		expect(arr.length).to.equal(7);
-		expect(arr[4]).to.equal(7);
-		expect(arr[6]).to.equal(6);
-		expect;
+		// expect(arr.unorderedRemove((i *= 2))).to.equal(4);
+		// expect(arr.length).to.equal(7);
+		// expect(arr[4]).to.equal(7);
+		// expect(arr[6]).to.equal(6);
 	});
 };

--- a/tests/src/literal.spec.ts
+++ b/tests/src/literal.spec.ts
@@ -28,9 +28,9 @@ export = () => {
 		expect("foo").to.equal("foo");
 		expect('foo').to.equal("foo");
 		expect(`foo`).to.equal("foo");
-		expect("foo".length).to.equal(3);
-		expect('foo'.length).to.equal(3);
-		expect(`foo`.length).to.equal(3);
+		expect("foo".length()).to.equal(3);
+		expect('foo'.length()).to.equal(3);
+		expect(`foo`.length()).to.equal(3);
 		expect("\"").to.equal("\"");
 		expect(`\"`).to.equal("\"");
 		expect('\"').to.equal("\"");

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -167,7 +167,7 @@ export = () => {
 				c: 3,
 			};
 			const keys = Object.keys(obj);
-			expect(keys.length).to.equal(3);
+			expect(keys.length()).to.equal(3);
 			expect(keys.some(v => v === "a")).to.equal(true);
 			expect(keys.some(v => v === "b")).to.equal(true);
 			expect(keys.some(v => v === "c")).to.equal(true);
@@ -180,7 +180,7 @@ export = () => {
 				c: 3,
 			};
 			const values = Object.values(obj);
-			expect(values.length).to.equal(3);
+			expect(values.length()).to.equal(3);
 			expect(values.some(v => v === 1)).to.equal(true);
 			expect(values.some(v => v === 2)).to.equal(true);
 			expect(values.some(v => v === 3)).to.equal(true);

--- a/tests/src/string.spec.ts
+++ b/tests/src/string.spec.ts
@@ -1,11 +1,11 @@
 export = () => {
 	it("should support string methods", () => {
-		expect("Hello, world".sub(1, 1)).to.equal("H");
+		expect("Hello, world".sub(0, 0)).to.equal("H");
 	});
 
 	it("should support string methods on identifiers", () => {
 		const str = "Hello, world";
-		expect(str.sub(1, 1)).to.equal("H");
+		expect(str.sub(0, 0)).to.equal("H");
 	});
 
 	it("should support string.split", () => {
@@ -15,7 +15,7 @@ export = () => {
 		}
 
 		const str = "Hello, world";
-		const chars = [str.byte(1, -1)].map(i => string.char(i));
+		const chars = [str.byte(0, -1)].map(i => string.char(i));
 		const words = ["Hello", "world"];
 		const hSplit = ["", "ello, world"];
 

--- a/tests/src/string.spec.ts
+++ b/tests/src/string.spec.ts
@@ -1,16 +1,23 @@
 export = () => {
 	it("should support string methods", () => {
-		expect("Hello, world".sub(0, 1)).to.equal("H");
+		expect("Hello, world".sub(0, 0)).to.equal("H");
 	});
 
 	it("should support string methods on identifiers", () => {
 		const str = "Hello, world";
-		expect(str.sub(0, 1)).to.equal("H");
+		expect(str.sub(0, 0)).to.equal("H");
+	});
+
+	it("should support string.slice", () => {
+		const str = "Hello, world";
+		expect(str.slice(0, 1)).to.equal("H");
+
+		expect("Hello, world".slice(0, 1)).to.equal("H");
 	});
 
 	it("should support string.split", () => {
 		function checkLen<T>(len: number, arr: Array<T>) {
-			expect(arr.length).to.equal(len);
+			expect(arr.length()).to.equal(len);
 			return arr;
 		}
 
@@ -27,7 +34,7 @@ export = () => {
 		for (let i = 2; i < 10; i++) {
 			const str = "d".rep(i - 1);
 			const str1 = str.split("d");
-			expect(str1.length).to.equal(i);
+			expect(str1.length()).to.equal(i);
 			expect(str1.every(c => c === "")).to.equal(true);
 		}
 

--- a/tests/src/string.spec.ts
+++ b/tests/src/string.spec.ts
@@ -1,11 +1,11 @@
 export = () => {
 	it("should support string methods", () => {
-		expect("Hello, world".sub(0, 0)).to.equal("H");
+		expect("Hello, world".sub(0, 1)).to.equal("H");
 	});
 
 	it("should support string methods on identifiers", () => {
 		const str = "Hello, world";
-		expect(str.sub(0, 0)).to.equal("H");
+		expect(str.sub(0, 1)).to.equal("H");
 	});
 
 	it("should support string.split", () => {


### PR DESCRIPTION
- Makes string indexing start at 0. At the current moment, the `string:sub()` method works equivalently to the `array:slice()` method. I did this because I would like to consider removing `string:sub()` in favor of `string:slice()`. Try the `string:byte()` method for a demo on how the raw `string:sub()` method would compile.

- Adds array_unorderedRemove
- Adds string.padStart/string.padEnd. I also would like to remove `trimRight` and `trimLeft` so that we have `padStart`/`trimStart` and `padEnd`/`trimEnd`.
- Moves to a new system of computed array indexing with the function `addOneToArrayIndex/addOneToStringIndex`

Typings:

```ts
	/**
	 * Removes a value at `index` from this array, replacing it with the last value in this array and popping the last value.
	 * Returns the value removed from `index` in this way.
	 * @param index The index to remove from this array and return
	 */
	unorderedRemove(index: number): T;
```

Closes https://github.com/roblox-ts/roblox-ts/issues/353

We will want to resolve this PR first: https://github.com/roblox-ts/rbx-types/pull/66