### PR TITLE
Roact TSX: Missing feature additions + fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -715,7 +715,7 @@
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
 			"requires": {
 				"nice-try": "^1.0.4",
 				"path-key": "^2.0.1",
@@ -832,7 +832,7 @@
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
@@ -878,7 +878,7 @@
 		"eslint-formatter-pretty": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
-			"integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+			"integrity": "sha1-mF2eQcH4R19KCQxdvS388oIdYH4=",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^2.0.0",
@@ -891,7 +891,7 @@
 		"eslint-plugin-prettier": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
-			"integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
+			"integrity": "sha1-tDEtzywdllN51/nVtfiqrcakWQQ=",
 			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.1",
@@ -943,7 +943,7 @@
 		"fast-diff": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
 			"dev": true
 		},
 		"fast-glob": {
@@ -1245,7 +1245,7 @@
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
 			"dev": true
 		},
 		"http-signature": {
@@ -1261,7 +1261,7 @@
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
 			"dev": true
 		},
 		"imurmurhash": {
@@ -1296,7 +1296,7 @@
 		"invert-kv": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
 			"dev": true
 		},
 		"irregular-plurals": {
@@ -1308,7 +1308,7 @@
 		"is-absolute": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+			"integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
 			"requires": {
 				"is-relative": "^1.0.0",
 				"is-windows": "^1.0.1"
@@ -1404,7 +1404,7 @@
 		"is-relative": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+			"integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
@@ -1432,7 +1432,7 @@
 		"is-unc-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+			"integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
 			"requires": {
 				"unc-path-regex": "^0.1.2"
 			}
@@ -1566,7 +1566,7 @@
 		"jest-docblock": {
 			"version": "21.2.0",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+			"integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
 			"dev": true
 		},
 		"js-tokens": {
@@ -1647,7 +1647,7 @@
 		"lcid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
 			"dev": true,
 			"requires": {
 				"invert-kv": "^2.0.0"
@@ -1689,7 +1689,7 @@
 		"locate-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
@@ -1716,7 +1716,7 @@
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
@@ -1782,13 +1782,13 @@
 		"make-error": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+			"integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg=",
 			"dev": true
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
 			"dev": true,
 			"requires": {
 				"p-defer": "^1.0.0"
@@ -1863,7 +1863,7 @@
 		"merge2": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+			"integrity": "sha1-fumdvWm7ZIFoklPwGEiKG5ArDtU="
 		},
 		"micromatch": {
 			"version": "4.0.2",
@@ -2122,7 +2122,7 @@
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+			"integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
 		},
 		"node-environment-flags": {
 			"version": "1.0.5",
@@ -2153,7 +2153,7 @@
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
@@ -2376,7 +2376,7 @@
 		"p-locate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
 			"requires": {
 				"p-limit": "^2.0.0"
 			}
@@ -2503,7 +2503,7 @@
 		"prettylint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettylint/-/prettylint-1.0.0.tgz",
-			"integrity": "sha512-IjIAoGeIve8NQR6WbslnMs5rcnEVbJkZN/IXm302wNlSEo+3pIyxroy+3bkEFLP14prz1Aq1GGlKsX0UXHXuEQ==",
+			"integrity": "sha1-txcgrZcz4Jj92OvqkMYc2jM3GqE=",
 			"dev": true,
 			"requires": {
 				"eslint-formatter-pretty": "^1.3.0",
@@ -2517,7 +2517,7 @@
 			"dependencies": {
 				"globby": {
 					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
@@ -2530,7 +2530,7 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
@@ -2591,7 +2591,7 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
@@ -2820,7 +2820,7 @@
 		"spdx-correct": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"integrity": "sha1-GbtAnpG0exrVQVkkP3MSqFjbPC4=",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -2830,13 +2830,13 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
 			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -2846,7 +2846,7 @@
 		"spdx-license-ids": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-			"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+			"integrity": "sha1-pZ78CXhMKlutoTz+r1x13SFARNI=",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -2874,7 +2874,7 @@
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
@@ -3180,7 +3180,7 @@
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
 			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
@@ -3200,7 +3200,7 @@
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -3279,7 +3279,7 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
 		},
 		"yallist": {
 			"version": "2.1.2",

--- a/src/compiler/roact.ts
+++ b/src/compiler/roact.ts
@@ -124,6 +124,13 @@ function isRoactElementArrayType(type: ts.Type) {
 	}
 }
 
+/**
+ * Returns whether or not this is a valid roact child element type
+ *
+ * e.g. `Roact.Element`, `Map<string, Roact.Element>`, `Map<number, Roact.Element>`
+ * or `Array<Roact.Element | undefined>`
+ * @param type
+ */
 function isRoactChildElementType(type: ts.Type) {
 	if (isRoactElementMapType(type) || isRoactElementArrayType(type) || isRoactElementType(type)) {
 		return true;
@@ -302,7 +309,6 @@ export function generateRoactSymbolProperty(
 
 export function generateRoactElement(
 	state: CompilerState,
-	// name: string,
 	nameNode: ts.JsxTagNameExpression,
 	attributes: Array<ts.JsxAttributeLike>,
 	children: Array<ts.JsxChild>,

--- a/src/compiler/roact.ts
+++ b/src/compiler/roact.ts
@@ -382,7 +382,17 @@ export function generateRoactElement(
 			} else {
 				const attribute = attributeLike as ts.JsxAttribute;
 				const attributeName = attribute.getName();
-				const value = compileExpression(state, attribute.getInitializerOrThrow());
+				const attributeType = attribute.getType();
+
+				let value;
+				console.log(attributeName, attributeType.getText());
+				if (attributeType.isBooleanLiteral()) {
+					// Allow <Component BooleanValue/> (implicit form of <Component BooleanValue={true}/>)
+					const initializer = attribute.getInitializer();
+					value = initializer ? compileExpression(state, initializer) : attributeType.getText();
+				} else {
+					value = compileExpression(state, attribute.getInitializerOrThrow());
+				}
 
 				if (attributeName === "Key") {
 					// handle setting a key for this element

--- a/src/compiler/roact.ts
+++ b/src/compiler/roact.ts
@@ -589,7 +589,7 @@ export function generateRoactElement(
 			str += ")";
 		} else {
 			// state.pushIndent();
-			str += state.indent + isFragment ? "{\n" : ", {\n";
+			str += isFragment ? "{\n" : ", {\n";
 			str += childCollection.join(",\n") + `\n${state.indent}})`;
 		}
 	} else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
 		"strictNullChecks": true,
 		"sourceMap": true,
 		"noUnusedLocals": true,
-		"esModuleInterop": true
+		"esModuleInterop": true,
+		"removeComments": true
 	},
 	"include": [
 		"src/**/*"


### PR DESCRIPTION
Fixes
- Ability to add a Map (number & string keys, Roact.Element values) to be used in roact element children. (Good for dynamic keys)

Additions
- Support for Roact.Fragment (uses `Roact.createFragment`)
- Support BinaryExpressions inside JSX elements that return Elements (e.g. `{condition && <frame/>}`)
- Support ConditionalExpressions inside JSX elements that return Elements or undefined (e.g. `{condition ? <frame/> : <textlabel/>}` and `{condition ? <frame/> : undefined}`
- Added ability for implicit boolean initialization (e.g. `<frame Modal={true}/>` can now be shortened to `<frame Modal/>`)