### PR TITLE
Disallow enum merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Changed our limited emulation of JS behavior where many array methods wouldn't call callbacks on empty values in arrays (we considered any `nil` value `empty`). Now, every callback in every array method gets called on every item within arrays, even `nil` values if applicable. This should be more straightforward and easier to understand (and easier for our type system). This change shouldn't affect most people, since we discourage using arrays with holes anyway.
 	- If you need to strip an array of `nil` values, use `Array.filter((v): v is NonNullable<typeof v> => v !== undefined);`
     - We should release a library for safely making arrays with holes for that niche use case, where `length` is tracked as a real value.
+- Declaring the same enum multiple times (merging) is no longer allowed. As a result `Object.keys` and `Object.values` now work with enums!
 
 ### **0.2.14**
 - Fixed analytics bug

--- a/src/compiler/enum.ts
+++ b/src/compiler/enum.ts
@@ -21,31 +21,35 @@ export function compileEnumDeclaration(state: CompilerState, node: ts.EnumDeclar
 	if (shouldHoist(node, nameNode)) {
 		state.pushHoistStack(name);
 	}
-	result += state.indent + `${name} = ${name} or {};\n`;
+	result += state.indent + `local ${name};\n`;
 	result += state.indent + `do\n`;
 	state.pushIndent();
+	state.pushIdStack();
+	const inverseId = state.getNewId();
+	result += state.indent + `local ${inverseId} = {};\n`;
+	result += state.indent + `${name} = setmetatable({}, { __index = ${inverseId} });\n`;
 	for (const member of node.getMembers()) {
 		const memberName = member.getName();
 		const memberValue = member.getValue();
 		const safeIndex = safeLuaIndex(name, memberName);
-
 		if (typeof memberValue === "string") {
 			const strForm = '"' + sanitizeTemplate(memberValue) + '"';
 			result += state.indent + `${safeIndex} = ${strForm};\n`;
 		} else if (typeof memberValue === "number") {
 			result += state.indent + `${safeIndex} = ${memberValue};\n`;
-			result += state.indent + `${name}[${memberValue}] = "${memberName}";\n`;
+			result += state.indent + `${inverseId}[${memberValue}] = "${memberName}";\n`;
 		} else if (member.hasInitializer()) {
 			const initializer = skipNodesDownwards(member.getInitializerOrThrow());
 			state.enterPrecedingStatementContext();
 			const expStr = getReadableExpressionName(state, initializer);
 			result += state.exitPrecedingStatementContextAndJoin();
 			result += state.indent + `${safeIndex} = ${expStr};\n`;
-			result += state.indent + `${name}[${expStr}] = "${memberName}";\n`;
+			result += state.indent + `${inverseId}[${expStr}] = "${memberName}";\n`;
 		} else {
 			throw new CompilerError("Unexpected enum structure.", node, CompilerErrorType.BadEnum, true);
 		}
 	}
+	state.popIdStack();
 	state.popIndent();
 	result += state.indent + `end;\n`;
 	return result;

--- a/src/errors/CompilerError.ts
+++ b/src/errors/CompilerError.ts
@@ -96,6 +96,7 @@ export enum CompilerErrorType {
 	BadDestructSubType,
 	MixedMethodSet,
 	BadNamespaceExport,
+	NoEnumMerging,
 }
 
 export class CompilerError extends LoggableError {

--- a/src/test.ts
+++ b/src/test.ts
@@ -482,6 +482,11 @@ const errorMatrix: ErrorMatrix = {
 		instance: CompilerError,
 		type: CompilerErrorType.MixedMethodSet,
 	},
+	"noEnumMerging.spec.ts": {
+		message: "should not allow enum merging",
+		instance: CompilerError,
+		type: CompilerErrorType.NoEnumMerging,
+	},
 };
 /* tslint:enable:object-literal-sort-keys */
 

--- a/tests/src/errors/noEnumMerging.spec.ts
+++ b/tests/src/errors/noEnumMerging.spec.ts
@@ -1,0 +1,9 @@
+export {};
+
+enum X {
+	A,
+}
+
+enum X {
+	B = X.A + 1,
+}


### PR DESCRIPTION
This PR bans enum merging to simplify compilation. It's also a bit of a footgun since you really should only ever have one source of truth for data like that.

```TS
enum GameState {
	None,
	Lobby,
	InProgress,
	End,
}
```

```Lua
local GameState;
do
	local _0 = {};
	GameState = setmetatable({}, { __index = _0 });
	GameState.None = 0;
	_0[0] = "None";
	GameState.Lobby = 1;
	_0[1] = "Lobby";
	GameState.InProgress = 2;
	_0[2] = "InProgress";
	GameState.End = 3;
	_0[3] = "End";
end;
```

This new format allows you to iterate over enum keys and values using the following:
```TS
Object.keys(GameState); // "None" | "Lobby" | "InProgress" | "End"
Object.values(GameState): // GameState
```
while still allowing inverse lookups for debugging:
```TS
declare const myState: GameState;
print(GameState[myState]);
```