### PR TITLE
Fix reducers, remove nullable array ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Fixed importing system for when your project requires a package version other than the globally installed one.
 - Added macro variable `PKG_VERSION` which gets replaced with the "version" string in your package.json file on compile
 - Replaced our `getfenv(0).script` calls with passing in `script` as the first parameter in `TS.import` and `TS.getModule`. This means packages will have to be republished, but anyone can easily fix a broken package by inserting `script` as the first parameter themselves.
+- Fixed `Array.reduce` and `Array.reduceRight` functions
+    - They now pass in the right index into the reducer function (arrays start at 0, not 1)
+	- They now pass the array into the reducer function
+	- They now error when attempting to reduce an empty array without an initialValue passed in
+	- `undefined` is now a valid initialValue
 
 ### **0.2.14**
 - Fixed analytics bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
 	- They now pass the array into the reducer function
 	- They now error when attempting to reduce an empty array without an initialValue passed in
 	- `undefined` is now a valid initialValue
-- Removed limited support for array methods with holes. We don't support arrays with holes in them.
-	- If want to strip an array of `nil` values, use `Array.filter((v): v is NonNullable<typeof v> => v !== undefined);`
-    - We should release a library for making with arrays with holes for that niche use case, where `length` is tracked as a real value.
+- Changed our limited emulation of JS behavior where many array methods wouldn't call callbacks on empty values in arrays (we considered any `nil` value `empty`). Now, every callback in every array method gets called on every item within arrays, even `nil` values if applicable. This should be more straightforward and easier to understand (and easier for our type system). This change shouldn't affect most people, since we discourage using arrays with holes anyway.
+	- If you need to strip an array of `nil` values, use `Array.filter((v): v is NonNullable<typeof v> => v !== undefined);`
+    - We should release a library for safely making arrays with holes for that niche use case, where `length` is tracked as a real value.
 
 ### **0.2.14**
 - Fixed analytics bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 	- They now pass the array into the reducer function
 	- They now error when attempting to reduce an empty array without an initialValue passed in
 	- `undefined` is now a valid initialValue
+- Removed limited support for array methods with holes. We don't support arrays with holes in them.
+    - We should release a library for making with arrays with holes for that niche use case, where `length` is tracked as a real value.
 
 ### **0.2.14**
 - Fixed analytics bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 	- They now error when attempting to reduce an empty array without an initialValue passed in
 	- `undefined` is now a valid initialValue
 - Removed limited support for array methods with holes. We don't support arrays with holes in them.
+	- If want to strip an array of `nil` values, use `Array.filter((v): v is NonNullable<typeof v> => v !== undefined);`
     - We should release a library for making with arrays with holes for that niche use case, where `length` is tracked as a real value.
 
 ### **0.2.14**

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -363,10 +363,12 @@ end
 
 function TS.array_filter(list, callback)
 	local result = {}
+	local count = 0
 	for i = 1, #list do
 		local v = list[i]
 		if v ~= nil and callback(v, i - 1, list) == true then
-			result[#result + 1] = v
+			count = count + 1
+			result[count] = v
 		end
 	end
 	return result
@@ -377,7 +379,16 @@ local function sortFallback(a, b)
 end
 
 function TS.array_sort(list, callback)
-	local sorted = array_copy(list)
+	local sorted = {}
+	local count = 0
+
+	for i = 1, #list do
+		local v = list[i]
+		if v ~= nil then
+			count = count + 1
+			sorted[count] = v
+		end
+	end
 
 	if callback then
 		table.sort(sorted, function(a, b)
@@ -524,7 +535,8 @@ end
 
 function TS.array_indexOf(list, value, fromIndex)
 	for i = (fromIndex or 0) + 1, #list do
-		if value == list[i] then
+		local v = list[i]
+		if v ~= nil and value == v then
 			return i - 1
 		end
 	end
@@ -533,7 +545,8 @@ end
 
 function TS.array_lastIndexOf(list, value, fromIndex)
 	for i = (fromIndex or #list - 1) + 1, 1, -1 do
-		if value == list[i] then
+		local v = list[i]
+		if v ~= nil and value == v then
 			return i - 1
 		end
 	end
@@ -658,7 +671,7 @@ end
 function TS.array_find(list, callback)
 	for i = 1, #list do
 		local v = list[i]
-		if v ~= nil and callback(v, i - 1, list) == true then
+		if callback(v, i - 1, list) == true then
 			return v
 		end
 	end
@@ -666,8 +679,7 @@ end
 
 function TS.array_findIndex(list, callback)
 	for i = 0, #list - 1 do
-		local v = list[i + 1]
-		if v ~= nil and callback(v, i, list) == true then
+		if callback(list[i + 1], i, list) == true then
 			return i
 		end
 	end
@@ -679,13 +691,8 @@ local function array_flat_helper(list, depth, count, result)
 		local v = list[i]
 
 		if v ~= nil then
-			if type(v) == "table" then
-				if depth ~= 0 then
-					count = array_flat_helper(v, depth - 1, count, result)
-				else
-					count = count + 1
-					result[count] = v
-				end
+			if type(v) == "table" and depth ~= 0 then
+				count = array_flat_helper(v, depth - 1, count, result)
 			else
 				count = count + 1
 				result[count] = v

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -343,20 +343,14 @@ end
 
 function TS.array_forEach(list, callback)
 	for i = 1, #list do
-		local v = list[i]
-		if v ~= nil then
-			callback(v, i - 1, list)
-		end
+		callback(list[i], i - 1, list)
 	end
 end
 
 function TS.array_map(list, callback)
 	local result = {}
 	for i = 1, #list do
-		local v = list[i]
-		if v ~= nil then
-			result[i] = callback(v, i - 1, list)
-		end
+		result[i] = callback(list[i], i - 1, list)
 	end
 	return result
 end
@@ -365,7 +359,7 @@ function TS.array_filter(list, callback)
 	local result = {}
 	for i = 1, #list do
 		local v = list[i]
-		if v ~= nil and callback(v, i - 1, list) == true then
+		if callback(v, i - 1, list) == true then
 			result[#result + 1] = v
 		end
 	end
@@ -377,16 +371,7 @@ local function sortFallback(a, b)
 end
 
 function TS.array_sort(list, callback)
-	local sorted = {}
-	local count = 0
-
-	for i = 1, #list do
-		local v = list[i]
-		if v ~= nil then
-			count = count + 1
-			sorted[count] = v
-		end
-	end
+	local sorted = array_copy(list)
 
 	if callback then
 		table.sort(sorted, function(a, b)
@@ -504,8 +489,7 @@ end
 
 function TS.array_some(list, callback)
 	for i = 1, #list do
-		local v = list[i]
-		if v ~= nil and callback(v, i - 1, list) == true then
+		if callback(list[i], i - 1, list) == true then
 			return true
 		end
 	end
@@ -514,8 +498,7 @@ end
 
 function TS.array_every(list, callback)
 	for i = 1, #list do
-		local v = list[i]
-		if v ~= nil and callback(v, i - 1, list) == false then
+		if callback(list[i], i - 1, list) == false then
 			return false
 		end
 	end
@@ -533,8 +516,7 @@ end
 
 function TS.array_indexOf(list, value, fromIndex)
 	for i = (fromIndex or 0) + 1, #list do
-		local v = list[i]
-		if v ~= nil and value == v then
+		if value == list[i] then
 			return i - 1
 		end
 	end
@@ -543,8 +525,7 @@ end
 
 function TS.array_lastIndexOf(list, value, fromIndex)
 	for i = (fromIndex or #list - 1) + 1, 1, -1 do
-		local v = list[i]
-		if v ~= nil and value == v then
+		if value == list[i] then
 			return i - 1
 		end
 	end
@@ -578,10 +559,7 @@ function TS.array_reduce(list, callback, ...)
 		accumulator = ...
 	end
 	for i = first, last do
-		local v = list[i]
-		if v ~= nil then
-			accumulator = callback(accumulator, v, i - 1, list)
-		end
+		accumulator = callback(accumulator, list[i], i - 1, list)
 	end
 	return accumulator
 end
@@ -603,10 +581,7 @@ function TS.array_reduceRight(list, callback, ...)
 		accumulator = ...
 	end
 	for i = first, last, -1 do
-		local v = list[i]
-		if v ~= nil then
-			accumulator = callback(accumulator, v, i - 1, list)
-		end
+		accumulator = callback(accumulator, list[i], i - 1, list)
 	end
 	return accumulator
 end

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -363,12 +363,10 @@ end
 
 function TS.array_filter(list, callback)
 	local result = {}
-	local count = 0
 	for i = 1, #list do
 		local v = list[i]
 		if v ~= nil and callback(v, i - 1, list) == true then
-			count = count + 1
-			result[count] = v
+			result[#result + 1] = v
 		end
 	end
 	return result

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -553,10 +553,8 @@ function TS.array_reduce(list, callback, ...)
 		if last == 0 then
 			error("Reduce of empty array with no initial value at Array.reduce", 2)
 		end
-		repeat
-			accumulator = list[first]
-			first = first + 1
-		until accumulator ~= nil
+		accumulator = list[first]
+		first = first + 1
 	else
 		accumulator = ...
 	end
@@ -575,10 +573,8 @@ function TS.array_reduceRight(list, callback, ...)
 		if first == 0 then
 			error("Reduce of empty array with no initial value at Array.reduceRight", 2)
 		end
-		repeat
-			accumulator = list[first]
-			first = first - 1
-		until accumulator ~= nil
+		accumulator = list[first]
+		first = first - 1
 	else
 		accumulator = ...
 	end

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -663,13 +663,11 @@ local function array_flat_helper(list, depth, count, result)
 	for i = 1, #list do
 		local v = list[i]
 
-		if v ~= nil then
-			if type(v) == "table" and depth ~= 0 then
-				count = array_flat_helper(v, depth - 1, count, result)
-			else
-				count = count + 1
-				result[count] = v
-			end
+		if type(v) == "table" and depth ~= 0 then
+			count = array_flat_helper(v, depth - 1, count, result)
+		else
+			count = count + 1
+			result[count] = v
 		end
 	end
 

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -347,13 +347,15 @@ function TS.array_forEach(list, callback)
 	end
 end
 
-function TS.array_map(list, callback)
+local function array_map(list, callback)
 	local result = {}
 	for i = 1, #list do
 		result[i] = callback(list[i], i - 1, list)
 	end
 	return result
 end
+
+TS.array_map = array_map
 
 function TS.array_filter(list, callback)
 	local result = {}
@@ -629,16 +631,7 @@ function TS.array_concat(...)
 end
 
 function TS.array_join(list, separator)
-	local result = {}
-	for i = 1, #list do
-		local item = list[i]
-		if item == nil then
-			result[i] = ""
-		else
-			result[i] = tostring(list[i])
-		end
-	end
-	return table.concat(result, separator or ",")
+	return table.concat(array_map(list, tostring), separator or ",")
 end
 
 function TS.array_find(list, callback)

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -556,10 +556,10 @@ function TS.array_reduce(list, callback, ...)
 	local accumulator
 	-- support `nil` initialValues
 	if select("#", ...) == 0 then
+		if last == 0 then
+			error("Reduce of empty array with no initial value at Array.reduce", 2)
+		end
 		repeat
-			if first > last then
-				error("Reduce of empty array with no initial value at Array.reduce", 2)
-			end
 			accumulator = list[first]
 			first = first + 1
 		until accumulator ~= nil
@@ -575,17 +575,26 @@ function TS.array_reduce(list, callback, ...)
 	return accumulator
 end
 
-function TS.array_reduceRight(list, callback, initialValue)
-	local start = #list
-	if initialValue == nil then
-		initialValue = list[start]
-		start = start - 1
+function TS.array_reduceRight(list, callback, ...)
+	local first = #list
+	local last = 1
+	local accumulator
+	-- support `nil` initialValues
+	if select("#", ...) == 0 then
+		if first == 0 then
+			error("Reduce of empty array with no initial value at Array.array_reduceRight", 2)
+		end
+		repeat
+			accumulator = list[first]
+			first = first - 1
+		until accumulator ~= nil
+	else
+		accumulator = ...
 	end
-	local accumulator = initialValue
-	for i = start, 1, -1 do
+	for i = first, last, -1 do
 		local v = list[i]
 		if v ~= nil then
-			accumulator = callback(accumulator, v, i)
+			accumulator = callback(accumulator, v, i - 1, list)
 		end
 	end
 	return accumulator

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -550,17 +550,26 @@ function TS.array_reverse(list)
 	return result
 end
 
-function TS.array_reduce(list, callback, initialValue)
-	local start = 1
-	if initialValue == nil then
-		initialValue = list[start]
-		start = 2
+function TS.array_reduce(list, callback, ...)
+	local first = 1
+	local last = #list
+	local accumulator
+	-- support `nil` initialValues
+	if select("#", ...) == 0 then
+		repeat
+			if first > last then
+				error("Reduce of empty array with no initial value at Array.reduce", 2)
+			end
+			accumulator = list[first]
+			first = first + 1
+		until accumulator ~= nil
+	else
+		accumulator = ...
 	end
-	local accumulator = initialValue
-	for i = start, #list do
+	for i = first, last do
 		local v = list[i]
 		if v ~= nil then
-			accumulator = callback(accumulator, v, i)
+			accumulator = callback(accumulator, v, i - 1, list)
 		end
 	end
 	return accumulator
@@ -640,7 +649,7 @@ end
 function TS.array_find(list, callback)
 	for i = 1, #list do
 		local v = list[i]
-		if callback(v, i - 1, list) == true then
+		if v ~= nil and callback(v, i - 1, list) == true then
 			return v
 		end
 	end
@@ -648,7 +657,8 @@ end
 
 function TS.array_findIndex(list, callback)
 	for i = 0, #list - 1 do
-		if callback(list[i + 1], i, list) == true then
+		local v = list[i + 1]
+		if v ~= nil and callback(v, i, list) == true then
 			return i
 		end
 	end

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -573,7 +573,7 @@ function TS.array_reduceRight(list, callback, ...)
 	-- support `nil` initialValues
 	if select("#", ...) == 0 then
 		if first == 0 then
-			error("Reduce of empty array with no initial value at Array.array_reduceRight", 2)
+			error("Reduce of empty array with no initial value at Array.reduceRight", 2)
 		end
 		repeat
 			accumulator = list[first]

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -484,7 +484,7 @@ export = () => {
 		expect(z[5]).to.equal(6);
 		// [1, 2, 3, 4, 5, 6]
 
-		const arr4 = [1, 2, , 4, 5];
+		const arr4 = [1, 2, 4, 5];
 		const a = arr4.flat();
 		// [1, 2, 4, 5]
 		expect(a[0]).to.equal(1);

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -359,9 +359,13 @@ export = () => {
 	});
 
 	it("should support reducing forwards or backwards", () => {
-		expect([..."abcdef"].reduce((previous, current) => previous + current)).to.equal()
-		expect([..."abcdef"].reduceRight((previous, current) => previous + current)).to.equal()
-	})
+		expect([..."abcdef"].reduce((previous, current) => previous + current)).to.equal("abcdef");
+		expect([..."abcdef"].reduce((previous, current) => previous + current, " ")).to.equal(" " + "abcdef");
+		expect([..."abcdef"].reduceRight((previous, current) => previous + current)).to.equal("abcdef".reverse());
+		expect([..."abcdef"].reduceRight((previous, current) => previous + current, " ")).to.equal(
+			" " + "abcdef".reverse(),
+		);
+	});
 
 	it("should support find", () => {
 		const a = [1, 2, 3, 4, 5];

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -326,13 +326,13 @@ export = () => {
 				(previous: undefined | number, current, index, arr) => index + (previous || index),
 				undefined,
 			),
-		).to.equal(15);
+		).to.equal(16);
 		expect(
 			[..."😂😄😃😊😉😍"].reduceRight(
 				(previous: undefined | number, current, index, arr) => index + (previous || index),
 				undefined,
 			),
-		).to.equal(15);
+		).to.equal(20);
 		expect(
 			[].reduce(() => {
 				throw "Should not call the reducer function on an empty array! [1]";

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -304,6 +304,60 @@ export = () => {
 		expect(a[5]).to.equal(1);
 	});
 
+	it("should support reducing empty arrays only with a initialValue parameter", () => {
+		expect(() => new Array<string>().reduce((previous, current, index, arr) => previous + current)).to.throw();
+		expect(
+			new Array<string>().reduce((previous, current, index, arr) => {
+				throw "This should never run! [1]";
+			}, "a"),
+		).to.equal("a");
+
+		expect(() => new Array<string>().reduceRight((previous, current, index, arr) => previous + current)).to.throw();
+		expect(
+			new Array<string>().reduceRight((previous, current, index, arr) => {
+				throw "This should never run! [2]";
+			}, "a"),
+		).to.equal("a");
+	});
+
+	it("should support reducing arrays with an undefined initialValue", () => {
+		expect(
+			[..."😂😄😃😊😉😍"].reduce(
+				(previous: undefined | number, current, index, arr) => index + (previous || index),
+				undefined,
+			),
+		).to.equal(15);
+		expect(
+			[..."😂😄😃😊😉😍"].reduceRight(
+				(previous: undefined | number, current, index, arr) => index + (previous || index),
+				undefined,
+			),
+		).to.equal(15);
+		expect(
+			[].reduce(() => {
+				throw "Should not call the reducer function on an empty array! [1]";
+			}, undefined),
+		).to.equal(undefined);
+		expect(
+			[].reduceRight(() => {
+				throw "Should not call the reducer function on an empty array! [2]";
+			}, undefined),
+		).to.equal(undefined);
+	});
+
+	it("should support reducing single-element arrays without calling a reducer when no initialValue is passed in", () => {
+		expect(
+			[4].reduce(() => {
+				throw "Should not call the reducer function on a single-element array with no initialValue! [1]";
+			}),
+		).to.equal(4);
+		expect(
+			[5].reduceRight(() => {
+				throw "Should not call the reducer function on a single-element array with no initialValue! [2]";
+			}),
+		).to.equal(5);
+	});
+
 	it("should support find", () => {
 		const a = [1, 2, 3, 4, 5];
 

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -358,6 +358,11 @@ export = () => {
 		).to.equal(5);
 	});
 
+	it("should support reducing forwards or backwards", () => {
+		expect([..."abcdef"].reduce((previous, current) => previous + current)).to.equal()
+		expect([..."abcdef"].reduceRight((previous, current) => previous + current)).to.equal()
+	})
+
 	it("should support find", () => {
 		const a = [1, 2, 3, 4, 5];
 


### PR DESCRIPTION
- Simplify `array_flat_helper` a little
- Removed limited support for arrays with holes. We should just release a separate library for that. Previously, we partially copied JS' behavior on empty values in arrays. However, developers should expect that their callbacks will run on every value of an array.

- Fixed `Array.reduce` and `Array.reduceRight` functions
    - They now pass in the right index into the reducer function (arrays start at 0, not 1)
	- They now pass the array into the reducer function
	- They now error when attempting to reduce an empty array without an initialValue passed in
	- `undefined` is now a valid initialValue
- Removed limited support for array methods with holes. We don't support arrays with holes in them.
	- If want to strip an array of `nil` values, use `Array.filter((v): v is NonNullable<typeof v> => v !== undefined);`
    - We should release a library for making with arrays with holes for that niche use case, where `length` is tracked as a real value.

Still working on the corresponding type update :)