### PR TITLE
[READY TO MERGE] Optimize Object.values/entries/keys in forOf loops

### DIFF
--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -264,17 +264,17 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				throw new CompilerError(`ForOf Loop empty varName!`, init, CompilerErrorType.ForEmptyVarName);
 			}
 
-			if (isStringType(expType)) {
-				if (ts.TypeGuards.isStringLiteral(exp)) {
-					expStr = `(${expStr})`;
-				}
-				result += state.indent + `for ${varName} in ${expStr}:gmatch(".") do\n`;
-				state.pushIndent();
-			} else if (isExpSetType) {
+			if (isExpSetType) {
 				result += state.indent + `for ${varName} in pairs(${expStr}) do\n`;
 				state.pushIndent();
 			} else if (isExpValuesType) {
 				result += state.indent + `for _, ${varName} in pairs(${expStr}) do\n`;
+				state.pushIndent();
+			} else if (isStringType(expType)) {
+				if (ts.TypeGuards.isStringLiteral(exp)) {
+					expStr = `(${expStr})`;
+				}
+				result += state.indent + `for ${varName} in ${expStr}:gmatch(".") do\n`;
 				state.pushIndent();
 			} else if (isIterableFunction(expType)) {
 				result += state.indent + `for ${varName} in ${expStr} do\n`;

--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -168,8 +168,8 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 		const preStatements = new Array<string>();
 		const postStatements = new Array<string>();
 
-		let isExpMapType = isMapType(expType);
-		let isExpSetType = isSetType(expType);
+		let isExpEntriesType = isMapType(expType);
+		let isExpKeysType = isSetType(expType);
 		let isExpValuesType = false;
 
 		if (ts.TypeGuards.isCallExpression(exp)) {
@@ -180,10 +180,10 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 					const firstArg = exp.getArguments()[0] as ts.Expression;
 
 					if (subExpName === "keys") {
-						isExpSetType = true;
+						isExpKeysType = true;
 						exp = firstArg;
 					} else if (subExpName === "entries") {
-						isExpMapType = true;
+						isExpEntriesType = true;
 						exp = firstArg;
 					} else if (subExpName === "values") {
 						isExpValuesType = true;
@@ -195,7 +195,7 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 
 		let expStr = compileExpression(state, exp);
 
-		if (isExpMapType) {
+		if (isExpEntriesType) {
 			if (ts.TypeGuards.isArrayBindingPattern(lhs)) {
 				const syntaxList = lhs.getChildAtIndex(1);
 
@@ -264,7 +264,7 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				throw new CompilerError(`ForOf Loop empty varName!`, init, CompilerErrorType.ForEmptyVarName);
 			}
 
-			if (isExpSetType) {
+			if (isExpKeysType) {
 				result += state.indent + `for ${varName} in pairs(${expStr}) do\n`;
 				state.pushIndent();
 			} else if (isExpValuesType) {

--- a/src/compiler/loop.ts
+++ b/src/compiler/loop.ts
@@ -21,7 +21,12 @@ import {
 	isSetType,
 	isStringType,
 } from "../typeUtilities";
-import { isIdentifierWhoseDefinitionMatchesNode, joinIndentedLines } from "../utility";
+import {
+	getNonNullUnParenthesizedExpressionDownwards,
+	isIdentifierWhoseDefinitionMatchesNode,
+	joinIndentedLines,
+} from "../utility";
+import { getPropertyAccessExpressionType, PropertyCallExpType } from "./call";
 import { getReadableExpressionName } from "./indexed";
 
 function hasContinueDescendant(node: ts.Node) {
@@ -140,10 +145,9 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 	let lhs: ts.Node<ts.ts.Node> | undefined;
 	let varName = "";
 	const statement = node.getStatement();
-	const exp = node.getExpression();
+	let exp = getNonNullUnParenthesizedExpressionDownwards(node.getExpression());
 	const expType = exp.getType();
 	state.enterPrecedingStatementContext();
-	let expStr = compileExpression(state, exp);
 	let result = state.exitPrecedingStatementContextAndJoin();
 
 	if (ts.TypeGuards.isVariableDeclarationList(init)) {
@@ -164,7 +168,34 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 		const preStatements = new Array<string>();
 		const postStatements = new Array<string>();
 
-		if (isMapType(expType)) {
+		let isExpMapType = isMapType(expType);
+		let isExpSetType = isSetType(expType);
+		let isExpValuesType = false;
+
+		if (ts.TypeGuards.isCallExpression(exp)) {
+			const subExp = exp.getExpression();
+			if (ts.TypeGuards.isPropertyAccessExpression(subExp)) {
+				if (PropertyCallExpType.ObjectConstructor === getPropertyAccessExpressionType(state, subExp)) {
+					const subExpName = subExp.getName();
+					const firstArg = exp.getArguments()[0] as ts.Expression;
+
+					if (subExpName === "keys") {
+						isExpSetType = true;
+						exp = firstArg;
+					} else if (subExpName === "entries") {
+						isExpMapType = true;
+						exp = firstArg;
+					} else if (subExpName === "values") {
+						isExpValuesType = true;
+						exp = firstArg;
+					}
+				}
+			}
+		}
+
+		let expStr = compileExpression(state, exp);
+
+		if (isExpMapType) {
 			if (ts.TypeGuards.isArrayBindingPattern(lhs)) {
 				const syntaxList = lhs.getChildAtIndex(1);
 
@@ -233,7 +264,22 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				throw new CompilerError(`ForOf Loop empty varName!`, init, CompilerErrorType.ForEmptyVarName);
 			}
 
-			if (isArrayType(expType)) {
+			if (isStringType(expType)) {
+				if (ts.TypeGuards.isStringLiteral(exp)) {
+					expStr = `(${expStr})`;
+				}
+				result += state.indent + `for ${varName} in ${expStr}:gmatch(".") do\n`;
+				state.pushIndent();
+			} else if (isExpSetType) {
+				result += state.indent + `for ${varName} in pairs(${expStr}) do\n`;
+				state.pushIndent();
+			} else if (isExpValuesType) {
+				result += state.indent + `for _, ${varName} in pairs(${expStr}) do\n`;
+				state.pushIndent();
+			} else if (isIterableFunction(expType)) {
+				result += state.indent + `for ${varName} in ${expStr} do\n`;
+				state.pushIndent();
+			} else if (isArrayType(expType)) {
 				let varValue: string;
 
 				state.enterPrecedingStatementContext();
@@ -244,18 +290,6 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				state.pushIndent();
 				varValue = `${expStr}[${myInt}]`;
 				result += state.indent + `local ${varName} = ${varValue};\n`;
-			} else if (isStringType(expType)) {
-				if (ts.TypeGuards.isStringLiteral(exp)) {
-					expStr = `(${expStr})`;
-				}
-				result += state.indent + `for ${varName} in ${expStr}:gmatch(".") do\n`;
-				state.pushIndent();
-			} else if (isSetType(expType)) {
-				result += state.indent + `for ${varName} in pairs(${expStr}) do\n`;
-				state.pushIndent();
-			} else if (isIterableFunction(expType)) {
-				result += state.indent + `for ${varName} in ${expStr} do\n`;
-				state.pushIndent();
 			} else {
 				state.enterPrecedingStatementContext();
 				if (!isIterableIterator(expType, exp)) {


### PR DESCRIPTION
```ts
const o = { a: 1 };

// try changing this to Object.keys and Object.entries
for (const i of Object.values(o)) {
	print(i);
}
```

Implementation notes: We already had code to deal with `Object.entries`, which is just the Map logic. The only code I added is the code that checks if it is `Object.keys/entries/values` and I also added the logic for `Object.values` (1-2 lines). The `isArray` and `isString` blocks are unchanged, they were simply moved so that the `isExpMapType | isExpSetType | isExpValuesType` logic would come first.