### PR TITLE
Respect packages requiring a specific version other than the installed one

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -66,10 +66,6 @@ function TS.getModule(moduleName)
 		repeat
 			local modules = object:FindFirstChild("node_modules")
 			if modules then
-				local subModules = modules:FindFirstChild("@rbxts")
-				if subModules then
-					modules = subModules
-				end
 				local module = modules:FindFirstChild(moduleName)
 				if module then
 					return module

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -58,21 +58,22 @@ TS.Symbol_iterator = Symbol("Symbol.iterator")
 local globalModules = script.Parent:FindFirstChild("node_modules")
 
 function TS.getModule(moduleName)
-	local object = getfenv(2).script.Parent
-	if not globalModules then
-		error("Could not find any modules!", 2)
-	end
-	if object:IsDescendantOf(globalModules) then
-		while object.Parent do
+	local object = getfenv(2).script
+	if object:IsDescendantOf(globalModules or error("Could not find any modules!", 2)) then
+		repeat
 			local modules = object:FindFirstChild("node_modules")
 			if modules then
+				local subModules = modules:FindFirstChild("@rbxts")
+				if subModules then
+					modules = subModules
+				end
 				local module = modules:FindFirstChild(moduleName)
 				if module then
 					return module
 				end
 			end
 			object = object.Parent
-		end
+		until object == nil
 	else
 		local module = globalModules:FindFirstChild(moduleName)
 		if module then

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -59,7 +59,10 @@ local globalModules = script.Parent:FindFirstChild("node_modules")
 
 function TS.getModule(moduleName)
 	local object = getfenv(2).script
-	if object:IsDescendantOf(globalModules or error("Could not find any modules!", 2)) then
+	if not globalModules then
+		error("Could not find any modules!", 2)
+	end
+	if object:IsDescendantOf(globalModules) then
 		repeat
 			local modules = object:FindFirstChild("node_modules")
 			if modules then


### PR DESCRIPTION
I (accidentally) ran into this with my `@rbxts/yield-for-tree@1.0.6` package.

My package.json had this in it:
```js
"dependencies": {
    "@rbxts/validate-tree": "1.0.0" // note how there is no "^" at the start
}
```
In my project, I had installed `@rbxts/validate-tree@1.0.2`, so it (accidentally) installed like so:

![image](https://user-images.githubusercontent.com/15217173/62116195-606f2c00-b27f-11e9-8ff7-57c6d3e4acd1.png)