### PR TITLE
Object Redux Addendum

### DIFF
--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -47,7 +47,7 @@ function compileSetMapConstructorHelper(
 	mode: "" | "k" | "v" | "kv" = "",
 ) {
 	const preDeclaration = mode ? "setmetatable(" : "";
-	const postDeclaration = mode ? `, { __mode = ${mode} })` : "";
+	const postDeclaration = mode ? `, { __mode = "${mode}" })` : "";
 
 	const typeArgument = node.getType().getTypeArguments()[0];
 

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -8,7 +8,7 @@ function assignMembers(state: CompilerState, from: string, target: string) {
 	state.pushIdStack();
 	const i = state.getNewId();
 	const v = state.getNewId();
-	const str = `for ${i}, ${v} in pairs(${from}) do ${target}[${i}] = ${v}; end;\n`;
+	const str = state.indent + `for ${i}, ${v} in pairs(${from}) do ${target}[${i}] = ${v}; end;\n`;
 	state.popIdStack();
 	return str;
 }

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,9 +10,9 @@
 			"integrity": "sha512-fXPnex28S/134xpbYfjS8JGwalFthe8IkiG4+3kpF99G4uOse8aIrQikFzyLd3bnCD6NXfZhVdNjhSThsEyavg=="
 		},
 		"@rbxts/types": {
-			"version": "1.0.198",
-			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.198.tgz",
-			"integrity": "sha512-Ya8N7izAQ+giBeQ6TpPqQhCU9rX+nvZezuzWMdpdWeL2SJZA8gt4or1bHFOMFjdPYMqB1iYRiPkxsrQjujNj6A=="
+			"version": "1.0.205",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.205.tgz",
+			"integrity": "sha512-NqW47NKEIhVYUf08H/94r5E6XPPRcL8UWnXW5VKNNlii4ZBR3J2yRTyBiOJ/hN+7ZvKJsNMaV0x+oKuMoTrLwg=="
 		}
 	}
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,6 +11,6 @@
 	"license": "MIT",
 	"dependencies": {
 		"@rbxts/roact": "^1.0.2",
-		"@rbxts/types": "^1.0.198"
+		"@rbxts/types": "^1.0.205"
 	}
 }

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -122,15 +122,41 @@ export = () => {
 		expect(obj1.c).to.equal(3);
 		expect(obj1.d).to.equal(2);
 
-		const k = { o: 1, b: 2 };
-		const o = {
-			o: 3,
-			...k,
-			b: k.o++,
-		};
+		{
+			const k = { o: 1, b: 2 };
+			const o = {
+				...k,
+				o: 3,
+				b: k.o++,
+			};
 
-		expect(o.o).to.equal(1);
-		expect(o.b).to.equal(1);
+			expect(o.o).to.equal(3);
+			expect(o.b).to.equal(1);
+		}
+
+		{
+			const k = { o: 1, b: 2 };
+			const o = {
+				o: 3,
+				...k,
+				b: k.o++,
+			};
+
+			expect(o.o).to.equal(1);
+			expect(o.b).to.equal(1);
+		}
+
+		{
+			const k = { o: 1, b: 2 };
+			const o = {
+				o: 3,
+				b: k.o++,
+				...k,
+			};
+
+			expect(o.o).to.equal(2);
+			expect(o.b).to.equal(2);
+		}
 	});
 
 	it("should support Object.entries", () => {

--- a/tests/src/set.spec.ts
+++ b/tests/src/set.spec.ts
@@ -1,3 +1,5 @@
+declare function getmetatable(obj: object): { __mode: "k" | "v" | "kv" };
+
 export = () => {
 	it("should support set constructor", () => {
 		const set = new Set(["foo", "bar", "baz"]);
@@ -11,6 +13,37 @@ export = () => {
 		const f = new Instance("Frame");
 		set.add(f);
 		expect(set.has(f)).to.equal(true);
+		let i = 0;
+
+		let k = { x: i++ };
+
+		new WeakSet();
+		new WeakSet([]);
+		new WeakSet([...[[]]]);
+		new WeakSet([{}]);
+		new WeakSet([{ x: i++ }]);
+		new WeakSet([{ ...k }]);
+
+		expect(getmetatable(new WeakSet()).__mode).to.equal("k");
+		expect(getmetatable(new WeakSet([])).__mode).to.equal("k");
+		expect(getmetatable(new WeakSet([...[[]]])).__mode).to.equal("k");
+		expect(getmetatable(new WeakSet([{}])).__mode).to.equal("k");
+		expect(getmetatable(new WeakSet([{ x: i++ }])).__mode).to.equal("k");
+		expect(getmetatable(new WeakSet([{ ...k }])).__mode).to.equal("k");
+
+		const u = new WeakSet();
+		const v = new WeakSet([]);
+		const w = new WeakSet([...[[]]]);
+		const x = new WeakSet([{}]);
+		const y = new WeakSet([{ x: i++ }]);
+		const z = new WeakSet([{ ...k }]);
+
+		expect(getmetatable(u).__mode).to.equal("k");
+		expect(getmetatable(v).__mode).to.equal("k");
+		expect(getmetatable(w).__mode).to.equal("k");
+		expect(getmetatable(x).__mode).to.equal("k");
+		expect(getmetatable(y).__mode).to.equal("k");
+		expect(getmetatable(z).__mode).to.equal("k");
 	});
 
 	it("should support add", () => {


### PR DESCRIPTION
- Fixes WeakMap/WeakSet constructors so that they actually include `setmetatable({}, {__mode = "k"})` and so they do not create invalid expressionStatements in Lua (`appendDeclarationIfMissing`)
- Compiles `TS.Object_assign` in-line in object spread logic, and consolidates it into a single function for the compiler.
- Adds more tests for object spread logic appearing in different places (expected answers came from running the code as JS in Chrome)

Note: parameter [target](https://github.com/roblox-ts/roblox-ts/blob/f64d727314adc441203723b3a4b4484a8a5bc13a/src/compiler/object.ts#L7) is already a readable value, since Objects/Maps/Sets are by default pushed to `_0 = {}`, and are only named from the beginning in-line if they are the target of an identifier setter ([logic here](https://github.com/roblox-ts/roblox-ts/blob/f64d727314adc441203723b3a4b4484a8a5bc13a/src/compiler/object.ts#L101)). Hence the difference between `let o = {}` and `export let o = {}` when o has precedingStatements inside.