### PR TITLE
Fix destructuring cases

### DIFF
--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -172,6 +172,9 @@ function objectAccessor(
 		const exp = skipNodesDownwards(nameNode.getExpression());
 		name = getComputedPropertyAccess(state, exp, rhs);
 		return `${t}[${name}]`;
+	} else if (ts.TypeGuards.isNumericLiteral(nameNode) || ts.TypeGuards.isStringLiteral(nameNode)) {
+		name = compileExpression(state, nameNode);
+		return `${t}[${name}]`;
 	} else {
 		throw new CompilerError(
 			`Cannot index an object with type ${nameNode.getKindName()}.`,
@@ -447,7 +450,11 @@ export function getBindingData(
 			const nameNode = item.getNameNode();
 			if (item.hasInitializer()) {
 				const initializer = skipNodesDownwards(item.getInitializer()!);
-				if (ts.TypeGuards.isIdentifier(initializer)) {
+				if (
+					ts.TypeGuards.isIdentifier(initializer) ||
+					ts.TypeGuards.isPropertyAccessExpression(initializer) ||
+					ts.TypeGuards.isElementAccessExpression(initializer)
+				) {
 					alias = compileExpression(state, initializer);
 					preStatements.push(`${alias} = ${objectAccessor(state, parentId, item, getAccessor, nameNode)};`);
 				} else {

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -242,6 +242,35 @@ export = () => {
 		expect(f(3)).to.equal(4);
 	});
 
+	it("should destructure into objects", () => {
+		const o = {
+			a: 100,
+			b: 100,
+			c: 100,
+			d: 100,
+			1: 100,
+
+			// tslint:disable
+			// prettier-ignore
+			"e":100
+		};
+
+		const f = (): "6" => "6";
+
+		// tslint:disable
+		// prettier-ignore
+		({ a: o.a, b: o.b, "9": o.c, 5: o.d, [f()]: o["e"], c: o[1] } = { a: 1, b: 2, c: 3, "9": 4, 5: 5, ["6"]: 6 });
+
+		let i = 0;
+
+		expect(o.a).to.equal(++i);
+		expect(o.b).to.equal(++i);
+		expect(o[1]).to.equal(++i);
+		expect(o.c).to.equal(++i);
+		expect(o.d).to.equal(++i);
+		expect(o["e"]).to.equal(++i);
+	});
+
 	it("should properly destruct objects with a Symbol.iterator method", () => {
 		const k = { o: 1, b: 2 };
 		const o = {


### PR DESCRIPTION
It appears I accidentally merged the changes into this other PR: <https://github.com/roblox-ts/roblox-ts/pull/478#issue-289104811>

Fixes:
```ts
const o = {
	a: 100,
	b: 100,
	c: 100,
	d: 100,
	1: 100,

	// tslint:disable
	// prettier-ignore
	"e":100
};

const f = (): "6" => "6";

// tslint:disable
// prettier-ignore
({ a: o.a, b: o.b, "9": o.c, 5: o.d, [f()]: o["e"], c: o[1] } = { a: 1, b: 2, c: 3, "9": 4, 5: 5, ["6"]: 6 });

let i = 0;

print(o.a, ++i);
print(o.b, ++i);
print(o[1], ++i);
print(o.c, ++i);
print(o.d, ++i);
print(o["e"], ++i);
```

From https://github.com/TypeScriptToLua/TypeScriptToLua/issues/574