### PR TITLE
Make sure Sets/Map Constructors are always pushed

### DIFF
--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -48,13 +48,17 @@ export class CompilerState {
 		if (declaration && condition(declaration)) {
 			this.declarationContext.delete(node);
 			({ set: id } = declaration);
-			this.pushPrecedingStatements(
-				node,
+
+			const context = this.getCurrentPrecedingStatementContext(node);
+
+			context.push(
 				this.indent +
 					`${declaration.needsLocalizing ? "local " : ""}${id}${
 						expStr ? ` ${isReturn ? "" : "= "}${expStr}` : ""
 					};\n`,
 			);
+
+			context.isPushed = declaration.isIdentifier;
 		} else {
 			id = this.pushPrecedingStatementToReuseableId(node, expStr);
 		}
@@ -149,6 +153,8 @@ export class CompilerState {
 					}
 					const [, indentation, currentId, data] = matchesRegex;
 					if (indentation === this.indent && data === compiledSource) {
+						const currentContext = this.getCurrentPrecedingStatementContext(node);
+						currentContext.isPushed = true;
 						return currentId;
 					}
 				}

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -6,7 +6,7 @@ import { joinIndentedLines, removeBalancedParenthesisFromStringBorders, ScriptCo
 
 export type PrecedingStatementContext = Array<string> & { isPushed: boolean };
 
-interface DeclarationContext {
+export interface DeclarationContext {
 	isIdentifier: boolean;
 	needsLocalizing?: boolean;
 	set: string;

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -153,8 +153,7 @@ export class CompilerState {
 					}
 					const [, indentation, currentId, data] = matchesRegex;
 					if (indentation === this.indent && data === compiledSource) {
-						const currentContext = this.getCurrentPrecedingStatementContext(node);
-						currentContext.isPushed = true;
+						this.getCurrentPrecedingStatementContext(node).isPushed = true;
 						return currentId;
 					}
 				}

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -1,6 +1,6 @@
 import * as ts from "ts-morph";
 import { appendDeclarationIfMissing, compileCallArgumentsAndJoin, compileExpression, inheritsFromRoact } from ".";
-import { CompilerState } from "../CompilerState";
+import { CompilerState, DeclarationContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { inheritsFrom, isTupleType } from "../typeUtilities";
 import { getNonNullUnParenthesizedExpressionUpwards, joinIndentedLines, suggest } from "../utility";
@@ -61,32 +61,41 @@ function compileSetMapConstructorHelper(
 
 	const firstParam = args[0];
 
+	let exp: ts.Node = node;
+	let parent = getNonNullUnParenthesizedExpressionUpwards(node.getParent());
+	const { compile: compileElement, addMethodName: addMethodName } = compileMapSetElement.get(type)!;
+
+	while (ts.TypeGuards.isPropertyAccessExpression(parent) && addMethodName === parent.getName()) {
+		const grandparent = getNonNullUnParenthesizedExpressionUpwards(parent.getParent());
+		if (ts.TypeGuards.isCallExpression(grandparent)) {
+			exp = grandparent;
+			parent = getNonNullUnParenthesizedExpressionUpwards(grandparent.getParent());
+		} else {
+			break;
+		}
+	}
+
+	const pushCondition = ts.TypeGuards.isNewExpression(exp)
+		? () => true
+		: (declaration: DeclarationContext) => declaration.isIdentifier;
+
 	if (
 		firstParam &&
 		(!ts.TypeGuards.isArrayLiteralExpression(firstParam) ||
 			firstParam.getChildrenOfKind(ts.SyntaxKind.SpreadElement).length > 0)
 	) {
 		state.usesTSLibrary = true;
-		return preDeclaration + `TS.${type}_new(${compileCallArgumentsAndJoin(state, args)})` + postDeclaration;
+		const id = state.pushToDeclarationOrNewId(
+			exp,
+			preDeclaration + `TS.${type}_new(${compileCallArgumentsAndJoin(state, args)})` + postDeclaration,
+			pushCondition,
+		);
+		state.getCurrentPrecedingStatementContext(node).isPushed = true;
+		return id;
 	} else {
 		let id = "";
 		const lines = new Array<string>();
 		let hasContext = false;
-
-		const { compile: compileElement, addMethodName: addMethodName } = compileMapSetElement.get(type)!;
-
-		let exp: ts.Node = node;
-		let parent = getNonNullUnParenthesizedExpressionUpwards(node.getParent());
-
-		while (ts.TypeGuards.isPropertyAccessExpression(parent) && addMethodName === parent.getName()) {
-			const grandparent = getNonNullUnParenthesizedExpressionUpwards(parent.getParent());
-			if (ts.TypeGuards.isCallExpression(grandparent)) {
-				exp = grandparent;
-				parent = getNonNullUnParenthesizedExpressionUpwards(grandparent.getParent());
-			} else {
-				break;
-			}
-		}
 
 		if (firstParam) {
 			for (const element of firstParam.getElements()) {
@@ -131,7 +140,7 @@ function compileSetMapConstructorHelper(
 							"}" +
 							postDeclaration,
 
-				ts.TypeGuards.isNewExpression(exp) ? () => true : declaration => declaration.isIdentifier,
+				pushCondition,
 			);
 		}
 

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -90,7 +90,6 @@ function compileSetMapConstructorHelper(
 			preDeclaration + `TS.${type}_new(${compileCallArgumentsAndJoin(state, args)})` + postDeclaration,
 			pushCondition,
 		);
-		state.getCurrentPrecedingStatementContext(node).isPushed = true;
 		return id;
 	} else {
 		let id = "";
@@ -144,7 +143,6 @@ function compileSetMapConstructorHelper(
 			);
 		}
 
-		state.getCurrentPrecedingStatementContext(node).isPushed = true;
 		return id;
 	}
 }

--- a/tests/src/set.spec.ts
+++ b/tests/src/set.spec.ts
@@ -6,6 +6,66 @@ export = () => {
 		expect(set.has("foo")).to.equal(true);
 		expect(set.has("bar")).to.equal(true);
 		expect(set.has("baz")).to.equal(true);
+
+		{
+			new Set([1, 2, 3]);
+			new Set([1, 2, 3]).add(4);
+			new Set([1, 2, 3]).add(4).add(5);
+
+			const u = new Set([1, 2, 3]);
+			const v = new Set([1, 2, 3]).add(4);
+			const w = new Set([1, 2, 3]).add(4).add(5);
+
+			const x = () => new Set([1, 2, 3]);
+			const y = () => new Set([1, 2, 3]).add(4);
+			const z = () => new Set([1, 2, 3]).add(4).add(5);
+
+			let i = 0;
+
+			new Set([1, 2, i++]);
+			new Set([1, 2, i++]).add(4);
+			new Set([1, 2, i++]).add(4).add(5);
+
+			const a = new Set([1, 2, i++]);
+			const b = new Set([1, 2, i++]).add(4);
+			const c = new Set([1, 2, i++]).add(4).add(5);
+
+			const d = () => new Set([1, 2, i++]);
+			const e = () => new Set([1, 2, i++]).add(4);
+			const f = () => new Set([1, 2, i++]).add(4).add(5);
+
+			expect(i).to.equal(6);
+		}
+
+		{
+			new Set([...[1, 2, 3]]);
+			new Set([...[1, 2, 3]]).add(4);
+			new Set([...[1, 2, 3]]).add(4).add(5);
+
+			const u = new Set([...[1, 2, 3]]);
+			const v = new Set([...[1, 2, 3]]).add(4);
+			const w = new Set([...[1, 2, 3]]).add(4).add(5);
+
+			const x = () => new Set([...[1, 2, 3]]);
+			const y = () => new Set([...[1, 2, 3]]).add(4);
+			const z = () => new Set([...[1, 2, 3]]).add(4).add(5);
+
+			let i = 0;
+
+			new Set([...[1, 2, i++]]);
+			new Set([...[1, 2, i++]]).add(4);
+			new Set([...[1, 2, i++]]).add(4).add(5);
+
+			const a = new Set([...[1, 2, i++]]);
+			const b = new Set([...[1, 2, i++]]).add(4);
+			const c = new Set([...[1, 2, i++]]).add(4).add(5);
+
+			const d = () => new Set([...[1, 2, i++]]);
+			const e = () => new Set([...[1, 2, i++]]).add(4);
+			const f = () => new Set([...[1, 2, i++]]).add(4).add(5);
+
+			expect(i).to.equal(6);
+		}
 	});
 
 	it("should support weak sets", () => {

--- a/tests/src/set.spec.ts
+++ b/tests/src/set.spec.ts
@@ -22,19 +22,25 @@ export = () => {
 
 			let i = 0;
 
-			new Set([1, 2, i++]);
-			new Set([1, 2, i++]).add(4);
-			new Set([1, 2, i++]).add(4).add(5);
+			new Set([1, 2, () => i++]);
+			new Set([1, 2, () => i++]).add(4);
+			new Set([1, 2, () => i++]).add(4).add(5);
 
-			const a = new Set([1, 2, i++]);
-			const b = new Set([1, 2, i++]).add(4);
-			const c = new Set([1, 2, i++]).add(4).add(5);
+			const a = new Set([1, 2, () => i++]);
+			const b = new Set([1, 2, () => i++]).add(4);
+			const c = new Set([1, 2, () => i++]).add(4).add(5);
 
-			const d = () => new Set([1, 2, i++]);
-			const e = () => new Set([1, 2, i++]).add(4);
-			const f = () => new Set([1, 2, i++]).add(4).add(5);
+			const d = () => new Set([1, 2, () => i++]);
+			const e = () => new Set([1, 2, () => i++]).add(4);
+			const f = () => new Set([1, 2, () => i++]).add(4).add(5);
 
 			expect(i).to.equal(6);
+			d();
+			expect(i).to.equal(7);
+			e();
+			expect(i).to.equal(8);
+			f();
+			expect(i).to.equal(9);
 		}
 
 		{
@@ -52,19 +58,25 @@ export = () => {
 
 			let i = 0;
 
-			new Set([...[1, 2, i++]]);
-			new Set([...[1, 2, i++]]).add(4);
-			new Set([...[1, 2, i++]]).add(4).add(5);
+			new Set([...[1, 2, () => i++]]);
+			new Set([...[1, 2, () => i++]]).add(4);
+			new Set([...[1, 2, () => i++]]).add(4).add(5);
 
-			const a = new Set([...[1, 2, i++]]);
-			const b = new Set([...[1, 2, i++]]).add(4);
-			const c = new Set([...[1, 2, i++]]).add(4).add(5);
+			const a = new Set([...[1, 2, () => i++]]);
+			const b = new Set([...[1, 2, () => i++]]).add(4);
+			const c = new Set([...[1, 2, () => i++]]).add(4).add(5);
 
-			const d = () => new Set([...[1, 2, i++]]);
-			const e = () => new Set([...[1, 2, i++]]).add(4);
-			const f = () => new Set([...[1, 2, i++]]).add(4).add(5);
+			const d = () => new Set([...[1, 2, () => i++]]);
+			const e = () => new Set([...[1, 2, () => i++]]).add(4);
+			const f = () => new Set([...[1, 2, () => i++]]).add(4).add(5);
 
 			expect(i).to.equal(6);
+			d();
+			expect(i).to.equal(7);
+			e();
+			expect(i).to.equal(8);
+			f();
+			expect(i).to.equal(9);
 		}
 	});
 

--- a/tests/src/set.spec.ts
+++ b/tests/src/set.spec.ts
@@ -22,17 +22,17 @@ export = () => {
 
 			let i = 0;
 
-			new Set([1, 2, () => i++]);
-			new Set([1, 2, () => i++]).add(4);
-			new Set([1, 2, () => i++]).add(4).add(5);
+			new Set([1, 2, (() => i++)()]);
+			new Set([1, 2, (() => i++)()]).add(4);
+			new Set([1, 2, (() => i++)()]).add(4).add(5);
 
-			const a = new Set([1, 2, () => i++]);
-			const b = new Set([1, 2, () => i++]).add(4);
-			const c = new Set([1, 2, () => i++]).add(4).add(5);
+			const a = new Set([1, 2, (() => i++)()]);
+			const b = new Set([1, 2, (() => i++)()]).add(4);
+			const c = new Set([1, 2, (() => i++)()]).add(4).add(5);
 
-			const d = () => new Set([1, 2, () => i++]);
-			const e = () => new Set([1, 2, () => i++]).add(4);
-			const f = () => new Set([1, 2, () => i++]).add(4).add(5);
+			const d = () => new Set([1, 2, (() => i++)()]);
+			const e = () => new Set([1, 2, (() => i++)()]).add(4);
+			const f = () => new Set([1, 2, (() => i++)()]).add(4).add(5);
 
 			expect(i).to.equal(6);
 			d();
@@ -58,17 +58,17 @@ export = () => {
 
 			let i = 0;
 
-			new Set([...[1, 2, () => i++]]);
-			new Set([...[1, 2, () => i++]]).add(4);
-			new Set([...[1, 2, () => i++]]).add(4).add(5);
+			new Set([...[1, 2, (() => i++)()]]);
+			new Set([...[1, 2, (() => i++)()]]).add(4);
+			new Set([...[1, 2, (() => i++)()]]).add(4).add(5);
 
-			const a = new Set([...[1, 2, () => i++]]);
-			const b = new Set([...[1, 2, () => i++]]).add(4);
-			const c = new Set([...[1, 2, () => i++]]).add(4).add(5);
+			const a = new Set([...[1, 2, (() => i++)()]]);
+			const b = new Set([...[1, 2, (() => i++)()]]).add(4);
+			const c = new Set([...[1, 2, (() => i++)()]]).add(4).add(5);
 
-			const d = () => new Set([...[1, 2, () => i++]]);
-			const e = () => new Set([...[1, 2, () => i++]]).add(4);
-			const f = () => new Set([...[1, 2, () => i++]]).add(4).add(5);
+			const d = () => new Set([...[1, 2, (() => i++)()]]);
+			const e = () => new Set([...[1, 2, (() => i++)()]]).add(4);
+			const f = () => new Set([...[1, 2, (() => i++)()]]).add(4).add(5);
 
 			expect(i).to.equal(6);
 			d();


### PR DESCRIPTION
I documented they should always be pushed [here](https://github.com/roblox-ts/roblox-ts/blob/master/src/compiler/indexed.ts#L95). This makes sure they always are.