### PR TITLE
Add mapFiltered

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -361,6 +361,22 @@ end
 
 TS.array_map = array_map
 
+function TS.array_mapFiltered(list, callback)
+    local new = {}
+    local index = 1
+
+    for i = 1, #list do
+        local result = callback(list[i], i - 1, list)
+
+        if result ~= nil then
+            new[index] = result
+            index = index + 1
+        end
+    end
+
+    return new
+end
+
 function TS.array_filter(list, callback)
 	local result = {}
 	for i = 1, #list do

--- a/tests/src/array.spec.ts
+++ b/tests/src/array.spec.ts
@@ -660,4 +660,17 @@ export = () => {
 	it("should support Array constructor", () => {
 		expect(new Array(10).isEmpty()).to.equal(true);
 	});
+
+	it("should support Array.mapFiltered", () => {
+		class A {
+			static i = 0;
+
+			f() {
+				return ++A.i > 5 ? { x: A.i } : undefined;
+			}
+		}
+
+		const arr = [new A(), new A(), new A(), new A(), new A(), new A(), new A(), new A()];
+		expect(arr.mapFiltered(a => a.f()).reduce((a, c) => a + c.x, 0)).to.equal(21);
+	})
 };


### PR DESCRIPTION
Adds `mapFiltered` method to arrays, which works like the `map` function but excludes undefined values.

I think `mapFiltered` is the best name because it is more indicative of "map with exceptions" than "filter but it maps", which makes less sense. In intellisense, it will be right underneath `map`, and should seem to be a clear alternative to using `array.map`.

Ripped definition from Cryo. I just modified the callback arguments to match our spec. `i` -> `i - 1`, and added the `list` argument as well.

Closes https://github.com/roblox-ts/roblox-ts/issues/716