### PR TITLE
Make string destructuring and iterating unicode safe

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -867,6 +867,17 @@ TS.set_size = getNumKeys
 
 TS.set_toString = toString
 
+-- spread cache functions
+function TS.string_spread(str)
+	local results = {}
+	local count = 0
+	for char in string.gmatch(str, "[%z\1-\127\194-\244][\128-\191]*") do
+		count = count + 1
+		results[count] = char
+	end
+	return results
+end
+
 function TS.iterableCache(iter)
 	local results = {}
 	local count = 0

--- a/src/compiler/forOf.ts
+++ b/src/compiler/forOf.ts
@@ -278,7 +278,7 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				break;
 			case ForOfLoopType.String:
 				key = varName;
-				expStr = `(${expStr}):gmatch(".")`;
+				expStr = `string.gmatch(${expStr}, "[%z\1-\127\194-\244][\128-\191]*")`;
 				break;
 			case ForOfLoopType.IterableFunction:
 				key = varName;

--- a/src/compiler/forOf.ts
+++ b/src/compiler/forOf.ts
@@ -278,7 +278,7 @@ export function compileForOfStatement(state: CompilerState, node: ts.ForOfStatem
 				break;
 			case ForOfLoopType.String:
 				key = varName;
-				expStr = `string.gmatch(${expStr}, "[%z\1-\127\194-\244][\128-\191]*")`;
+				expStr = `string.gmatch(${expStr}, "[%z\\1-\\127\\194-\\244][\\128-\\191]*")`;
 				break;
 			case ForOfLoopType.IterableFunction:
 				key = varName;

--- a/src/compiler/spread.ts
+++ b/src/compiler/spread.ts
@@ -200,9 +200,10 @@ export function compileSpreadExpression(state: CompilerState, expression: ts.Exp
 		if (ts.TypeGuards.isStringLiteral(expression)) {
 			const text = expression.getText();
 			const quote = text.slice(-1);
-			return "{" + text.replace(/\\?./g, a => `${quote}${a}${quote}, `).slice(4, -7) + " }";
+			return "{" + text.replace(/\\?[^]/gu, a => `${quote}${a}${quote}, `).slice(4, -7) + " }";
 		} else {
-			return `string.split(${compileExpression(state, expression)}, "")`;
+			state.usesTSLibrary = true;
+			return `TS.string_spread(${compileExpression(state, expression)})`;
 		}
 	} else if (isIterableFunctionType(expType)) {
 		state.usesTSLibrary = true;

--- a/tests/src/string.spec.ts
+++ b/tests/src/string.spec.ts
@@ -103,4 +103,33 @@ export = () => {
 		let j = 2;
 		expect("foobar".sub(i, j)).to.equal("foo");
 	});
+
+	it("should support proper destructuring and iterating", () => {
+		function compare(results: Array<string>, array2: Array<string>) {
+			for (const [i, v] of array2.entries()) {
+				expect(results[i]).to.equal(v);
+			}
+		}
+
+		// optimized destructuring
+		compare([..."𝟘𝟙𝟚𝟛"], ["𝟘", "𝟙", "𝟚", "𝟛"]);
+		compare([..."யாமறிந்த"], ["ய", "ா", "ம", "ற", "ி", "ந", "்", "த"]);
+
+		const spreadString = (str: string) => [...str];
+
+		// run-time destructuring
+		compare(spreadString("𝟘𝟙𝟚𝟛"), ["𝟘", "𝟙", "𝟚", "𝟛"]);
+		compare(spreadString("யாமறிந்த"), ["ய", "ா", "ம", "ற", "ி", "ந", "்", "த"]);
+
+		let i = 0;
+		for (const substr of "𝟘𝟙𝟚𝟛") {
+			expect(substr).to.equal(["𝟘", "𝟙", "𝟚", "𝟛"][i++]);
+		}
+
+		let j = 0;
+		let myStr = "யாமறிந்த";
+		for (const substr of myStr) {
+			expect(substr).to.equal(["ய", "ா", "ம", "ற", "ி", "ந", "்", "த"][j++]);
+		}
+	});
 };


### PR DESCRIPTION
- Adds `TS.string_spread` function which properly destructures unicode graphemes (without regarding clusters, like utf8.graphemes does). This is used for destructuring strings now.
- This will make string iteration and string destructuring out of the box more useful for working with graphemes, and also is more in line with how JS works.

Inspired by https://stackoverflow.com/questions/4547609/how-do-you-get-a-string-to-a-character-array-in-javascript/34717402#34717402
