### PR TITLE
Fix circular dependency checker

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -134,8 +134,8 @@ function TS.import(caller, module, ...)
 	end
 
 	_G[module] = TS
-	loadedLibraries[module] = true -- register as already loaded for subsequent calls
 	local data = require(module)
+	loadedLibraries[module] = true -- register as already loaded for subsequent calls
 
 	if currentlyLoading[caller] == module then -- Thread-safe cleanup!
 		currentlyLoading[caller] = nil

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -85,8 +85,8 @@ function TS.getModule(object, moduleName)
 end
 
 -- This is a hash which TS.import uses as a kind of linked-list-like history of [Script who Loaded] -> Library
-local loadedLibraries = {}
 local currentlyLoading = {}
+local registeredLibraries = {}
 
 function TS.import(caller, module, ...)
 	for i = 1, select("#", ...) do
@@ -95,10 +95,6 @@ function TS.import(caller, module, ...)
 
 	if module.ClassName ~= "ModuleScript" then
 		error("Failed to import! Expected ModuleScript, got " .. module.ClassName, 2)
-	end
-
-	if loadedLibraries[module] then
-		return require(module)
 	end
 
 	currentlyLoading[caller] = module
@@ -122,20 +118,23 @@ function TS.import(caller, module, ...)
 
 			for _ = 1, depth do
 				currentModule = currentlyLoading[currentModule]
-				str = str .. " -> " .. currentModule.Name
+				str = str .. "  ⇒ " .. currentModule.Name
 			end
 
 			error("Failed to import! Detected a circular dependency chain: " .. str, 2)
 		end
 	end
 
-	if _G[module] then
-		error("Invalid module access! Do you have two TS runtimes trying to import this? " .. module:GetFullName(), 2)
+	if not registeredLibraries[module] then
+		if _G[module] then
+			error("Invalid module access! Do you have two TS runtimes trying to import this? " .. module:GetFullName(), 2)
+		end
+
+		_G[module] = TS
+		registeredLibraries[module] = true -- register as already loaded for subsequent calls
 	end
 
-	_G[module] = TS
 	local data = require(module)
-	loadedLibraries[module] = true -- register as already loaded for subsequent calls
 
 	if currentlyLoading[caller] == module then -- Thread-safe cleanup!
 		currentlyLoading[caller] = nil


### PR DESCRIPTION
This is the problem Vorlias was having: There was a circular dependency and our code which checks against that didn't work because `loadedLibraries[module] = true` made it skip the dependency check logic, even if the library hadn't finished loading.