### PR TITLE
Fix parenthesized left-hand side on equals expressions

### DIFF
--- a/src/compiler/binary.ts
+++ b/src/compiler/binary.ts
@@ -124,7 +124,7 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 
 	const rawRhs = node.getRight();
 
-	const lhs = skipNodesDownwards(node.getLeft(), true);
+	let lhs = skipNodesDownwards(node.getLeft(), true);
 	const rhs = skipNodesDownwards(rawRhs, true);
 	let lhsStr: string;
 	let rhsStr: string;
@@ -189,6 +189,7 @@ export function compileBinaryExpression(state: CompilerState, node: ts.BinaryExp
 	}
 
 	if (isSetToken(opKind)) {
+		lhs = skipNodesDownwards(lhs);
 		let isLhsIdentifier = ts.TypeGuards.isIdentifier(lhs) && !isIdentifierDefinedInExportLet(lhs);
 
 		let rhsStrContext: PrecedingStatementContext;

--- a/tests/src/binary.spec.ts
+++ b/tests/src/binary.spec.ts
@@ -115,4 +115,19 @@ export = () => {
 		expect(a).to.equal(-66);
 		expect(b).to.equal(-30);
 	});
+
+	it("should support set expressions with parenthesis around the left-hand side", () => {
+		let x = 5;
+		// prettier-ignore
+		(x) *= 9;
+		expect(x).to.equal(45);
+
+		let o = { x: 3 };
+		// prettier-ignore
+		(o.x) = 5;
+		expect(o.x).to.equal(5);
+		// prettier-ignore
+		(o["x"]) = 8;
+		expect(o.x).to.equal(8);
+	});
 };


### PR DESCRIPTION
Fixes cases like these:
```ts
let x = 5;
// prettier-ignore
(x) *= 9;
```