### PR TITLE
Simplify push implementation

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -671,6 +671,15 @@ end
 
 TS.array_push_apply = array_push_apply
 
+function TS.array_push_stack(list, ...)
+	local len = #list
+	local len2 = select("#", ...)
+	for i = 1, len2 do
+		list[len + i] = select(i, ...)
+	end
+	return len + len2
+end
+
 function TS.array_concat(...)
 	local result = {}
 	array_push_apply(result, ...)

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -452,18 +452,20 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				const accessPath = getReadableExpressionName(state, subExp);
 
 				if (numParams <= 2) {
-					let accessor = `#${accessPath} + 1`;
+					const firstParam = params[1];
+					let accessor = `#${accessPath}${firstParam ? " + 1" : ""}`;
 					if (isStatement) {
-						return params[1]
-							? `${accessPath}[${accessor}] = ${compileExpression(state, params[1])}`
+						return firstParam
+							? `${accessPath}[${accessor}] = ${compileExpression(state, firstParam)}`
 							: `local _ = ${accessor}`;
 					} else {
 						accessor = state.pushToDeclarationOrNewId(node, accessor);
 
-						if (params[1]) {
+						if (firstParam) {
 							state.pushPrecedingStatements(
 								subExp,
-								state.indent + `${accessPath}[${accessor}] = ${compileExpression(state, params[1])};\n`,
+								state.indent +
+									`${accessPath}[${accessor}] = ${compileExpression(state, firstParam)};\n`,
 							);
 						}
 

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -449,8 +449,11 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				return `TS.array_push_apply(${arrayStr}, ${listStr})`;
 			} else {
 				const accessPath = getReadableExpressionName(state, subExp);
-				if (isStatement && numParams === 2) {
-					return `${accessPath}[#${accessPath} + 1] = ${compileExpression(state, params[1])}`;
+				if (numParams === 2) {
+					const accessor = `#${accessPath} + 1`;
+					if (!isStatement) {
+					}
+					return `${accessPath}[${accessor}] = ${compileExpression(state, params[1])}`;
 				} else {
 					state.usesTSLibrary = true;
 					return `TS.array_push_stack(${accessPath}, ${compileList(state, params.slice(1)).join(", ")})`;

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -75,6 +75,8 @@ export = () => {
 		expect(arr[1]).to.equal(1);
 		expect(arr[2]).to.equal(2);
 		expect(arr[3]).to.equal(undefined);
+
+		expect([1, 2].push()).to.equal(2);
 	});
 
 	it("should support pop", () => {

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -67,6 +67,14 @@ export = () => {
 		expect(noodle.strings[1]).to.equal("Spaghetti");
 		expect(noodle.strings[2]).to.equal("Lasagna");
 		expect(noodle.strings[3]).to.equal("Penne");
+
+		let arr = [0];
+		arr.push(1, 2, arr[1]);
+
+		expect(arr[0]).to.equal(0);
+		expect(arr[1]).to.equal(1);
+		expect(arr[2]).to.equal(2);
+		expect(arr[3]).to.equal(undefined);
 	});
 
 	it("should support pop", () => {


### PR DESCRIPTION
Fixes cases like this:
```ts
let arr = [0];
arr.push(1, 2, arr[1]); // arr[1] should be undefined
```