### PR TITLE
Move to explicitly specifying which expressions shouldn't be pushed in getWritableOperandName

### DIFF
--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -47,13 +47,14 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 		const child = operand.getChildAtIndex(0);
 
 		if (
-			ts.TypeGuards.isPropertyAccessExpression(child) ||
-			(ts.TypeGuards.isIdentifier(child) && isIdentifierDefinedInExportLet(child))
+			!ts.TypeGuards.isThisExpression(child) &&
+			(!ts.TypeGuards.isIdentifier(child) || isIdentifierDefinedInExportLet(child))
 		) {
-			const expression = operand.getExpression();
-			const opExpStr = compileExpression(state, expression);
 			const propertyStr = operand.getName();
-			const id = state.pushPrecedingStatementToReuseableId(operand, opExpStr);
+			const id = state.pushPrecedingStatementToReuseableId(
+				operand,
+				compileExpression(state, operand.getExpression()),
+			);
 			return { expStr: `${id}.${propertyStr}`, isIdentifier: false };
 		}
 	}

--- a/tests/src/binary.spec.ts
+++ b/tests/src/binary.spec.ts
@@ -27,4 +27,12 @@ export = () => {
 		expect((arr[f()] *= ++x)).to.equal(8);
 		expect(x).to.equal(2);
 	});
+
+	it("should push WritableOperandNames", () => {
+		let numItems = 0;
+		new (class {
+			public id = numItems++;
+		})().id++;
+		expect(numItems).to.equal(1);
+	});
 };


### PR DESCRIPTION
Instead of specifying which Operands we should push, we should specify which operand types we know we don't need to push. When in doubt, it should push to a variable to make sure we don't output incorrect code.