### PR TITLE
Object redux

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -12,7 +12,7 @@ import { ProjectError, ProjectErrorType } from "./errors/ProjectError";
 import { ProjectInfo } from "./types";
 import { red, transformPathToLua, yellow } from "./utility";
 
-const MINIMUM_RBX_TYPES_VERSION = 198;
+const MINIMUM_RBX_TYPES_VERSION = 203;
 
 const LIB_PATH = path.resolve(__dirname, "..", "lib");
 const ROJO_FILE_REGEX = /^.+\.project\.json$/;

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -248,7 +248,6 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 			}
 
 			lhsStr = compileLhsStr(innerStr);
-			console.log(innerStr);
 		} else if (!isEqualsOperation) {
 			const newLhsStrData = getWritableOperandName(state, lhs);
 			lhsStr = newLhsStrData.expStr;

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -222,7 +222,6 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 		let stashedInnerStr: (() => string) | undefined;
 
 		const upperContext = state.getCurrentPrecedingStatementContext(node);
-
 		if (ts.TypeGuards.isElementAccessExpression(lhs)) {
 			const compileLhsStr = compileElementAccessDataTypeExpression(state, lhs);
 			let innerStr = compileElementAccessBracketExpression(state, lhs);

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -3,6 +3,7 @@ import { checkNonAny, compileCallExpression, compileExpression, concatNamesAndVa
 import { CompilerState, PrecedingStatementContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import {
+	isArrayType,
 	isConstantExpression,
 	isNumberType,
 	isStringType,
@@ -223,9 +224,18 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 
 		const upperContext = state.getCurrentPrecedingStatementContext(node);
 		if (ts.TypeGuards.isElementAccessExpression(lhs)) {
-			const compileLhsStr = compileElementAccessDataTypeExpression(state, lhs);
+			const compileLhsStr = compileElementAccessDataTypeExpression(
+				state,
+				lhs,
+				getWritableOperandName(state, lhs, true).expStr,
+			);
 			let innerStr = compileElementAccessBracketExpression(state, lhs);
-			if (!isConstantExpression(lhs.getArgumentExpressionOrThrow(), 0)) {
+
+			if (
+				!isConstantExpression(lhs.getArgumentExpressionOrThrow(), 0) &&
+				// Always push array values, even when isPushed, because we need to increment by 1
+				(!upperContext.isPushed || isArrayType(lhs.getExpression().getType()))
+			) {
 				const previousInner = innerStr;
 				const previouslyPushed = upperContext.isPushed;
 				stashedInnerStr = () => {
@@ -238,6 +248,7 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 			}
 
 			lhsStr = compileLhsStr(innerStr);
+			console.log(innerStr);
 		} else if (!isEqualsOperation) {
 			const newLhsStrData = getWritableOperandName(state, lhs);
 			lhsStr = newLhsStrData.expStr;

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -34,6 +34,7 @@ const STRING_MACRO_METHODS = ["format", "gmatch", "gsub", "lower", "rep", "rever
 export function shouldWrapExpression(subExp: ts.Node, strict: boolean) {
 	return (
 		!ts.TypeGuards.isIdentifier(subExp) &&
+		!ts.TypeGuards.isThisExpression(subExp) &&
 		!ts.TypeGuards.isElementAccessExpression(subExp) &&
 		(strict ||
 			(!ts.TypeGuards.isCallExpression(subExp) &&

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -68,6 +68,18 @@ export function compileReturnStatement(state: CompilerState, node: ts.ReturnStat
 	}
 }
 
+export function isFunctionExpressionMethod(node: ts.FunctionExpression) {
+	const parent = node.getParent();
+	return ts.TypeGuards.isPropertyAssignment(parent) && ts.TypeGuards.isObjectLiteralExpression(parent.getParent());
+}
+
+export function isMethodDeclaration(node: ts.Node<ts.ts.Node>): node is ts.MethodDeclaration | ts.FunctionExpression {
+	return (
+		ts.TypeGuards.isMethodDeclaration(node) ||
+		(ts.TypeGuards.isFunctionExpression(node) && isFunctionExpressionMethod(node))
+	);
+}
+
 function compileFunctionBody(state: CompilerState, body: ts.Node, node: HasParameters, initializers: Array<string>) {
 	const isBlock = ts.TypeGuards.isBlock(body);
 	const isExpression = ts.TypeGuards.isExpression(body);
@@ -107,7 +119,7 @@ function compileFunction(state: CompilerState, node: HasParameters, name: string
 	checkReturnsNonAny(node);
 
 	if (
-		ts.TypeGuards.isMethodDeclaration(node) ||
+		isMethodDeclaration(node) ||
 		ts.TypeGuards.isGetAccessorDeclaration(node) ||
 		ts.TypeGuards.isSetAccessorDeclaration(node)
 	) {
@@ -174,10 +186,7 @@ function compileFunction(state: CompilerState, node: HasParameters, name: string
 	return result + "end" + backWrap;
 }
 
-function giveInitialSelfParameter(
-	node: ts.MethodDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration,
-	paramNames: Array<string>,
-) {
+function giveInitialSelfParameter(node: HasParameters, paramNames: Array<string>) {
 	const parameters = node.getParameters();
 	let replacedThis = false;
 

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -57,11 +57,11 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 	if (ts.TypeGuards.isPropertyAccessExpression(operand)) {
 		const child = operand.getNameNode();
 		if (!ts.TypeGuards.isIdentifier(child) || isIdentifierDefinedInExportLet(child)) {
-			const propertyStr = compileExpression(state, child);
 			const id = state.pushPrecedingStatementToReuseableId(
 				operand,
 				compileExpression(state, operand.getExpression()),
 			);
+			const propertyStr = compileExpression(state, child);
 			return { expStr: `${id}.${propertyStr}`, isIdentifier: false };
 		}
 	}
@@ -83,6 +83,7 @@ export function getReadableExpressionName(
 	const nonNullExp = getNonNullExpressionDownwards(exp);
 	if (
 		expStr.match(/^\(*_\d+\)*$/) ||
+		ts.TypeGuards.isThisExpression(nonNullExp) ||
 		(ts.TypeGuards.isIdentifier(nonNullExp) && !isIdentifierDefinedInExportLet(nonNullExp)) ||
 		// We know that new Sets and Maps are already ALWAYS pushed
 		(ts.TypeGuards.isNewExpression(nonNullExp) && (isSetType(exp.getType()) || isMapType(exp.getType())))

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -229,11 +229,10 @@ export function compileElementAccessDataTypeExpression(
 
 	if (expStr === "") {
 		if (ts.TypeGuards.isCallExpression(expNode) && isTupleReturnTypeCall(expNode)) {
-			expStr = expStr || compileCallExpression(state, expNode, true);
-
+			expStr = compileCallExpression(state, expNode, true);
 			return (argExpStr: string) => (argExpStr === "1" ? `(${expStr})` : `(select(${argExpStr}, ${expStr}))`);
 		} else {
-			expStr = expStr || compileExpression(state, expNode);
+			expStr = compileExpression(state, expNode);
 		}
 	}
 

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -55,13 +55,9 @@ export function isIdentifierDefinedInExportLet(exp: ts.Identifier) {
  */
 export function getWritableOperandName(state: CompilerState, operand: ts.Expression) {
 	if (ts.TypeGuards.isPropertyAccessExpression(operand)) {
-		const child = operand.getChildAtIndex(0);
-
-		if (
-			!ts.TypeGuards.isThisExpression(child) &&
-			(!ts.TypeGuards.isIdentifier(child) || isIdentifierDefinedInExportLet(child))
-		) {
-			const propertyStr = operand.getName();
+		const child = operand.getNameNode();
+		if (!ts.TypeGuards.isIdentifier(child) || isIdentifierDefinedInExportLet(child)) {
+			const propertyStr = compileExpression(state, child);
 			const id = state.pushPrecedingStatementToReuseableId(
 				operand,
 				compileExpression(state, operand.getExpression()),

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -117,6 +117,6 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 	if (id) {
 		return id;
 	} else {
-		return `{\n${lines.map(myLine => state.indent + joinIndentedLines([myLine], 1)).join("")}${state.indent}}`;
+		return "{\n" + lines.map(myLine => state.indent + joinIndentedLines([myLine], 1)).join("") + state.indent + "}";
 	}
 }

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -82,31 +82,28 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 		state.exitPrecedingStatementContext();
 
 		if (hasContext) {
-			let fullLine: string;
-
 			if (ts.TypeGuards.isSpreadAssignment(prop)) {
 				state.usesTSLibrary = true;
-				fullLine = state.indent + `TS.Object_assign(${id}, ${line});\n`;
+				line = state.indent + `TS.Object_assign(${id}, ${line});\n`;
 			} else {
-				fullLine = state.indent + id + (line.startsWith("[") ? "" : ".") + line;
+				line = state.indent + id + (line.startsWith("[") ? "" : ".") + line;
 			}
-			state.pushPrecedingStatements(node, ...context, fullLine);
+			state.pushPrecedingStatements(node, ...context, line);
 		} else if (context.length > 0 || ts.TypeGuards.isSpreadAssignment(prop)) {
 			id = state.pushToDeclarationOrNewId(node, "{}", declaration => declaration.isIdentifier);
-			let fullLine: string;
 
 			if (ts.TypeGuards.isSpreadAssignment(prop)) {
 				state.usesTSLibrary = true;
-				fullLine = state.indent + `TS.Object_assign(${id}, ${line});\n`;
+				line = state.indent + `TS.Object_assign(${id}, ${line});\n`;
 			} else {
-				fullLine = state.indent + id + (line.startsWith("[") ? "" : ".") + line;
+				line = state.indent + id + (line.startsWith("[") ? "" : ".") + line;
 			}
 
 			state.pushPrecedingStatements(
 				node,
 				...lines.map(current => state.indent + id + (current.startsWith("[") ? "" : ".") + current),
 				...context,
-				fullLine,
+				line,
 			);
 			hasContext = true;
 		} else {

--- a/src/compiler/security.ts
+++ b/src/compiler/security.ts
@@ -246,7 +246,7 @@ export function checkApiAccess(state: CompilerState, node: ts.Node) {
 	}
 }
 
-export function checkNonAny(node: ts.Node, checkArrayType = false) {
+export function checkNonAny<T extends ts.Node>(node: T, checkArrayType = false): T {
 	const isInCatch = node.getFirstAncestorByKind(ts.SyntaxKind.CatchClause) !== undefined;
 	let type = node.getType();
 	if (checkArrayType && type.isArray()) {
@@ -275,6 +275,7 @@ export function checkNonAny(node: ts.Node, checkArrayType = false) {
 			);
 		}
 	}
+	return node;
 }
 
 export function checkReturnsNonAny(node: HasParameters) {

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -77,6 +77,7 @@ export enum CompilerErrorType {
 	InvalidComputedIndex,
 	TupleLength,
 	BadMethodCall,
+	BadFunctionExpressionMethodCall,
 }
 
 export class CompilerError extends Error {

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -78,6 +78,7 @@ export enum CompilerErrorType {
 	TupleLength,
 	BadMethodCall,
 	BadFunctionExpressionMethodCall,
+	BadObjectPropertyType,
 }
 
 export class CompilerError extends Error {

--- a/src/test.ts
+++ b/src/test.ts
@@ -298,6 +298,11 @@ const errorMatrix: ErrorMatrix = {
 		instance: CompilerError,
 		type: CompilerErrorType.TupleLength,
 	},
+	"funcExpMethodCall.spec.ts": {
+		message: "should not allow calling from function method expressions",
+		instance: CompilerError,
+		type: CompilerErrorType.BadFunctionExpressionMethodCall,
+	},
 };
 /* tslint:enable:object-literal-sort-keys */
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -201,7 +201,7 @@ const errorMatrix: ErrorMatrix = {
 	"any/computedAccess2.spec.ts": {
 		message: "should not allow computed accessing type any #2",
 		instance: CompilerError,
-		type: CompilerErrorType.NoAny,
+		type: CompilerErrorType.InvalidComputedIndex,
 	},
 	"any/func.spec.ts": {
 		message: "should not allow functions that return type any",

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -406,6 +406,8 @@ export function isConstantExpression(node: ts.Expression, maxDepth: number = Num
 			return true;
 		} else if (ts.TypeGuards.isIdentifier(node) && isIdentifierDefinedInConst(node)) {
 			return true;
+		} else if (ts.TypeGuards.isThisExpression(node)) {
+			return true;
 		} else if (
 			ts.TypeGuards.isBinaryExpression(node) &&
 			isConstantExpression(node.getLeft(), maxDepth - 1) &&

--- a/tests/src/binary.spec.ts
+++ b/tests/src/binary.spec.ts
@@ -54,11 +54,9 @@ export = () => {
 									this.b++;
 								},
 
-								// tslint:disable
-								// prettier-ignore
-								no: function () {
-							return this[5] *= 7
-						},
+								no: function() {
+									return (this[5] *= 7);
+								},
 
 								5: 3,
 							},

--- a/tests/src/binary.spec.ts
+++ b/tests/src/binary.spec.ts
@@ -35,6 +35,54 @@ export = () => {
 		let i = 2;
 		expect((g()[i++] *= i)).to.equal(3);
 		expect(numCalls).to.equal(1);
+
+		i = 0;
+		expect(({ [++i]: ++i }[i++ - 1] *= ++i)).to.equal(8);
+
+		{
+			{
+				{
+					let i = 0;
+					expect(
+						{
+							jk: {
+								o: 3,
+								b: i++,
+								a4: { 2: i, k: 4 },
+
+								g() {
+									this.b++;
+								},
+
+								// tslint:disable
+								// prettier-ignore
+								no: function () {
+							return this[5] *= 7
+						},
+
+								5: 3,
+							},
+						}.jk.no(),
+					).to.equal(21);
+
+					expect(
+						{
+							o: 8,
+							a() {
+								++this.o;
+								return this;
+							},
+
+							e() {
+								return ++this.o;
+							},
+						}
+							.a()
+							.e(),
+					).to.equal(10);
+				}
+			}
+		}
 	});
 
 	it("should push WritableOperandNames", () => {

--- a/tests/src/binary.spec.ts
+++ b/tests/src/binary.spec.ts
@@ -26,6 +26,15 @@ export = () => {
 
 		expect((arr[f()] *= ++x)).to.equal(8);
 		expect(x).to.equal(2);
+
+		let numCalls = 0;
+		function g(): { [k: number]: number } {
+			return { [2]: ++numCalls };
+		}
+
+		let i = 2;
+		expect((g()[i++] *= i)).to.equal(3);
+		expect(numCalls).to.equal(1);
 	});
 
 	it("should push WritableOperandNames", () => {

--- a/tests/src/errors/funcExpMethodCall.spec.ts
+++ b/tests/src/errors/funcExpMethodCall.spec.ts
@@ -1,0 +1,13 @@
+export = () => {
+	const o = {
+		c: 1,
+
+		a: function add(i: number): number {
+			if (i === 0) {
+				return 0;
+			} else {
+				return i + add(i - 1);
+			}
+		},
+	};
+};

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -233,6 +233,7 @@ export = () => {
 			};
 			expect(object1[1]).to.equal(1);
 			expect(object1[2]).to.equal(1);
+			expect({ [0]: 1 }[0]).to.equal(1);
 		});
 
 		it("should support isEmpty", () => {

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -121,6 +121,16 @@ export = () => {
 		expect(obj1.b).to.equal(2);
 		expect(obj1.c).to.equal(3);
 		expect(obj1.d).to.equal(2);
+
+		const k = { o: 1, b: 2 };
+		const o = {
+			o: 3,
+			...k,
+			b: k.o++,
+		};
+
+		expect(o.o).to.equal(1);
+		expect(o.b).to.equal(1);
 	});
 
 	it("should support Object.entries", () => {
@@ -134,32 +144,6 @@ export = () => {
 		expect(a.some(v => v[0] === "a" && v[1] === 1)).to.equal(true);
 		expect(a.some(v => v[0] === "b" && v[1] === 2)).to.equal(true);
 		expect(a.some(v => v[0] === "c" && v[1] === 3)).to.equal(true);
-	});
-
-	it("should support Object.keys", () => {
-		const foo = {
-			a: 1,
-			b: 2,
-			c: 3,
-		};
-
-		const a = Object.keys(foo);
-		expect(a.some(v => v === "a")).to.equal(true);
-		expect(a.some(v => v === "b")).to.equal(true);
-		expect(a.some(v => v === "c")).to.equal(true);
-	});
-
-	it("should support Object.values", () => {
-		const foo = {
-			a: 1,
-			b: 2,
-			c: 3,
-		};
-
-		const a = Object.values(foo);
-		expect(a.some(v => v === 1)).to.equal(true);
-		expect(a.some(v => v === 2)).to.equal(true);
-		expect(a.some(v => v === 3)).to.equal(true);
 	});
 
 	describe("it should support Object methods", () => {
@@ -188,6 +172,17 @@ export = () => {
 		});
 
 		it("should support Object.keys()", () => {
+			const foo = {
+				a: 1,
+				b: 2,
+				c: 3,
+			};
+
+			const a = Object.keys(foo);
+			expect(a.some(v => v === "a")).to.equal(true);
+			expect(a.some(v => v === "b")).to.equal(true);
+			expect(a.some(v => v === "c")).to.equal(true);
+
 			const obj = {
 				a: 1,
 				b: 2,
@@ -201,6 +196,17 @@ export = () => {
 		});
 
 		it("should support Object.values()", () => {
+			const foo = {
+				a: 1,
+				b: 2,
+				c: 3,
+			};
+
+			const a = Object.values(foo);
+			expect(a.some(v => v === 1)).to.equal(true);
+			expect(a.some(v => v === 2)).to.equal(true);
+			expect(a.some(v => v === 3)).to.equal(true);
+
 			const obj = {
 				a: 1,
 				b: 2,


### PR DESCRIPTION
After this PR is merged, I consider roblox-ts to officially support objects.

This PR fixes the following issues:
Fixes https://github.com/roblox-ts/roblox-ts/issues/351
https://github.com/microsoft/TypeScript/issues/31469

This PR fully finishes the last thing I considered necessary to close this issue:
Fixes https://github.com/roblox-ts/roblox-ts/issues/131

Also:
- The following code should error now:
```ts
const o = {
	c: 1,
	a: function add(i: number): number {
		if (i === 0) {
			return 0;
		} else {
			return i + add(i - 1); // footgun! `this` won't get passed into add!
		}
	},
};
```

- Minor fixes for the following:
    - Fixes whitespace issues with Set/Map instantiation, and allows map constructor to be more flexible.
    - Fixes https://github.com/roblox-ts/roblox-ts/issues/433
    - Fixes https://github.com/roblox-ts/roblox-ts/issues/432