### PR TITLE
Fix getWritableOperandName

### DIFF
--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -59,11 +59,6 @@ export function isIdentifierDefinedInExportLet(exp: ts.Identifier) {
 	return false;
 }
 
-function log<T>(arg: T) {
-	console.log(arg);
-	return arg;
-}
-
 /**
  * Gets the writable operand name, meaning the code should be able to do `returnValue = x;`
  * The rule in this case is that if there is a depth of 3 or more, e.g. `Foo.Bar.i`, we push `Foo.Bar`
@@ -112,10 +107,10 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 		}
 	}
 
-	return log({
+	return {
 		expStr: compileExpression(state, operand),
 		isIdentifier: ts.TypeGuards.isIdentifier(operand) && !isIdentifierDefinedInExportLet(operand),
-	});
+	};
 }
 
 /**

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -224,6 +224,10 @@ export function isNumberTypeStrict(type: ts.Type) {
 	return isSomeType(type, strictTypeConstraint, t => t.isNumber() || t.isNumberLiteral());
 }
 
+export function isNumericLiteralTypeStrict(type: ts.Type) {
+	return isSomeType(type, strictTypeConstraint, t => t.isNumberLiteral());
+}
+
 export function isStringType(type: ts.Type) {
 	return isSomeType(type, typeConstraint, t => t.isString() || t.isStringLiteral());
 }

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -41,6 +41,24 @@ export = () => {
 		expect(b).to.equal(1);
 		expect(c).to.equal(1);
 		expect(d).to.equal(1);
+
+		let j = 0;
+		function f() {
+			j++;
+			return 2;
+		}
+		const o: { [i: number]: number } = {
+			0: 2,
+			1: 4,
+			2: 5,
+			3: 6,
+			4: 5,
+		};
+		o[f()]++;
+		const x = o[f()]++;
+		expect(x).to.equal(6);
+		expect(o[2]).to.equal(7);
+		expect(j).to.equal(2);
 	});
 
 	it("should support bracket index definitions", () => {


### PR DESCRIPTION
Fixes cases like this from calling `f` twice due to not pushing it for a writable value:
```ts

const f = () => 2;
const o: { [i: number]: number } = {
	0: 2,
	1: 4,
	2: 5,
	3: 6,
	4: 5,
};
const x = o[f()]++;
```