### PR TITLE
Remove __concat metamethod generation

### DIFF
--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -489,7 +489,6 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 
 	if (getClassMethod(node, "toString")) {
 		results.push(state.indent + `function ${name}:__tostring() return self:toString(); end;\n`);
-		results.push(state.indent + `function ${name}.__concat(a, b) return tostring(a) .. tostring(b) end;\n`);
 	}
 
 	if (isExpression) {


### PR DESCRIPTION
Since we already compile concats of classes with `tostring()`, it is unnecessary and cluttering to have __concat metamethods generated without reason.