### PR TITLE
Rename _exports/_default to exports/default

### DIFF
--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -225,7 +225,7 @@ export class CompilerState {
 		}
 
 		const ancestorName = this.getExportContextName(node);
-		const alias = node.hasDefaultKeyword() ? "_default" : name;
+		const alias = node.hasDefaultKeyword() ? "default" : name;
 		this.exportStack[this.exportStack.length - 1].add(`${ancestorName}.${alias} = ${name};\n`);
 	}
 
@@ -236,7 +236,7 @@ export class CompilerState {
 			name = myNamespace.getName();
 			name = this.namespaceStack.get(name) || name;
 		} else {
-			name = "_exports";
+			name = "exports";
 			this.isModule = true;
 		}
 

--- a/src/compiler/module.ts
+++ b/src/compiler/module.ts
@@ -274,7 +274,7 @@ export function compileImportDeclaration(state: CompilerState, node: ts.ImportDe
 		}
 
 		lhs.push(defaultImportExp);
-		rhs.push(`._default`);
+		rhs.push(`.default`);
 		unlocalizedImports.push("");
 	}
 
@@ -395,7 +395,7 @@ export function compileExportDeclaration(state: CompilerState, node: ts.ExportDe
 			ancestorName = ancestor.getName();
 		} else {
 			state.isModule = true;
-			ancestorName = "_exports";
+			ancestorName = "exports";
 		}
 		return state.indent + `TS.exportNamespace(${luaPath}, ${ancestorName});\n`;
 	} else {
@@ -409,7 +409,7 @@ export function compileExportDeclaration(state: CompilerState, node: ts.ExportDe
 			ancestorName = ancestor.getName();
 		} else {
 			state.isModule = true;
-			ancestorName = "_exports";
+			ancestorName = "exports";
 		}
 
 		namedExports.forEach(namedExport => {
@@ -417,7 +417,7 @@ export function compileExportDeclaration(state: CompilerState, node: ts.ExportDe
 			const nameNode = namedExport.getNameNode();
 			let name = nameNode.getText();
 			if (name === "default") {
-				name = "_default";
+				name = "default";
 			}
 			const alias = aliasNode ? aliasNode.getText() : name;
 			checkReserved(aliasNode || nameNode);
@@ -454,7 +454,7 @@ export function compileExportAssignment(state: CompilerState, node: ts.ExportAss
 		state.isModule = true;
 		state.enterPrecedingStatementContext();
 		const expStr = compileExpression(state, exp);
-		return state.exitPrecedingStatementContextAndJoin() + `_exports = ${expStr};\n`;
+		return state.exitPrecedingStatementContextAndJoin() + `exports = ${expStr};\n`;
 	} else {
 		const symbol = node.getSymbol();
 		if (symbol) {
@@ -462,7 +462,7 @@ export function compileExportAssignment(state: CompilerState, node: ts.ExportAss
 				state.isModule = true;
 				state.enterPrecedingStatementContext();
 				const expStr = compileExpression(state, exp);
-				return state.exitPrecedingStatementContextAndJoin() + "_exports._default = " + expStr + ";\n";
+				return state.exitPrecedingStatementContextAndJoin() + "exports.default = " + expStr + ";\n";
 			}
 		}
 	}

--- a/src/compiler/security.ts
+++ b/src/compiler/security.ts
@@ -89,7 +89,7 @@ const LUA_RESERVED_NAMESPACES = [
 	"Ray",
 ];
 
-const TS_RESERVED_KEYWORDS = ["_exports", "undefined", "TS", "globalThis", "table", "_continue_"];
+const TS_RESERVED_KEYWORDS = ["undefined", "TS", "globalThis", "table", "_continue_"];
 
 const LUA_RESERVED_KEYWORDS = [
 	"and",

--- a/src/compiler/sourceFile.ts
+++ b/src/compiler/sourceFile.ts
@@ -80,11 +80,11 @@ export function compileSourceFile(state: CompilerState, node: ts.SourceFile) {
 		}
 
 		if (hasExportEquals) {
-			result = state.indent + `local _exports;\n` + result;
+			result = state.indent + `local exports;\n` + result;
 		} else {
-			result = state.indent + `local _exports = {};\n` + result;
+			result = state.indent + `local exports = {};\n` + result;
 		}
-		result += state.indent + "return _exports;\n";
+		result += state.indent + "return exports;\n";
 	} else {
 		if (scriptType === ScriptType.Module) {
 			result += state.indent + "return nil;\n";

--- a/tests/src/errors/reservedId.spec.ts
+++ b/tests/src/errors/reservedId.spec.ts
@@ -1,2 +1,2 @@
-const _exports = 1;
+const globalThis = 1;
 export {};


### PR DESCRIPTION
"_exports" -> "exports"
"_default" -> "default"

These are already reserved keywords in TS, so we're safe. Magically resolves a few bugs.

Slightly breaking change, these packages would need to be recompiled:
https://www.npmjs.com/package/@rbxts/tween @Validark 
https://www.npmjs.com/package/@rbxts/yield-for-character @Validark 
https://www.npmjs.com/package/@rbxts/net @Vorlias 