### PR TITLE
Fix #506

### DIFF
--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -69,14 +69,15 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 			const rhsContext = state.exitPrecedingStatementContext();
 
 			if (rhsContext.length > 0) {
-				if (!ts.TypeGuards.isIdentifier(lhs) && !context.isPushed) {
+				if (!ts.TypeGuards.isIdentifier(child) && !context.isPushed) {
 					lhsStr = state.pushPrecedingStatementToReuseableId(lhs, lhsStr, rhsContext);
 				}
 				context.push(...rhsContext);
 				context.isPushed = rhsContext.isPushed;
 			}
+
 			line = `${
-				ts.TypeGuards.isIdentifier(lhs) ? safeLuaIndex("", lhs.getText()) : `[${lhsStr}]`
+				ts.TypeGuards.isIdentifier(child) ? safeLuaIndex("", lhs.getText()) : `[${lhsStr}]`
 			} = ${rhsStr};\n`;
 		} else if (ts.TypeGuards.isMethodDeclaration(prop)) {
 			line = "";

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -404,4 +404,13 @@ export = () => {
 	it("should support shorthand assignments", () => {
 		expect(++N.p.a.x).to.equal(6);
 	});
+
+	it("should support computed members", () => {
+		let a = 8;
+		let i = 0;
+		const b = { [a]: `${++i}${(a = 9)}` };
+		const c = { [a]: 1 };
+		expect(b[8]).to.equal(`19`);
+		expect(c[9]).to.equal(1);
+	});
 };


### PR DESCRIPTION
We were checking whether the wrong node is an identifier. We should have been checking `child`