### PR TITLE
Block static toString

### DIFF
--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -311,9 +311,9 @@ function compileClassInitializer(
 	results.push(state.indent + `${prefix}${name} = setmetatable({}, {\n`);
 	state.pushIndent();
 	if (node.getExtends()) {
-		results.push(state.indent + `__index = super,\n`);
+		results.push(state.indent + `__index = super;\n`);
 	}
-	results.push(state.indent + `__tostring = function() return "${name}" end,\n`);
+	results.push(state.indent + `__tostring = function() return "${name}" end;\n`);
 	state.popIndent();
 	results.push(state.indent + `});\n`);
 	results.push(state.indent + `${name}.__index = ${name};\n`);
@@ -444,7 +444,7 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 		if (method.getBody() !== undefined) {
 			const methodName = method.getName();
 
-			if (methodName === "new" || LUA_RESERVED_METAMETHODS.includes(methodName)) {
+			if (methodName === "new" || methodName === "toString" || LUA_RESERVED_METAMETHODS.includes(methodName)) {
 				throw new CompilerError(
 					`Cannot make a static method with name "${methodName}"!`,
 					method,


### PR DESCRIPTION
We need to block a static toString because of the way we now compile classes within a single namespace