### PR TITLE
Method Redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed and/or expressions which now respect the control flow of expressions which require multiple statements in Lua
 - Fixed #586 - `new ReadonlySet()` and `new ReadonlyMap()` now work
 - Fixed #604 - `rbxtsc --init package` now fills out package.json better
+- Fix issues relating to method vs callback logic, specifically, making `this` work better as a first parameter. This should improve object composability.
 
 ### **0.2.14**
 - Fixed analytics bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed and/or expressions which now respect the control flow of expressions which require multiple statements in Lua
 - Fixed #586 - `new ReadonlySet()` and `new ReadonlyMap()` now work
 - Fixed #604 - `rbxtsc --init package` now fills out package.json better
-- Fix issues relating to method vs callback logic, specifically, making `this` work better as a first parameter. This should improve object composability. See https://github.com/roblox-ts/roblox-ts/blob/191be59f83f0c030609e09502722bddbaf53a450/tests/src/object.spec.ts#L417-L437
+- Fix issues relating to method vs callback logic, specifically, making `this` work better as a first parameter. This should improve object composability. See https://git.io/fjxRS
 
 ### **0.2.14**
 - Fixed analytics bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed and/or expressions which now respect the control flow of expressions which require multiple statements in Lua
 - Fixed #586 - `new ReadonlySet()` and `new ReadonlyMap()` now work
 - Fixed #604 - `rbxtsc --init package` now fills out package.json better
-- Fix issues relating to method vs callback logic, specifically, making `this` work better as a first parameter. This should improve object composability.
+- Fix issues relating to method vs callback logic, specifically, making `this` work better as a first parameter. This should improve object composability. See https://github.com/roblox-ts/roblox-ts/blob/191be59f83f0c030609e09502722bddbaf53a450/tests/src/object.spec.ts#L417-L437
 
 ### **0.2.14**
 - Fixed analytics bug

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -988,7 +988,7 @@ export function isDefinedAsMethod(node: ts.Node): boolean | undefined {
 
 		if (hasMethodDefinition && hasCallbackDefinition) {
 			throw new CompilerError(
-				"Attempted to call a function with mixed types! All definitions must either be a method or a callback.",
+				"Attempted to define or call a function with mixed types! All definitions must either be a method or a callback.",
 				node,
 				CompilerErrorType.MixedMethodCall,
 			);

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -434,7 +434,16 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 		compileConstructorDeclaration(state, node, name, getConstructor(node), extraInitializers, hasSuper, isRoact),
 	);
 
-	for (const method of node.getStaticMethods()) {
+	const staticMethods = node.getStaticMethods();
+	const instanceMethods = node.getInstanceMethods();
+
+	const makeFunctionCategoryComments = staticMethods.length > 0;
+
+	if (makeFunctionCategoryComments) {
+		results.push(state.indent + "-- static methods\n");
+	}
+
+	for (const method of staticMethods) {
 		if (method.getBody() !== undefined) {
 			const methodName = method.getName();
 
@@ -447,16 +456,20 @@ function compileClass(state: CompilerState, node: ts.ClassDeclaration | ts.Class
 			}
 			validateMethod(node, method, extendsArray, isRoact);
 			state.enterPrecedingStatementContext(results);
-			results.push(compileMethodDeclaration(state, method, name + "."));
+			results.push(compileMethodDeclaration(state, method, name));
 			state.exitPrecedingStatementContext();
 		}
 	}
 
-	for (const method of node.getInstanceMethods()) {
+	if (makeFunctionCategoryComments) {
+		results.push(state.indent + "-- instance methods\n");
+	}
+
+	for (const method of instanceMethods) {
 		if (method.getBody() !== undefined) {
 			validateMethod(node, method, extendsArray, isRoact);
 			state.enterPrecedingStatementContext(results);
-			results.push(compileMethodDeclaration(state, method, name + ":"));
+			results.push(compileMethodDeclaration(state, method, name));
 			state.exitPrecedingStatementContext();
 		}
 	}

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -21,6 +21,7 @@ import {
 	superExpressionClassInheritsFromArray,
 	superExpressionClassInheritsFromSetOrMap,
 } from "../utility/type";
+import { isDefinedAsMethod } from "./call";
 
 const LUA_RESERVED_METAMETHODS = [
 	"__index",
@@ -278,6 +279,7 @@ function validateMethod(
 	checkDecorators(method);
 	checkMethodCollision(node, method);
 	checkDefaultIterator(extendsArray, method);
+	isDefinedAsMethod(method);
 	const nameNode = method.getNameNode();
 	if (ts.TypeGuards.isComputedPropertyName(nameNode)) {
 		let isSymbolPropAccess = false;

--- a/src/compiler/class.ts
+++ b/src/compiler/class.ts
@@ -21,7 +21,6 @@ import {
 	superExpressionClassInheritsFromArray,
 	superExpressionClassInheritsFromSetOrMap,
 } from "../utility/type";
-import { isDefinedAsMethod } from "./call";
 
 const LUA_RESERVED_METAMETHODS = [
 	"__index",
@@ -279,7 +278,6 @@ function validateMethod(
 	checkDecorators(method);
 	checkMethodCollision(node, method);
 	checkDefaultIterator(extendsArray, method);
-	isDefinedAsMethod(method);
 	const nameNode = method.getNameNode();
 	if (ts.TypeGuards.isComputedPropertyName(nameNode)) {
 		let isSymbolPropAccess = false;

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -179,12 +179,16 @@ function compileFunction(
 		isGenerator = !ts.TypeGuards.isArrowFunction(node) && node.isGenerator();
 	}
 
+	const isMethod = isMethodDeclaration(node);
+
 	if (name) {
 		results.push(state.indent, declarationPrefix);
 		if (frontWrap === "" && canSugaryCompileFunction(node)) {
 			results.push("function ");
 			if (namePrefix) {
-				results.push(namePrefix, isMethodDeclaration(node) ? ":" : ".");
+				results.push(namePrefix, isMethod ? ":" : ".");
+			} else if (isMethod) {
+				paramNames.unshift("self");
 			}
 			results.push(name);
 		} else {
@@ -195,14 +199,14 @@ function compileFunction(
 				}
 			}
 			results.push(name, " = ", frontWrap, "function");
-			if (isMethodDeclaration(node)) {
+			if (isMethod) {
 				paramNames.unshift("self");
 			}
 		}
 		backWrap += ";\n";
 	} else {
 		results.push(frontWrap, "function");
-		if (isMethodDeclaration(node)) {
+		if (isMethod) {
 			paramNames.unshift("self");
 		}
 	}

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -199,7 +199,7 @@ function compileFunction(
 		}
 		backWrap += ";\n";
 	} else {
-		results.push(frontWrap + "function");
+		results.push(frontWrap, "function");
 		if (isMethodDeclaration(node)) {
 			paramNames.unshift("self");
 		}
@@ -226,7 +226,7 @@ function compileFunction(
 		results.push(compileFunctionBody(state, body, node, initializers));
 	}
 	state.popIdStack();
-	results.push("end" + backWrap);
+	results.push("end", backWrap);
 	return results.join("");
 }
 

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -19,6 +19,7 @@ import {
 	shouldHoist,
 } from "../utility/type";
 import { isValidLuaIdentifier } from "./security";
+import { isDefinedAsMethod } from "./call";
 
 export type HasParameters =
 	| ts.FunctionExpression
@@ -144,6 +145,7 @@ function compileFunction(
 	body: ts.Node<ts.ts.Node>,
 	namePrefix = "",
 ) {
+	isDefinedAsMethod(node);
 	state.pushIdStack();
 	const paramNames = new Array<string>();
 	const initializers = new Array<string>();

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -78,14 +78,17 @@ export function isFunctionExpressionMethod(node: ts.FunctionExpression) {
 }
 
 export function isMethodDeclaration(node: ts.Node<ts.ts.Node>): node is ts.MethodDeclaration | ts.FunctionExpression {
-	if (
-		ts.TypeGuards.isMethodSignature(node) ||
-		ts.TypeGuards.isMethodDeclaration(node) ||
-		(ts.TypeGuards.isFunctionExpression(node) && isFunctionExpressionMethod(node))
-	) {
+	if (ts.TypeGuards.isParameteredNode(node)) {
 		const thisParam = node.getParameter("this");
-
-		return !thisParam || getType(thisParam).getText() !== "void";
+		if (thisParam) {
+			return getType(thisParam).getText() !== "void";
+		} else {
+			return (
+				ts.TypeGuards.isMethodDeclaration(node) ||
+				ts.TypeGuards.isMethodSignature(node) ||
+				(ts.TypeGuards.isFunctionExpression(node) && isFunctionExpressionMethod(node))
+			);
+		}
 	}
 
 	return false;
@@ -148,17 +151,17 @@ function compileFunction(
 	getParameterData(state, paramNames, initializers, node);
 	checkReturnsNonAny(node);
 
-	let result: string;
+	const results = new Array<string>();
 	let frontWrap = "";
 	let backWrap = "";
-	let prefix = "";
+	let declarationPrefix = "";
 
 	if (ts.TypeGuards.isFunctionDeclaration(node)) {
 		const nameNode = node.getNameNode();
 		if (nameNode && shouldHoist(node, nameNode)) {
 			state.pushHoistStack(name);
 		} else {
-			prefix = "local ";
+			declarationPrefix = "local ";
 		}
 	}
 
@@ -168,90 +171,57 @@ function compileFunction(
 		/* istanbul ignore next */
 		if (node.isAsync()) {
 			state.usesTSLibrary = true;
-			frontWrap = "TS.async(";
-			backWrap = ")" + backWrap;
+			frontWrap += "TS.async(";
+			backWrap += ")" + backWrap;
 		}
 		isGenerator = !ts.TypeGuards.isArrowFunction(node) && node.isGenerator();
 	}
 
-	const sugarcoat = name !== "" && frontWrap === "" && canSugaryCompileFunction(node);
-	let namePrefixEndsInColon = namePrefix.endsWith(":");
-
-	if (isMethodDeclaration(node)) {
-		if (!namePrefixEndsInColon) {
-			giveInitialSelfParameter(node, paramNames);
-		}
-	} else if (namePrefixEndsInColon) {
-		namePrefixEndsInColon = false;
-		namePrefix = namePrefix.slice(0, -1) + ".";
-	}
-
 	if (name) {
-		if (sugarcoat) {
-			result = state.indent + prefix;
+		results.push(state.indent, declarationPrefix);
+		if (frontWrap === "" && canSugaryCompileFunction(node)) {
+			results.push("function ", namePrefix, isMethodDeclaration(node) ? ":" : ".", name);
 		} else {
-			if (namePrefix && namePrefixEndsInColon) {
-				namePrefix = namePrefix.slice(0, -1) + ".";
-				namePrefixEndsInColon = false;
+			results.push(namePrefix);
+			if (!name.startsWith("[")) {
+				results.push(".");
 			}
-			result = state.indent + prefix + namePrefix + name + " = ";
+			results.push(name, " = ", frontWrap, "function");
+			if (isMethodDeclaration(node)) {
+				paramNames.unshift("self");
+			}
 		}
 		backWrap += ";\n";
 	} else {
-		result = "";
+		results.push(frontWrap + "function");
+		if (isMethodDeclaration(node)) {
+			paramNames.unshift("self");
+		}
 	}
 
-	result += frontWrap + "function" + (sugarcoat ? " " + namePrefix + name : "") + "(" + paramNames.join(", ") + ")";
+	results.push("(", paramNames.join(", "), ")");
 
 	if (isGenerator) {
 		// will error if IterableIterator is nullable
 		isIterableIteratorType(node.getReturnType());
-		result += "\n";
+		results.push("\n");
 		state.pushIndent();
-		result += state.indent + `return {\n`;
+		results.push(state.indent, `return {\n`);
 		state.pushIndent();
-		result += state.indent + `next = coroutine.wrap(function()`;
-		result += compileFunctionBody(state, body, node, initializers);
-		result += `\twhile true do coroutine.yield({ done = true }) end;\n`;
-		result += state.indent + `end);\n`;
+		results.push(state.indent, `next = coroutine.wrap(function()`);
+		results.push(compileFunctionBody(state, body, node, initializers));
+		results.push(`\twhile true do coroutine.yield({ done = true }) end;\n`);
+		results.push(state.indent, `end);\n`);
 		state.popIndent();
-		result += state.indent + `};\n`;
+		results.push(state.indent, `};\n`);
 		state.popIndent();
-		result += state.indent;
+		results.push(state.indent);
 	} else {
-		result += compileFunctionBody(state, body, node, initializers);
+		results.push(compileFunctionBody(state, body, node, initializers));
 	}
 	state.popIdStack();
-	return result + "end" + backWrap;
-}
-
-function giveInitialSelfParameter(node: ts.MethodDeclaration | ts.FunctionExpression, paramNames: Array<string>) {
-	const parameters = node.getParameters();
-	let replacedThis = false;
-
-	if (parameters.length > 0) {
-		const child = parameters[0].getFirstChildByKind(ts.SyntaxKind.Identifier);
-		const classParent = node.getFirstAncestor(
-			(ancestor): ancestor is ts.ClassDeclaration | ts.ClassExpression =>
-				ts.TypeGuards.isClassDeclaration(ancestor) || ts.TypeGuards.isClassExpression(ancestor),
-		);
-		if (
-			classParent &&
-			child &&
-			child.getText() === "this" &&
-			(getType(child).getText() === "this" || getType(child) === getType(classParent))
-		) {
-			paramNames[0] = "self";
-			replacedThis = true;
-		}
-	}
-
-	if (!replacedThis) {
-		const thisParam = node.getParameter("this");
-		if (!thisParam || getType(thisParam).getText() !== "void") {
-			paramNames.unshift("self");
-		}
-	}
+	results.push("end" + backWrap);
+	return results.join("");
 }
 
 export function compileFunctionDeclaration(state: CompilerState, node: ts.FunctionDeclaration) {
@@ -272,12 +242,10 @@ export function compileMethodDeclaration(state: CompilerState, node: ts.MethodDe
 	let name: string;
 
 	if (ts.TypeGuards.isComputedPropertyName(nameNode)) {
-		namePrefix = namePrefix.slice(0, -1);
 		name = `[${compileExpression(state, skipNodesDownwards(nameNode.getExpression()))}]`;
 	} else {
 		name = compileExpression(state, nameNode);
 		if (!isValidLuaIdentifier(name)) {
-			namePrefix = namePrefix.slice(0, -1);
 			name = `["${name}"]`;
 		}
 	}

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -18,8 +18,8 @@ import {
 	isTupleType,
 	shouldHoist,
 } from "../utility/type";
-import { isValidLuaIdentifier } from "./security";
 import { isDefinedAsMethod } from "./call";
+import { isValidLuaIdentifier } from "./security";
 
 export type HasParameters =
 	| ts.FunctionExpression

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -180,11 +180,17 @@ function compileFunction(
 	if (name) {
 		results.push(state.indent, declarationPrefix);
 		if (frontWrap === "" && canSugaryCompileFunction(node)) {
-			results.push("function ", namePrefix, isMethodDeclaration(node) ? ":" : ".", name);
+			results.push("function ");
+			if (namePrefix) {
+				results.push(namePrefix, isMethodDeclaration(node) ? ":" : ".");
+			}
+			results.push(name);
 		} else {
-			results.push(namePrefix);
-			if (!name.startsWith("[")) {
-				results.push(".");
+			if (namePrefix) {
+				results.push(namePrefix);
+				if (!name.startsWith("[")) {
+					results.push(".");
+				}
 			}
 			results.push(name, " = ", frontWrap, "function");
 			if (isMethodDeclaration(node)) {

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -3,6 +3,7 @@ import { compileExpression, compileMethodDeclaration } from ".";
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { joinIndentedLines, safeLuaIndex, skipNodesDownwards } from "../utility/general";
+import { isMethodDeclaration } from "./function";
 
 function assignMembers(state: CompilerState, from: string, target: string) {
 	state.pushIdStack();
@@ -107,7 +108,7 @@ export function compileObjectLiteralExpression(state: CompilerState, node: ts.Ob
 			if (ts.TypeGuards.isSpreadAssignment(prop)) {
 				line = assignMembers(state, line, id);
 			} else if (ts.TypeGuards.isMethodDeclaration(prop)) {
-				line = state.indent + compileMethodDeclaration(state, prop, id + ":").trimLeft();
+				line = state.indent + compileMethodDeclaration(state, prop, id).trimLeft();
 			} else {
 				line = state.indent + id + (line.startsWith("[") ? "" : ".") + line;
 			}

--- a/src/compiler/object.ts
+++ b/src/compiler/object.ts
@@ -3,7 +3,6 @@ import { compileExpression, compileMethodDeclaration } from ".";
 import { CompilerState } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
 import { joinIndentedLines, safeLuaIndex, skipNodesDownwards } from "../utility/general";
-import { isMethodDeclaration } from "./function";
 
 function assignMembers(state: CompilerState, from: string, target: string) {
 	state.pushIdStack();

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -92,6 +92,7 @@ export enum CompilerErrorType {
 	IsolatedContainer,
 	UnexpectedExtensionType,
 	BadDestructSubType,
+	MixedMethodSet,
 }
 
 export class CompilerError extends LoggableError {

--- a/src/test.ts
+++ b/src/test.ts
@@ -437,7 +437,7 @@ const errorMatrix: ErrorMatrix = {
 		instance: CompilerError,
 		type: CompilerErrorType.MixedMethodSet,
 	},
-	"conflictingVars.spec.ts": {
+	"method-callback/conflictingVars.spec.ts": {
 		message: "should not allow definition changing of mixed methods/member functions",
 		instance: CompilerError,
 		type: CompilerErrorType.MixedMethodSet,

--- a/src/test.ts
+++ b/src/test.ts
@@ -422,6 +422,26 @@ const errorMatrix: ErrorMatrix = {
 		instance: CompilerError,
 		type: CompilerErrorType.InvalidIdentifier,
 	},
+	"method-callback/conflictingDefinitions.spec.ts": {
+		message: "should not allow definition overloading of mixed methods/member functions",
+		instance: CompilerError,
+		type: CompilerErrorType.MixedMethodCall,
+	},
+	"method-callback/conflictingClassMethods.spec.ts": {
+		message: "should not allow definition clashing of mixed methods/member functions",
+		instance: CompilerError,
+		type: CompilerErrorType.MixedMethodCall,
+	},
+	"method-callback/conflictingObjectMethodSet.spec.ts": {
+		message: "should not allow definition changing of mixed methods/member functions",
+		instance: CompilerError,
+		type: CompilerErrorType.MixedMethodSet,
+	},
+	"conflictingVars.spec.ts": {
+		message: "should not allow definition changing of mixed methods/member functions",
+		instance: CompilerError,
+		type: CompilerErrorType.MixedMethodSet,
+	},
 };
 /* tslint:enable:object-literal-sort-keys */
 

--- a/src/utility/type.ts
+++ b/src/utility/type.ts
@@ -428,24 +428,24 @@ export function isSetType(type: ts.Type) {
 	return getCompilerDirectiveWithConstraint(type, CompilerDirective.Set);
 }
 
-export function isMethodType(type: ts.Type) {
+export function isFunctionType(type: ts.Type) {
 	return type.getCallSignatures().length > 0;
 }
 
 export function isArrayMethodType(type: ts.Type) {
-	return isMethodType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.Array);
+	return isFunctionType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.Array);
 }
 
 export function isMapMethodType(type: ts.Type) {
-	return isMethodType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.Map);
+	return isFunctionType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.Map);
 }
 
 export function isSetMethodType(type: ts.Type) {
-	return isMethodType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.Set);
+	return isFunctionType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.Set);
 }
 
 export function isStringMethodType(type: ts.Type) {
-	return isMethodType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.String);
+	return isFunctionType(type) && getCompilerDirectiveWithConstraint(type, CompilerDirective.String);
 }
 
 const LUA_TUPLE_REGEX = /^LuaTuple<[^]+>$/;

--- a/tests/src/errors/method-callback/conflictingClassMethods.spec.ts
+++ b/tests/src/errors/method-callback/conflictingClassMethods.spec.ts
@@ -1,0 +1,14 @@
+{
+	class A {
+		f() {}
+	}
+
+	class B {
+		f = () => {};
+	}
+
+	function f(x: A | B) {
+		x.f();
+	}
+}
+export {};

--- a/tests/src/errors/method-callback/conflictingDefinitions.spec.ts
+++ b/tests/src/errors/method-callback/conflictingDefinitions.spec.ts
@@ -1,0 +1,7 @@
+{
+	class A {
+		public test(): void;
+		public test(this: void) {}
+	}
+}
+export {};

--- a/tests/src/errors/method-callback/conflictingObjectMethodSet.spec.ts
+++ b/tests/src/errors/method-callback/conflictingObjectMethodSet.spec.ts
@@ -1,0 +1,8 @@
+{
+	const o = {
+		f: function(this: {}) {},
+	};
+
+	o.f = () => {};
+}
+export {};

--- a/tests/src/errors/method-callback/conflictingVars.spec.ts
+++ b/tests/src/errors/method-callback/conflictingVars.spec.ts
@@ -1,0 +1,7 @@
+{
+	let x = () => 1;
+	x = function(this: {}) {
+		return 2;
+	};
+}
+export {};

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -424,7 +424,8 @@ export = () => {
 		}
 
 		const g = function<T extends Numerable>(this: T, n: number) {
-			return (this.n *= n);
+			this.n *= n;
+			return this;
 		};
 
 		function h(n: number) {
@@ -433,7 +434,7 @@ export = () => {
 
 		const obj = { f, n: 10, g, h };
 		expect(obj.f(5)).to.equal(15);
-		expect(obj.g(3)).to.equal(45);
+		expect(obj.g(3).f(6)).to.equal(51);
 		obj.h(5);
 	});
 };

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -437,4 +437,18 @@ export = () => {
 		expect(obj.mul(3).add(6)).to.equal(51);
 		obj.h(5);
 	});
+
+	it("should support object member functions as implicitly being methods", () => {
+		// don't ask me why, but for some reason non-method function members in objects are implicitly methods
+
+		const o = {
+			count: 1,
+
+			getCount: function() {
+				return this.count;
+			},
+		};
+
+		expect(o.getCount()).to.equal(1);
+	});
 };

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -419,11 +419,11 @@ export = () => {
 			n: number;
 		}
 
-		function f(this: Numerable, n: number) {
+		function add(this: Numerable, n: number) {
 			return (this.n += n);
 		}
 
-		const g = function<T extends Numerable>(this: T, n: number) {
+		const mul = function<T extends Numerable>(this: T, n: number) {
 			this.n *= n;
 			return this;
 		};
@@ -432,9 +432,9 @@ export = () => {
 			expect(n).to.equal(5);
 		}
 
-		const obj = { f, n: 10, g, h };
-		expect(obj.f(5)).to.equal(15);
-		expect(obj.g(3).f(6)).to.equal(51);
+		const obj = { add, n: 10, mul, h };
+		expect(obj.add(5)).to.equal(15);
+		expect(obj.mul(3).add(6)).to.equal(51);
 		obj.h(5);
 	});
 };

--- a/tests/src/object.spec.ts
+++ b/tests/src/object.spec.ts
@@ -413,4 +413,27 @@ export = () => {
 		expect(b[8]).to.equal(`19`);
 		expect(c[9]).to.equal(1);
 	});
+
+	it("should support composing objects with methods and callbacks", () => {
+		interface Numerable {
+			n: number;
+		}
+
+		function f(this: Numerable, n: number) {
+			return (this.n += n);
+		}
+
+		const g = function<T extends Numerable>(this: T, n: number) {
+			return (this.n *= n);
+		};
+
+		function h(n: number) {
+			expect(n).to.equal(5);
+		}
+
+		const obj = { f, n: 10, g, h };
+		expect(obj.f(5)).to.equal(15);
+		expect(obj.g(3)).to.equal(45);
+		obj.h(5);
+	});
 };


### PR DESCRIPTION
- Unified logic for isMethodDeclaration and isDefinedAsMethod
- Removed the `:` and `.` magic string manipulation. It doesn't make sense with our new isMethodDeclaration/isDefinedAsMethod system
- Fixed the regressions introduced in https://github.com/roblox-ts/roblox-ts/pull/646
    - There was a problem that arose from `isParameteredNode` functions not always being handled in `isMethodDeclaration`
    - There was a problem with `self` not getting inserted in some methods