### PR TITLE
Make definedInConst logic a bit smarter

### DIFF
--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -27,7 +27,14 @@ import { safeLuaIndex, skipNodesDownwards } from "../utility";
 export function isIdentifierDefinedInConst(exp: ts.Identifier) {
 	// I have no idea why, but getDefinitionNodes() cannot replace this
 	for (const def of exp.getDefinitions()) {
-		const definition = def.getNode().getFirstAncestorByKind(ts.SyntaxKind.VariableStatement);
+		const node = def.getNode();
+		// Namespace name identifiers are not variables which can be changed at run-time
+		if (ts.TypeGuards.isNamespaceDeclaration(node.getParent())) {
+			return true;
+		}
+
+		const definition = node.getFirstAncestorByKind(ts.SyntaxKind.VariableDeclarationList);
+
 		if (definition && definition.getDeclarationKind() === ts.VariableDeclarationKind.Const) {
 			return true;
 		}


### PR DESCRIPTION
In the future, I may write some code to detect whether a variable is modified within a given space, but for now, this will help cases like these compile better:

```ts
function catchLetters(...letterPairs: Array<LuaTuple<Array<string>>>) {
	let i = 96;
	for (const [a, b] of letterPairs) {
		print(a, string.char(++i));
		print(b, string.char(++i));
	}
}
```
Before:
```lua
local function catchLetters(...)
	local letterPairs = { ... };
	local i = 96;
	for _1 = 1, #letterPairs do
		local _0 = letterPairs[_1];
		local a, b = _0[1], _0[2];
		local _3 = a;
		local _2 = string;
		i = i + 1;
		print(_3, _2.char(i));
		local _5 = b;
		local _4 = string;
		i = i + 1;
		print(_5, _4.char(i));
	end;
end;
```
After:
```lua
local function catchLetters(...)
	local letterPairs = { ... };
	local i = 96;
	for _1 = 1, #letterPairs do
		local _0 = letterPairs[_1];
		local a, b = _0[1], _0[2];
		i = i + 1;
		print(a, string.char(i));
		i = i + 1;
		print(b, string.char(i));
	end;
end;
```