### PR TITLE
Improve destructured assignment type tracking

### DIFF
--- a/src/Watcher.ts
+++ b/src/Watcher.ts
@@ -41,7 +41,10 @@ export class Watcher {
 	private async onSuccess() {
 		if (this.onSuccessCmd.length > 0) {
 			const parts = this.onSuccessCmd.split(/\s+/);
-			await spawn(parts.shift()!, parts, { stdio: "inherit" });
+			const command = parts.shift();
+			if (command) {
+				await spawn(command, parts, { stdio: "inherit" });
+			}
 		}
 	}
 

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -112,7 +112,7 @@ function compileBinaryLiteral(
 		statements.push(`local ${rootId} = ${compileExpression(state, rhs)};`);
 	}
 
-	statements.push(...compileBindingLiteral(state, lhs, rootId, rhs));
+	statements.push(...compileBindingLiteral(state, lhs, rootId, getType(rhs)));
 
 	const parent = skipNodesUpwards(node.getParentOrThrow());
 
@@ -168,7 +168,7 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 						ts.TypeGuards.isObjectLiteralExpression(element)
 					) {
 						const rootId = state.getNewId();
-						statements.push(...compileBindingLiteral(state, element, rootId, rhs));
+						statements.push(...compileBindingLiteral(state, element, rootId, getType(rhs)));
 						return rootId;
 					} else {
 						return compileExpression(state, element);

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -14,8 +14,8 @@ import {
 	getType,
 	isArrayMethodType,
 	isArrayType,
-	isIterableFunction,
-	isIterableIterator,
+	isIterableFunctionType,
+	isIterableIteratorType,
 	isMapMethodType,
 	isMapType,
 	isObjectType,
@@ -286,10 +286,10 @@ function getAccessorForBindingType(binding: ts.Node, type: ts.Type | Array<ts.Ty
 		return setAccessor;
 	} else if (isMapType(type)) {
 		return mapAccessor;
-	} else if (isIterableFunction(type)) {
+	} else if (isIterableFunctionType(type)) {
 		return iterableFunctionAccessor;
 	} else if (
-		isIterableIterator(type) ||
+		isIterableIteratorType(type) ||
 		isObjectType(type) ||
 		(node && (ts.TypeGuards.isThisExpression(node) || ts.TypeGuards.isSuperExpression(node)))
 	) {
@@ -481,7 +481,7 @@ function getSubTypeOrThrow(node: ts.Node, type: ts.Type | Array<ts.Type>, index:
 		} else if (isMapType(type)) {
 			// Map<K, V> -> [K, V]
 			return type.getTypeArguments();
-		} else if (isIterableIterator(type)) {
+		} else if (isIterableIteratorType(type)) {
 			// IterableIterator<T> -> T
 			return type.getTypeArguments()[0];
 		}

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -288,28 +288,22 @@ function getAccessorForBindingType(binding: ts.Node, type: ts.Type | Array<ts.Ty
 		return mapAccessor;
 	} else if (isIterableFunction(type)) {
 		return iterableFunctionAccessor;
-	} else {
-		if (
-			isIterableIterator(type) ||
-			isObjectType(type) ||
-			(node && (ts.TypeGuards.isThisExpression(node) || ts.TypeGuards.isSuperExpression(node)))
-		) {
-			return iterAccessor;
-		} else if (node) {
-			if (ts.TypeGuards.isObjectBindingPattern(node)) {
-				return null as never;
-			} else {
-				throw new CompilerError(
-					`Cannot destructure an object of type ${type.getText()}`,
-					node,
-					CompilerErrorType.BadDestructuringType,
-				);
-			}
-		}
+	} else if (
+		isIterableIterator(type) ||
+		isObjectType(type) ||
+		(node && (ts.TypeGuards.isThisExpression(node) || ts.TypeGuards.isSuperExpression(node)))
+	) {
+		return iterAccessor;
+	} else if (node && ts.TypeGuards.isObjectBindingPattern(node)) {
+		return null as never;
 	}
 
-	console.log(type.getText());
-	throw new CompilerError("Could not find get accessor", binding, CompilerErrorType.NoGetAccessor, true);
+	throw new CompilerError(
+		`Cannot destructure an object of type ${type.getText()}`,
+		binding,
+		CompilerErrorType.BadDestructuringType,
+		true,
+	);
 }
 
 export function concatNamesAndValues(

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -294,10 +294,9 @@ function getAccessorForBindingType(binding: ts.Node, type: ts.Type | Array<ts.Ty
 		(node && (ts.TypeGuards.isThisExpression(node) || ts.TypeGuards.isSuperExpression(node)))
 	) {
 		return iterAccessor;
-	} else if (node && ts.TypeGuards.isObjectBindingPattern(node)) {
-		return null as never;
 	}
 
+	/* istanbul ignore next */
 	throw new CompilerError(
 		`Cannot destructure an object of type ${type.getText()}`,
 		binding,

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -474,12 +474,16 @@ function getSubTypeOrThrow(node: ts.Node, type: ts.Type | Array<ts.Type>, index:
 				}
 			}
 		} else if (isStringType(type)) {
+			// T -> T
 			return type;
 		} else if (isSetType(type)) {
+			// Set<T> -> T
 			return type.getTypeArguments()[0];
 		} else if (isMapType(type)) {
+			// Map<K, V> -> [K, V]
 			return type.getTypeArguments();
 		} else if (isIterableIterator(type)) {
+			// IterableIterator<T> -> T
 			return type.getTypeArguments()[0];
 		}
 	} else {

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -485,11 +485,11 @@ function getSubTypeOrThrow(node: ts.Node, type: ts.Type | Array<ts.Type>, index:
 			// IterableIterator<T> -> T
 			return type.getTypeArguments()[0];
 		}
-	} else {
-		if (typeof index === "number") {
-			return type[index];
-		}
+	} else if (typeof index === "number") {
+		return type[index];
 	}
+
+	/* istanbul ignore next */
 	throw new CompilerError("Could not find subtype!", node, CompilerErrorType.BadDestructSubType, true);
 }
 

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -310,8 +310,8 @@ function getAccessorForBindingType(type: ts.Type | Array<ts.Type>, node?: ts.Nod
 			}
 		}
 	}
-	console.log(type.getText());
-	throw "hecK";
+	// todo make this a real CompilerError
+	throw "Could not find get accessor";
 }
 
 export function concatNamesAndValues(

--- a/src/compiler/binding.ts
+++ b/src/compiler/binding.ts
@@ -273,36 +273,45 @@ function iterableFunctionAccessor(
 	}
 }
 
-export function getAccessorForBindingType(bindingPattern: ts.Node) {
-	const bindingPatternType = getType(bindingPattern);
-	if (isArrayType(bindingPatternType)) {
+function getAccessorForBindingNode(bindingPattern: ts.Node) {
+	return getAccessorForBindingType(getType(bindingPattern), bindingPattern)!;
+}
+
+function getAccessorForBindingType(type: ts.Type | Array<ts.Type>, node?: ts.Node) {
+	if (!(type instanceof ts.Type) || isArrayType(type)) {
 		return arrayAccessor;
-	} else if (isStringType(bindingPatternType)) {
+	} else if (isStringType(type)) {
 		return stringAccessor;
-	} else if (isSetType(bindingPatternType)) {
+	} else if (isSetType(type)) {
 		return setAccessor;
-	} else if (isMapType(bindingPatternType)) {
+	} else if (isMapType(type)) {
 		return mapAccessor;
-	} else if (isIterableFunction(bindingPatternType)) {
+	} else if (isIterableFunction(type)) {
 		return iterableFunctionAccessor;
-	} else if (
-		isIterableIterator(bindingPatternType, bindingPattern) ||
-		isObjectType(bindingPatternType) ||
-		ts.TypeGuards.isThisExpression(bindingPattern) ||
-		ts.TypeGuards.isSuperExpression(bindingPattern)
-	) {
-		return iterAccessor;
 	} else {
-		if (ts.TypeGuards.isObjectBindingPattern(bindingPattern)) {
-			return null as never;
-		} else {
-			throw new CompilerError(
-				`Cannot destructure an object of type ${bindingPatternType.getText()}`,
-				bindingPattern,
-				CompilerErrorType.BadDestructuringType,
-			);
+		if (node) {
+			if (
+				isIterableIterator(type, node) ||
+				isObjectType(type) ||
+				ts.TypeGuards.isThisExpression(node) ||
+				ts.TypeGuards.isSuperExpression(node)
+			) {
+				return iterAccessor;
+			} else {
+				if (ts.TypeGuards.isObjectBindingPattern(node)) {
+					return null as never;
+				} else {
+					throw new CompilerError(
+						`Cannot destructure an object of type ${type.getText()}`,
+						node,
+						CompilerErrorType.BadDestructuringType,
+					);
+				}
+			}
 		}
 	}
+	console.log(type.getText());
+	throw "hecK";
 }
 
 export function concatNamesAndValues(
@@ -333,7 +342,7 @@ function compileArrayBindingPattern(
 ) {
 	let childIndex = 1;
 	const idStack = new Array<string>();
-	const getAccessor = getAccessorForBindingType(bindingPattern);
+	const getAccessor = getAccessorForBindingNode(bindingPattern);
 	for (const element of bindingPattern.getElements()) {
 		if (ts.TypeGuards.isOmittedExpression(element)) {
 			getAccessor(state, element, parentId, childIndex, idStack, true);
@@ -457,11 +466,11 @@ function compileArrayBindingLiteral(
 	state: CompilerState,
 	bindingLiteral: ts.ArrayLiteralExpression,
 	parentId: string,
-	accessNode: ts.Node,
+	accessType: ts.Type | Array<ts.Type>,
 ) {
 	let childIndex = 1;
 	const idStack = new Array<string>();
-	const getAccessor = getAccessorForBindingType(accessNode);
+	const getAccessor = getAccessorForBindingType(accessType);
 	for (const element of bindingLiteral.getElements()) {
 		if (ts.TypeGuards.isOmittedExpression(element)) {
 			getAccessor(state, element, parentId, childIndex, idStack, true);
@@ -488,7 +497,12 @@ function compileArrayBindingLiteral(
 			) {
 				const id = state.getNewId();
 				state.pushPrecedingStatements(bindingLiteral, state.indent + `local ${id} = ${rhs};\n`);
-				compileBindingLiteralInner(state, element, id, accessNode);
+				compileBindingLiteralInner(
+					state,
+					element,
+					id,
+					getSubTypeOrThrow(bindingLiteral, accessType, childIndex - 1),
+				);
 			} else {
 				throw new CompilerError(
 					`Unexpected ${element.getKindName()} in compileArrayBindingLiteral.`,
@@ -502,11 +516,41 @@ function compileArrayBindingLiteral(
 	}
 }
 
+function getSubTypeOrThrow(node: ts.Node, type: ts.Type | Array<ts.Type>, index: string | number) {
+	if (type instanceof ts.Type) {
+		if (typeof index === "string") {
+			const prop = type.getProperty(index);
+			if (prop) {
+				const valDec = prop.getValueDeclaration();
+				if (valDec) {
+					return getType(valDec);
+				}
+			}
+		} else if (isArrayType(type)) {
+			if (type.isTuple()) {
+				return type.getTupleElements()[index];
+			} else {
+				const numIndexType = type.getNumberIndexType();
+				if (numIndexType) {
+					return numIndexType;
+				}
+			}
+		} else if (isMapType(type)) {
+			return type.getTypeArguments();
+		}
+	} else {
+		if (typeof index === "number") {
+			return type[index];
+		}
+	}
+	throw new CompilerError("Could not find subtype!", node, CompilerErrorType.BadDestructSubType, true);
+}
+
 function compileObjectBindingLiteral(
 	state: CompilerState,
 	bindingLiteral: ts.ObjectLiteralExpression,
 	parentId: string,
-	accessNode: ts.Node,
+	accessType: ts.Type | Array<ts.Type>,
 ) {
 	for (const property of bindingLiteral.getProperties()) {
 		if (ts.TypeGuards.isShorthandPropertyAssignment(property)) {
@@ -543,7 +587,12 @@ function compileObjectBindingLiteral(
 			} else if (ts.TypeGuards.isObjectLiteralExpression(init) || ts.TypeGuards.isArrayLiteralExpression(init)) {
 				const id = state.getNewId();
 				state.pushPrecedingStatements(bindingLiteral, state.indent + `local ${id} = ${rhs};\n`);
-				compileBindingLiteralInner(state, init, id, accessNode);
+				compileBindingLiteralInner(
+					state,
+					init,
+					id,
+					getSubTypeOrThrow(bindingLiteral, accessType, property.getName()),
+				);
 			}
 		} else {
 			throw new CompilerError(
@@ -560,12 +609,12 @@ function compileBindingLiteralInner(
 	state: CompilerState,
 	bindingLiteral: BindingLiteral,
 	parentId: string,
-	accessNode: ts.Node,
+	accessType: ts.Type | Array<ts.Type>,
 ) {
 	if (ts.TypeGuards.isArrayLiteralExpression(bindingLiteral)) {
-		compileArrayBindingLiteral(state, bindingLiteral, parentId, accessNode);
+		compileArrayBindingLiteral(state, bindingLiteral, parentId, accessType);
 	} else if (ts.TypeGuards.isObjectLiteralExpression(bindingLiteral)) {
-		compileObjectBindingLiteral(state, bindingLiteral, parentId, accessNode);
+		compileObjectBindingLiteral(state, bindingLiteral, parentId, accessType);
 	}
 }
 
@@ -573,10 +622,10 @@ export function compileBindingLiteral(
 	state: CompilerState,
 	bindingLiteral: BindingLiteral,
 	parentId: string,
-	accessNode: ts.Node = bindingLiteral,
+	accessType: ts.Type | Array<ts.Type> = getType(bindingLiteral),
 ) {
 	state.enterPrecedingStatementContext();
-	compileBindingLiteralInner(state, bindingLiteral, parentId, accessNode);
+	compileBindingLiteralInner(state, bindingLiteral, parentId, accessType);
 	// TODO: remove .trim(), fix call sites
 	return state.exitPrecedingStatementContext().map(v => v.trim());
 }

--- a/src/compiler/forOf.ts
+++ b/src/compiler/forOf.ts
@@ -13,8 +13,8 @@ import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import {
 	getType,
 	isArrayType,
-	isIterableFunction,
-	isIterableIterator,
+	isIterableFunctionType,
+	isIterableIteratorType,
 	isMapType,
 	isSetType,
 	isStringType,
@@ -169,7 +169,7 @@ function getLoopType(
 		return [exp, ForOfLoopType.Array, reversed, backwards];
 	} else if (isStringType(expType)) {
 		return [exp, ForOfLoopType.String, reversed, backwards];
-	} else if (isIterableFunction(expType)) {
+	} else if (isIterableFunctionType(expType)) {
 		// Hack
 		if (expType.getText().match("<LuaTuple<")) {
 			return [exp, ForOfLoopType.IterableLuaTuple, reversed, backwards];
@@ -284,7 +284,7 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				key = varName;
 				break;
 			case ForOfLoopType.Symbol_iterator: {
-				if (!isIterableIterator(getType(exp))) {
+				if (!isIterableIteratorType(getType(exp))) {
 					expStr = getReadableExpressionName(state, exp, expStr);
 					expStr = `${expStr}[TS.Symbol_iterator](${expStr})`;
 				}

--- a/src/compiler/forOf.ts
+++ b/src/compiler/forOf.ts
@@ -284,7 +284,7 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				key = varName;
 				break;
 			case ForOfLoopType.Symbol_iterator: {
-				if (!isIterableIterator(getType(exp), exp)) {
+				if (!isIterableIterator(getType(exp))) {
 					expStr = getReadableExpressionName(state, exp, expStr);
 					expStr = `${expStr}[TS.Symbol_iterator](${expStr})`;
 				}

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -193,7 +193,7 @@ function compileFunction(
 
 	if (isGenerator) {
 		// will error if IterableIterator is nullable
-		isIterableIterator(node.getReturnType(), node);
+		isIterableIterator(node.getReturnType());
 		result += "\n";
 		state.pushIndent();
 		result += state.indent + `return {\n`;

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -13,7 +13,7 @@ import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import {
 	classDeclarationInheritsFromArray,
 	getType,
-	isIterableIterator,
+	isIterableIteratorType,
 	isTupleType,
 	shouldHoist,
 } from "../typeUtilities";
@@ -193,7 +193,7 @@ function compileFunction(
 
 	if (isGenerator) {
 		// will error if IterableIterator is nullable
-		isIterableIterator(node.getReturnType());
+		isIterableIteratorType(node.getReturnType());
 		result += "\n";
 		state.pushIndent();
 		result += state.indent + `return {\n`;

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -5,8 +5,8 @@ import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import {
 	getType,
 	isArrayType,
-	isIterableFunction,
-	isIterableIterator,
+	isIterableFunctionType,
+	isIterableIteratorType,
 	isMapType,
 	isSetType,
 	isStringType,
@@ -204,10 +204,10 @@ export function compileSpreadExpression(state: CompilerState, expression: ts.Exp
 		} else {
 			return `string.split(${compileExpression(state, expression)}, "")`;
 		}
-	} else if (isIterableFunction(expType)) {
+	} else if (isIterableFunctionType(expType)) {
 		state.usesTSLibrary = true;
 		return `TS.iterableFunctionCache(${compileExpression(state, expression)})`;
-	} else if (isIterableIterator(expType)) {
+	} else if (isIterableIteratorType(expType)) {
 		state.usesTSLibrary = true;
 		return `TS.iterableCache(${compileExpression(state, expression)})`;
 	} else {

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -207,7 +207,7 @@ export function compileSpreadExpression(state: CompilerState, expression: ts.Exp
 	} else if (isIterableFunction(expType)) {
 		state.usesTSLibrary = true;
 		return `TS.iterableFunctionCache(${compileExpression(state, expression)})`;
-	} else if (isIterableIterator(expType, expression)) {
+	} else if (isIterableIterator(expType)) {
 		state.usesTSLibrary = true;
 		return `TS.iterableCache(${compileExpression(state, expression)})`;
 	} else {

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -127,7 +127,7 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 				!isArrayType(rhsType) &&
 				!isMapType(rhsType) &&
 				!isSetType(rhsType) &&
-				!isIterableIterator(rhsType, rhs) &&
+				!isIterableIterator(rhsType) &&
 				!isIterableFunction(rhsType) &&
 				(isObjectType(rhsType) || ts.TypeGuards.isThisExpression(rhs))
 			) {

--- a/src/compiler/variable.ts
+++ b/src/compiler/variable.ts
@@ -5,8 +5,8 @@ import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import {
 	getType,
 	isArrayType,
-	isIterableFunction,
-	isIterableIterator,
+	isIterableFunctionType,
+	isIterableIteratorType,
 	isMapType,
 	isObjectType,
 	isSetType,
@@ -127,8 +127,8 @@ export function compileVariableDeclaration(state: CompilerState, node: ts.Variab
 				!isArrayType(rhsType) &&
 				!isMapType(rhsType) &&
 				!isSetType(rhsType) &&
-				!isIterableIterator(rhsType) &&
-				!isIterableFunction(rhsType) &&
+				!isIterableIteratorType(rhsType) &&
+				!isIterableFunctionType(rhsType) &&
 				(isObjectType(rhsType) || ts.TypeGuards.isThisExpression(rhs))
 			) {
 				state.usesTSLibrary = true;

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -90,6 +90,7 @@ export enum CompilerErrorType {
 	ClassWithComputedMethodNames,
 	IsolatedContainer,
 	UnexpectedExtensionType,
+	BadDestructSubType,
 }
 
 export class CompilerError extends LoggableError {

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -91,6 +91,7 @@ export enum CompilerErrorType {
 	IsolatedContainer,
 	UnexpectedExtensionType,
 	BadDestructSubType,
+	NoGetAccessor,
 }
 
 export class CompilerError extends LoggableError {

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -91,7 +91,6 @@ export enum CompilerErrorType {
 	IsolatedContainer,
 	UnexpectedExtensionType,
 	BadDestructSubType,
-	NoGetAccessor,
 }
 
 export class CompilerError extends LoggableError {

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -242,7 +242,7 @@ export function isEnumType(type: ts.Type) {
 	});
 }
 
-export function isIterableIterator(type: ts.Type, node: ts.Node) {
+export function isIterableIterator(type: ts.Type) {
 	return isSomeType(type, typeConstraint, t => {
 		const symbol = t.getSymbol();
 		return symbol ? symbol.getEscapedName() === "IterableIterator" : false;

--- a/src/typeUtilities.ts
+++ b/src/typeUtilities.ts
@@ -242,14 +242,14 @@ export function isEnumType(type: ts.Type) {
 	});
 }
 
-export function isIterableIterator(type: ts.Type) {
+export function isIterableIteratorType(type: ts.Type) {
 	return isSomeType(type, typeConstraint, t => {
 		const symbol = t.getSymbol();
 		return symbol ? symbol.getEscapedName() === "IterableIterator" : false;
 	});
 }
 
-export function isIterableFunction(type: ts.Type) {
+export function isIterableFunctionType(type: ts.Type) {
 	return isSomeType(type, check, t => {
 		const symbol = t.getAliasSymbol();
 		return symbol ? symbol.getEscapedName() === "IterableFunction" : false;

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -541,4 +541,53 @@ export = () => {
 		({ x: y = 5 } = {});
 		expect(y).to.equal(5);
 	});
+
+	it("should destructure assign with nested sets", () => {
+		let a = "";
+		const obj = {
+			x: new Set(["heck"]),
+		};
+		({
+			x: [a],
+		} = obj);
+		expect(a).to.equal("heck");
+	});
+
+	it("should destructure assign with nested maps", () => {
+		let a: [string, number];
+		const obj = {
+			x: new Map([["heck", 123]]),
+		};
+		({
+			x: [a],
+		} = obj);
+		expect(a[0]).to.equal("heck");
+		expect(a[1]).to.equal(123);
+	});
+
+	it("should destructure assign with nested maps keys and values", () => {
+		let a: string;
+		let b: number;
+		const obj = {
+			x: new Map([["heck", 123]]),
+		};
+		({
+			x: [[a, b]],
+		} = obj);
+		expect(a).to.equal("heck");
+		expect(b).to.equal(123);
+	});
+
+	it("should destructure assign with double nested maps keys and values", () => {
+		let a: string;
+		let b: number;
+		const obj = {
+			x: [new Map([["heck", 123]])],
+		};
+		({
+			x: [[[a, b]]],
+		} = obj);
+		expect(a).to.equal("heck");
+		expect(b).to.equal(123);
+	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -612,4 +612,46 @@ export = () => {
 		} = obj);
 		expect(a).to.equal("h");
 	});
+
+	it("should destructure nested generators", () => {
+		function* foo() {
+			yield 1;
+			yield 2;
+			yield 3;
+		}
+
+		const obj = {
+			x: foo(),
+		};
+		let a = 0;
+		let b = 0;
+		let c = 0;
+		({
+			x: [a, b, c],
+		} = obj);
+		expect(a).to.equal(1);
+		expect(b).to.equal(2);
+		expect(c).to.equal(3);
+	});
+
+	it("should destructure double nested generators", () => {
+		function* foo() {
+			yield 1;
+			yield 2;
+			yield 3;
+		}
+
+		const obj = {
+			x: [foo()],
+		};
+		let a = 0;
+		let b = 0;
+		let c = 0;
+		({
+			x: [[a, b, c]],
+		} = obj);
+		expect(a).to.equal(1);
+		expect(b).to.equal(2);
+		expect(c).to.equal(3);
+	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -672,14 +672,35 @@ export = () => {
 
 	it("should destructure nested strings", () => {
 		const obj = {
-			x: "abc",
+			x: new Map([["foo", 1]]),
 		};
+
+		let a = "";
+
+		({
+			x: [[[[[a]]]]],
+		} = obj);
+
+		expect(a).to.equal("f");
+	});
+
+	it("should get sub type of iterable iterator", () => {
+		function* foo() {
+			yield "abc";
+		}
+
+		const obj = {
+			x: foo(),
+		};
+
 		let a = "";
 		let b = "";
 		let c = "";
+
 		({
-			x: [a, b, c],
+			x: [[a, b, c]],
 		} = obj);
+
 		expect(a).to.equal("a");
 		expect(b).to.equal("b");
 		expect(c).to.equal("c");

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -654,4 +654,34 @@ export = () => {
 		expect(b).to.equal(2);
 		expect(c).to.equal(3);
 	});
+
+	it("should destructure nested strings", () => {
+		const obj = {
+			x: "abc",
+		};
+		let a = "";
+		let b = "";
+		let c = "";
+		({
+			x: [a, b, c],
+		} = obj);
+		expect(a).to.equal("a");
+		expect(b).to.equal("b");
+		expect(c).to.equal("c");
+	});
+
+	it("should destructure nested strings", () => {
+		const obj = {
+			x: "abc",
+		};
+		let a = "";
+		let b = "";
+		let c = "";
+		({
+			x: [a, b, c],
+		} = obj);
+		expect(a).to.equal("a");
+		expect(b).to.equal("b");
+		expect(c).to.equal("c");
+	});
 };

--- a/tests/src/destructure.spec.ts
+++ b/tests/src/destructure.spec.ts
@@ -590,4 +590,26 @@ export = () => {
 		expect(a).to.equal("heck");
 		expect(b).to.equal(123);
 	});
+
+	it("should destructure assign with double nested sets", () => {
+		let a: string;
+		const obj = {
+			x: [new Set(["heck"])],
+		};
+		({
+			x: [[a]],
+		} = obj);
+		expect(a).to.equal("heck");
+	});
+
+	it("should destructure assign with triple nested sets", () => {
+		let a: string;
+		const obj = {
+			x: [new Set(["heck"])],
+		};
+		({
+			x: [[[a]]],
+		} = obj);
+		expect(a).to.equal("h");
+	});
 };


### PR DESCRIPTION
Still need to add tests. i.e.:

```TS
const obj = {
	y: [new Map([["a", 1]])]
};

let d: string;
let e: number;

({
	y: [[[d, e]]]
} = obj);

print(d, e); // a 1
```