### PR TITLE
Don't wrap ReadableExpressionNames

### DIFF
--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -37,6 +37,7 @@ const STRING_MACRO_METHODS = ["format", "gmatch", "gsub", "lower", "rep", "rever
 
 export function shouldWrapExpression(subExp: ts.Node, strict: boolean) {
 	subExp = skipNodesDownwards(subExp);
+	console.log(subExp.getKindName());
 	return (
 		!ts.TypeGuards.isIdentifier(subExp) &&
 		!ts.TypeGuards.isThisExpression(subExp) &&
@@ -1022,7 +1023,7 @@ export function compileElementAccessCallExpression(
 	const expExp = skipNodesDownwards(expression.getExpression());
 	const accessor = ts.TypeGuards.isSuperExpression(expExp) ? "super" : getReadableExpressionName(state, expExp);
 
-	let accessedPath = compileElementAccessDataTypeExpression(state, expression, accessor)(
+	const accessedPath = compileElementAccessDataTypeExpression(state, expression, accessor)(
 		compileElementAccessBracketExpression(state, expression),
 	);
 	const params = node.getArguments().map(arg => skipNodesDownwards(arg)) as Array<ts.Expression>;
@@ -1047,10 +1048,6 @@ export function compileElementAccessCallExpression(
 			node,
 			CompilerErrorType.MixedMethodCall,
 		);
-	}
-
-	if (shouldWrapExpression(expExp, false)) {
-		accessedPath = `(${accessedPath})`;
 	}
 
 	return `${accessedPath}(${paramsStr})`;

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -37,7 +37,7 @@ const STRING_MACRO_METHODS = ["format", "gmatch", "gsub", "lower", "rep", "rever
 
 export function shouldWrapExpression(subExp: ts.Node, strict: boolean) {
 	subExp = skipNodesDownwards(subExp);
-	console.log(subExp.getKindName());
+
 	return (
 		!ts.TypeGuards.isIdentifier(subExp) &&
 		!ts.TypeGuards.isThisExpression(subExp) &&

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -275,12 +275,24 @@ function validateMethod(
 	checkDecorators(method);
 	checkMethodCollision(node, method);
 	checkDefaultIterator(extendsArray, method);
-	if (ts.TypeGuards.isComputedPropertyName(method.getNameNode())) {
-		throw new CompilerError(
-			"Cannot make a class with computed method names!",
-			method,
-			CompilerErrorType.ClassWithComputedMethodNames,
-		);
+	const nameNode = method.getNameNode();
+	if (ts.TypeGuards.isComputedPropertyName(nameNode)) {
+		let isSymbolPropAccess = false;
+		const exp = skipNodesDownwards(nameNode.getExpression());
+		if (ts.TypeGuards.isPropertyAccessExpression(exp)) {
+			const subExp = exp.getExpression();
+			if (ts.TypeGuards.isIdentifier(subExp) && subExp.getText() === "Symbol") {
+				isSymbolPropAccess = true;
+			}
+		}
+
+		if (!isSymbolPropAccess) {
+			throw new CompilerError(
+				"Cannot make a class with computed method names!",
+				method,
+				CompilerErrorType.ClassWithComputedMethodNames,
+			);
+		}
 	}
 }
 

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -280,7 +280,7 @@ function validateMethod(
 		let isSymbolPropAccess = false;
 		const exp = skipNodesDownwards(nameNode.getExpression());
 		if (ts.TypeGuards.isPropertyAccessExpression(exp)) {
-			const subExp = exp.getExpression();
+			const subExp = skipNodesDownwards(exp.getExpression());
 			if (ts.TypeGuards.isIdentifier(subExp) && subExp.getText() === "Symbol") {
 				isSymbolPropAccess = true;
 			}

--- a/tests/src/class.spec.ts
+++ b/tests/src/class.spec.ts
@@ -267,6 +267,19 @@ export = () => {
 		})().f("Go!");
 	});
 
+	it("should support Symbol.iterator", () => {
+		let i = 0;
+		for (const foo of new (class A extends class B {
+			*[Symbol.iterator]() {
+				yield 1;
+				yield 2;
+				yield 3;
+			}
+		} {})()) {
+			expect(foo).to.equal(++i);
+		}
+	});
+
 	it("should support extending from Array", () => {
 		/** A very bad implementation of a SortedArray class. Just for testing purposes. */
 		class SortedArray extends Array<number> {

--- a/tests/src/class.spec.ts
+++ b/tests/src/class.spec.ts
@@ -258,6 +258,7 @@ export = () => {
 		let i = 0;
 		new (class Boat extends class Goat {
 			[key: number]: () => number;
+			[Symbol.iterator]() {}
 		} {
 			public f(s: string, b?: boolean) {
 				this[i] = () => 10;


### PR DESCRIPTION
Wrapping is redundant because we already have this: https://github.com/roblox-ts/roblox-ts/pull/477/files#diff-50cd0512e4a61af2b2be7f3990caca7fR1024