### PR TITLE
Truthy update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### **0.3.0**
-- Truthiness Rework
-	- ...
+- Truthiness Rework: Truthiness is now evaluated like in TypeScript/JavaScript
+	- Added compiler option `--logTruthyChanges`, which displays all code affected by the truthiness change.
+- Fixed and/or expressions which now respect the control flow of expressions which require multiple statements in Lua
 - Fixed #586 - `new ReadonlySet()` and `new ReadonlyMap()` now work
 - Fixed #604 - `rbxtsc --init package` now fills out package.json better
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### **0.3.0**
-- Truthiness Rework: Truthiness is now evaluated like in TypeScript/JavaScript
+- Truthiness Rework: Truthiness is now evaluated like in TypeScript/JavaScript. `0`, `""`, and `NaN` are now falsy.
 	- Added compiler option `--logTruthyChanges`, which displays all code affected by the truthiness change.
 - Fixed and/or expressions which now respect the control flow of expressions which require multiple statements in Lua
 - Fixed #586 - `new ReadonlySet()` and `new ReadonlyMap()` now work

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -39,6 +39,7 @@ export class CompilerState {
 		public readonly modulesPath: string,
 		public readonly rojoProject?: RojoProject,
 		public readonly runtimeOverride?: string,
+		public readonly logTruthyDifferences?: boolean,
 	) {}
 	public declarationContext = new Map<ts.Node, DeclarationContext>();
 	public alreadyCheckedTruthyConditionals = new Array<ts.Node>();

--- a/src/CompilerState.ts
+++ b/src/CompilerState.ts
@@ -58,7 +58,6 @@ export class CompilerState {
 	}
 
 	public currentConditionalContext: string = "";
-	public currentTruthyContext: string = "";
 	private precedingStatementContexts = new Array<PrecedingStatementContext>();
 
 	public getCurrentPrecedingStatementContext(node: ts.Node) {

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -117,7 +117,7 @@ interface ProjectOptions {
 	noInclude?: boolean;
 	minify?: boolean;
 	ci?: boolean;
-	truthyChanges?: boolean;
+	logTruthyChanges?: boolean;
 }
 
 export class Project {
@@ -252,7 +252,7 @@ export class Project {
 			this.rojoOverridePath = opts.rojo !== "" ? joinIfNotAbsolute(this.projectPath, opts.rojo) : undefined;
 
 			this.ci = opts.ci === true;
-			this.logTruthyDifferences = opts.truthyChanges;
+			this.logTruthyDifferences = opts.logTruthyChanges;
 
 			const rootPath = this.compilerOptions.rootDir;
 			if (!rootPath) {

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -117,6 +117,7 @@ interface ProjectOptions {
 	noInclude?: boolean;
 	minify?: boolean;
 	ci?: boolean;
+	truthyChanges?: boolean;
 }
 
 export class Project {
@@ -135,6 +136,8 @@ export class Project {
 	private readonly includePath: string;
 	private readonly noInclude: boolean;
 	private readonly minify: boolean;
+	public readonly logTruthyDifferences: boolean | undefined;
+
 	private readonly rootPath: string;
 	private readonly outPath: string;
 	private readonly rojoOverridePath: string | undefined;
@@ -249,6 +252,7 @@ export class Project {
 			this.rojoOverridePath = opts.rojo !== "" ? joinIfNotAbsolute(this.projectPath, opts.rojo) : undefined;
 
 			this.ci = opts.ci === true;
+			this.logTruthyDifferences = opts.truthyChanges;
 
 			const rootPath = this.compilerOptions.rootDir;
 			if (!rootPath) {
@@ -668,6 +672,7 @@ export class Project {
 			this.modulesPath,
 			this.rojoProject,
 			this.runtimeOverride,
+			this.logTruthyDifferences,
 		);
 	}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,6 +85,12 @@ const argv = yargs
 		type: "boolean",
 	})
 
+	.option("truthyChanges", {
+		alias: "logTruthyChanges",
+		boolean: true,
+		describe: "logs changes to truthiness evaluation from Lua truthiness rules",
+	})
+
 	// parse
 	.parse();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,8 +85,7 @@ const argv = yargs
 		type: "boolean",
 	})
 
-	.option("truthyChanges", {
-		alias: "logTruthyChanges",
+	.option("logTruthyChanges", {
 		boolean: true,
 		describe: "logs changes to truthiness evaluation from Lua truthiness rules",
 	})

--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -275,7 +275,7 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 			? ""
 			: isStatement && rhsStrContext.length === 0
 			? lhsStr
-			: state.pushPrecedingStatementToReuseableId(lhs, lhsStr, rhsStrContext);
+			: state.pushPrecedingStatementToNewId(lhs, lhsStr);
 
 		let { isPushed } = rhsStrContext;
 		state.pushPrecedingStatements(rhs, ...rhsStrContext);
@@ -374,7 +374,7 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 
 			if (rhsContext.length > 0) {
 				if (shouldPushToPrecedingStatement(lhs, lhsStr, state.getCurrentPrecedingStatementContext(lhs))) {
-					lhsStr = state.pushPrecedingStatementToReuseableId(lhs, lhsStr, rhsContext);
+					lhsStr = state.pushToDeclarationOrNewId(lhs, lhsStr);
 				}
 				state.pushPrecedingStatements(rhs, ...rhsContext);
 			}

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -353,7 +353,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			} else {
 				const node = getLeftHandSideParent(subExp, 2);
 				let id: string;
-				const len = state.pushPrecedingStatementToReuseableId(subExp, `#${accessPath}`);
+				const len = state.pushPrecedingStatementToNewId(subExp, `#${accessPath}`);
 				const place = `${accessPath}[${len}]`;
 				const nullSet = state.indent + `${place} = nil; -- ${subExp.getText()}.pop\n`;
 				id = state.pushToDeclarationOrNewId(node, place);
@@ -374,7 +374,7 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			const accessPath = getReadableExpressionName(state, subExp);
 			let id: string;
 
-			const len = state.pushPrecedingStatementToReuseableId(subExp, `#${accessPath}`);
+			const len = state.pushPrecedingStatementToNewId(subExp, `#${accessPath}`);
 			const lastPlace = `${accessPath}[${len}]`;
 
 			const isStatement = getPropertyCallParentIsExpressionStatement(subExp);
@@ -716,7 +716,7 @@ export function compileList(
 			}
 
 			if (shouldPushToPrecedingStatement(arg, argStr, cachedStrs || [])) {
-				argStrs[i] = state.pushPrecedingStatementToReuseableId(arg, argStr, cached[i + 1]);
+				argStrs[i] = state.pushPrecedingStatementToNewId(arg, argStr);
 			}
 		}
 

--- a/src/compiler/conditional.ts
+++ b/src/compiler/conditional.ts
@@ -26,6 +26,7 @@ function compileConditionalBlock(
 	if (state.declarationContext.delete(whenCondition) && id !== whenTrueStr) {
 		state.pushPrecedingStatements(whenCondition, makeSetStatement(state, id, whenTrueStr));
 	}
+
 	state.popIdStack();
 	state.popIndent();
 }
@@ -35,7 +36,7 @@ export function compileConditionalExpression(state: CompilerState, node: ts.Cond
 	const currentConditionalContext = state.currentConditionalContext;
 	const declaration = state.declarationContext.get(node);
 
-	const isInTruthyCheck = isExpInTruthyCheck(node);
+	const isInTruthyCheck = Boolean(isExpInTruthyCheck(node));
 
 	if (isInTruthyCheck) {
 		state.alreadyCheckedTruthyConditionals.push(skipNodesUpwardsLookAhead(node));

--- a/src/compiler/indexed.ts
+++ b/src/compiler/indexed.ts
@@ -72,7 +72,7 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 			!ts.TypeGuards.isSuperExpression(child) &&
 			(!ts.TypeGuards.isIdentifier(child) || isIdentifierDefinedInExportLet(child))
 		) {
-			const id = state.pushPrecedingStatementToReuseableId(operand, compileExpression(state, child));
+			const id = state.pushPrecedingStatementToNewId(operand, compileExpression(state, child));
 
 			let propertyStr: string;
 			if (doNotCompileAccess) {
@@ -100,7 +100,7 @@ export function getWritableOperandName(state: CompilerState, operand: ts.Express
 			) {
 				const access = getComputedPropertyAccess(state, exp, fromNode);
 				return {
-					expStr: id + "[" + state.pushPrecedingStatementToReuseableId(exp, access) + "]",
+					expStr: id + "[" + state.pushPrecedingStatementToNewId(exp, access) + "]",
 					isIdentifier: false,
 				};
 			}
@@ -132,7 +132,7 @@ export function getReadableExpressionName(
 	) {
 		return expStr;
 	} else {
-		return state.pushPrecedingStatementToReuseableId(nonNullExp, expStr);
+		return state.pushPrecedingStatementToNewId(nonNullExp, expStr);
 	}
 }
 

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -70,7 +70,7 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 
 			if (rhsContext.length > 0) {
 				if (!ts.TypeGuards.isIdentifier(child) && !context.isPushed) {
-					lhsStr = state.pushPrecedingStatementToReuseableId(lhs, lhsStr, rhsContext);
+					lhsStr = state.pushPrecedingStatementToNewId(lhs, lhsStr);
 				}
 				context.push(...rhsContext);
 				context.isPushed = rhsContext.isPushed;

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -129,7 +129,7 @@ export function compileSpreadableList(
 						nextContext.isPushed = false;
 					}
 
-					parts[i] = state.pushPrecedingStatementToReuseableId(arg, part, nextContext);
+					parts[i] = state.pushPrecedingStatementToNewId(arg, part);
 				}
 				gIter++;
 			} else {
@@ -146,7 +146,7 @@ export function compileSpreadableList(
 					}
 
 					if (shouldPushToPrecedingStatement(subExp, subStr, subContext)) {
-						part[j] = state.pushPrecedingStatementToReuseableId(subExp, subStr, context[j + 1]);
+						part[j] = state.pushPrecedingStatementToNewId(subExp, subStr);
 					}
 
 					if (++gIter === lastContextualIndex) {

--- a/src/compiler/truthiness.ts
+++ b/src/compiler/truthiness.ts
@@ -59,20 +59,20 @@ function getParentWhile(myNode: ts.Node, condition: (parent: ts.Node, node: ts.N
  * So we just whitelist the nodes we can safely climb and optimize those.
  */
 export function isExpInTruthyCheck(node: ts.Node) {
-	const parent = getParentWhile(node, (p, n) => {
-		if (ts.TypeGuards.isParenthesizedExpression(p) || ts.TypeGuards.isNonNullExpression(p)) {
-			return true;
-		} else if (ts.TypeGuards.isBinaryExpression(p)) {
-			const opKind = p.getOperatorToken().getKind();
-			return opKind === ts.SyntaxKind.AmpersandAmpersandToken || opKind === ts.SyntaxKind.BarBarToken;
-		} else if (ts.TypeGuards.isConditionalExpression(p) && (p.getWhenTrue() === n || p.getWhenFalse() === n)) {
-			return true;
-		} else {
-			return false;
-		}
-	});
+	const previous =
+		getParentWhile(node, (p, n) => {
+			if (ts.TypeGuards.isParenthesizedExpression(p) || ts.TypeGuards.isNonNullExpression(p)) {
+				return true;
+			} else if (ts.TypeGuards.isBinaryExpression(p)) {
+				const opKind = p.getOperatorToken().getKind();
+				return opKind === ts.SyntaxKind.AmpersandAmpersandToken || opKind === ts.SyntaxKind.BarBarToken;
+			} else if (ts.TypeGuards.isConditionalExpression(p) && (p.getWhenTrue() === n || p.getWhenFalse() === n)) {
+				return true;
+			} else {
+				return false;
+			}
+		}) || node;
 
-	const previous = parent || node;
 	const top = previous.getParent();
 
 	if (top) {

--- a/src/compiler/truthiness.ts
+++ b/src/compiler/truthiness.ts
@@ -59,20 +59,20 @@ function getParentWhile(myNode: ts.Node, condition: (parent: ts.Node, node: ts.N
  * So we just whitelist the nodes we can safely climb and optimize those.
  */
 export function isExpInTruthyCheck(node: ts.Node) {
-	const previous =
-		getParentWhile(node, (p, n) => {
-			if (ts.TypeGuards.isParenthesizedExpression(p) || ts.TypeGuards.isNonNullExpression(p)) {
-				return true;
-			} else if (ts.TypeGuards.isBinaryExpression(p)) {
-				const opKind = p.getOperatorToken().getKind();
-				return opKind === ts.SyntaxKind.AmpersandAmpersandToken || opKind === ts.SyntaxKind.BarBarToken;
-			} else if (ts.TypeGuards.isConditionalExpression(p) && (p.getWhenTrue() === n || p.getWhenFalse() === n)) {
-				return true;
-			} else {
-				return false;
-			}
-		}) || node;
+	const parent = getParentWhile(node, (p, n) => {
+		if (ts.TypeGuards.isParenthesizedExpression(p) || ts.TypeGuards.isNonNullExpression(p)) {
+			return true;
+		} else if (ts.TypeGuards.isBinaryExpression(p)) {
+			const opKind = p.getOperatorToken().getKind();
+			return opKind === ts.SyntaxKind.AmpersandAmpersandToken || opKind === ts.SyntaxKind.BarBarToken;
+		} else if (ts.TypeGuards.isConditionalExpression(p) && (p.getWhenTrue() === n || p.getWhenFalse() === n)) {
+			return true;
+		} else {
+			return false;
+		}
+	});
 
+	const previous = parent || node;
 	const top = previous.getParent();
 
 	if (top) {
@@ -130,42 +130,41 @@ export function compileLogicalBinary(
 	node: ts.BinaryExpression,
 ) {
 	const isInTruthyCheck = isExpInTruthyCheck(node);
-	const lhsData = getTruthyCompileData(state, lhs, true);
-	let expStr: string;
+
 	if (isInTruthyCheck) {
 		state.alreadyCheckedTruthyConditionals.push(skipNodesUpwardsLookAhead(node));
 	}
 
-	expStr = compileExpression(state, lhs);
+	const lhsData = getTruthyCompileData(state, lhs);
+	let expStr = compileExpression(state, lhs);
 
-	// if (!isInTruthyCheck || lhsData.numChecks > 1) {
-	console.log("pushing0", expStr);
-	expStr = state.pushPrecedingStatementToNewId(lhs, expStr);
-	// }
+	if (!isInTruthyCheck) {
+		expStr = state.pushPrecedingStatementToNewId(lhs, expStr);
+	}
 
 	let lhsStr = compileTruthyCheck(state, lhs, expStr, lhsData);
-	state.enterPrecedingStatementContext();
-	state.declarationContext.set(rhs, {
-		isIdentifier: true,
-		needsLocalizing: false,
-		set: expStr,
-	});
+
+	const context = state.enterPrecedingStatementContext();
+
 	let rhsStr = compileExpression(state, rhs);
+
 	if (isInTruthyCheck) {
 		rhsStr = compileTruthyCheck(state, rhs, rhsStr);
 	}
-	const context = state.exitPrecedingStatementContext();
+
+	state.exitPrecedingStatementContext();
 
 	if (context.length === 0) {
-		if (isInTruthyCheck) {
-			return lhsStr + (isAnd ? " and " : " or ") + rhsStr;
-		} else if (!isAnd && lhsData.checkTruthy) {
-			return lhsStr + " or " + rhsStr;
-		} else if (lhsData.numChecks === 1 && lhsData.checkTruthy) {
-			return lhsStr + (isAnd ? " and " : " or ") + rhsStr;
+		const luaOp = isAnd ? " and " : " or ";
+
+		if (
+			isInTruthyCheck ||
+			(!isAnd && lhsData.checkLuaTruthy) ||
+			(lhsData.numRefs === 1 && lhsData.checkLuaTruthy)
+		) {
+			return lhsStr + luaOp + rhsStr;
 		}
 	} else if (isInTruthyCheck) {
-		console.log("pushing1", lhsStr);
 		lhsStr = expStr = state.pushToDeclarationOrNewId(node, lhsStr);
 	}
 
@@ -174,6 +173,7 @@ export function compileLogicalBinary(
 		state.indent +
 			`if ${isAnd ? "" : "not ("}${removeBalancedParenthesisFromStringBorders(lhsStr)}${isAnd ? "" : ")"} then\n`,
 	);
+
 	if (expStr !== rhsStr) {
 		context.push(makeSetStatement(state, expStr, rhsStr));
 	}
@@ -183,7 +183,7 @@ export function compileLogicalBinary(
 }
 
 /** Returns an object specifying how many checks a given expression needs */
-function getTruthyCompileData(state: CompilerState, exp: ts.Expression, pushy = false) {
+function getTruthyCompileData(state: CompilerState, exp: ts.Expression) {
 	const expType = getType(exp);
 
 	if (isTupleType(expType)) {
@@ -193,71 +193,73 @@ function getTruthyCompileData(state: CompilerState, exp: ts.Expression, pushy = 
 			CompilerErrorType.LuaTupleInConditional,
 		);
 	}
+
 	const isUnknown = isUnknowableType(expType);
 	const checkNaN = isUnknown || isNumberTypeLax(expType);
 	const checkNon0 = isUnknown || checkNaN || isLiterally0Lax(expType);
 	const checkEmptyString = isUnknown || isFalsyStringTypeLax(expType);
-	const checkTruthy = isUnknown || isBoolishTypeLax(expType);
-	const numChecks = +checkNaN + +checkNon0 + +checkEmptyString + +checkTruthy;
+	const checkLuaTruthy = isUnknown || isBoolishTypeLax(expType);
+	const numRefs = 2 * +checkNaN + +checkNon0 + +checkEmptyString + +checkLuaTruthy;
 
-	return { checkNon0, checkNaN, checkEmptyString, checkTruthy, numChecks };
+	return { checkNon0, checkNaN, checkEmptyString, checkLuaTruthy, numRefs };
 }
 
 /** Compiles a given expression and check compileData and assembles an `and` chain for it. */
 export function compileTruthyCheck(
 	state: CompilerState,
 	exp: ts.Expression,
-	expStr = removeBalancedParenthesisFromStringBorders(compileExpression(state, exp)),
+	expStr = compileExpression(state, exp),
 	compileData = getTruthyCompileData(state, exp),
 ) {
 	if (state.alreadyCheckedTruthyConditionals.includes(skipNodesUpwardsLookAhead(exp))) {
 		return expStr;
 	}
 
-	const { checkNon0, checkNaN, checkEmptyString, checkTruthy, numChecks } = compileData;
+	const { checkNon0, checkNaN, checkEmptyString, checkLuaTruthy, numRefs } = compileData;
 
 	expStr = removeBalancedParenthesisFromStringBorders(expStr);
 
 	if (!isValidLuaIdentifier(expStr)) {
-		if (numChecks > 1) {
+		if (numRefs > 1) {
 			expStr = state.pushPrecedingStatementToNewId(exp, expStr);
 		} else {
 			expStr = `(${expStr})`;
 		}
 	}
 
-	const checkWarnings = new Array<string>();
 	const checks = new Array<string>();
 
 	if (checkNon0) {
 		checks.push(`${expStr} ~= 0`);
-		checkWarnings.push("0");
 	}
 
 	if (checkNaN) {
 		checks.push(`${expStr} == ${expStr}`);
-		checkWarnings.push("NaN");
 	}
 
 	if (checkEmptyString) {
 		checks.push(`${expStr} ~= ""`);
-		checkWarnings.push(`""`);
 	}
 
-	if (checkTruthy || checks.length === 0) {
+	if (checkLuaTruthy || checks.length === 0) {
 		checks.push(expStr);
 	}
 
 	const result = checks.join(" and ");
 
-	if (state.logTruthyDifferences && checkWarnings.length > 0) {
+	if (state.logTruthyDifferences && (checkNon0 || checkNaN || checkEmptyString)) {
 		console.log(
 			"%s:%d:%d - %s %s",
 			exp.getSourceFile().getFilePath(),
 			exp.getStartLineNumber(),
 			exp.getNonWhitespaceStart() - exp.getStartLinePos(),
 			yellow("Compiler Warning:"),
-			"`" + exp.getText() + "` will be checked against " + checkWarnings.join(", "),
+			"`" +
+				exp.getText() +
+				"` will be checked against " +
+				[checkNon0 ? "0" : undefined, checkNaN ? "NaN" : undefined, checkEmptyString ? `""` : undefined]
+					.filter(a => a !== undefined)
+					.join(", "),
 		);
 	}
 

--- a/src/compiler/unary.ts
+++ b/src/compiler/unary.ts
@@ -114,7 +114,7 @@ export function compilePostfixUnaryExpression(state: CompilerState, node: ts.Pos
 				const incrStr = getIncrementString(opKind, id, node, expStr);
 				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
 			} else {
-				id = state.pushPrecedingStatementToReuseableId(node, expStr);
+				id = state.pushPrecedingStatementToNewId(node, expStr);
 				const incrStr = getIncrementString(opKind, id, node, expStr);
 				state.pushPrecedingStatements(node, state.indent + incrStr + ";\n");
 				state.getCurrentPrecedingStatementContext(node).isPushed = true;


### PR DESCRIPTION
- Removed precedingStatement reuseable Id architecture.
    - While hypothetically useful, it doesn't really have much of an impact on real code. There's no real use case for being able to intelligently condense both `i`s in `print(++i, i++)` to the same temporary variable.
- Added `--logTruthyChanges` compiler option
- Removed the functionality of pushPrecedingStatementToNewId which can return the passed in value if it matches `_\d+`. As the precedingStatement system is being used more, this becomes less safe the more we have scenarios where temporary values can have their value changed. We will hopefully have another truthy PR which involves reusing and reassigning temp variables a lot, so this will become unsafe moving forward.
    - This should be replaced with a sound system which only pushes up variables if they are changed within a statement. With reference to the truthy logic, I am expecting a system similar to how conditional statements have a `conditionalContext` string which is the shared temp variable for the entire conditional expression.
- Cleaned up truthy code slightly.