### PR TITLE
Fix Roact.Element[] expression regression

### DIFF
--- a/src/compiler/roact.ts
+++ b/src/compiler/roact.ts
@@ -101,7 +101,7 @@ function isRoactElementMapType(type: ts.Type) {
  */
 function isRoactElementArrayType(type: ts.Type) {
 	if (isArrayType(type)) {
-		if (isRoactElementUnionType(type) || type.getText() === ROACT_ELEMENT_TYPE) {
+		if (isRoactElementUnionType(type) || type.getText() === `${ROACT_ELEMENT_TYPE}[]`) {
 			return true;
 		} else {
 			return false;

--- a/tests/src/roact.spec.tsx
+++ b/tests/src/roact.spec.tsx
@@ -327,8 +327,8 @@ export = () => {
 
 			expect(ElementKind.of(testProps[Roact.Children])).to.equal(ElementKind.Fragment);
 			expect(ElementKind.of(test2Props[Roact.Children])).to.equal(ElementKind.Fragment);
-			expect((testProps[Roact.Children] as unknown as FragmentLike).elements.IfFalse).to.be.ok();
-			expect((test2Props[Roact.Children] as unknown as FragmentLike).elements.IfTrue).to.be.ok();
+			expect(((testProps[Roact.Children] as unknown) as FragmentLike).elements.IfFalse).to.be.ok();
+			expect(((test2Props[Roact.Children] as unknown) as FragmentLike).elements.IfTrue).to.be.ok();
 		});
 	});
 
@@ -403,5 +403,15 @@ export = () => {
 		const props = f.props as ExplicitProps<Frame>;
 		expect(props[Roact.Children].TrueFrame).to.be.ok();
 		expect(props[Roact.Children][1]).to.be.ok();
+	});
+
+	it("should support roact element arrays as an expression", () => {
+		const test = [<frame Key="Test1" />, <frame Key="Test2" />];
+
+		const test2 = <frame>{test}</frame>;
+
+		const test2Props = test2.props as ExplicitProps<Frame>;
+		expect(test2Props[Roact.Children].Test1).to.be.ok();
+		expect(test2Props[Roact.Children].Test2).to.be.ok();
 	});
 };


### PR DESCRIPTION
Fixes expressions where the identifier is a `Roact.Element[]`. 

This previously worked (lol) but was changed when I fixed issues with other identifier expressions working when they shouldn't.

Test also added to ensure this works now.