### PR TITLE
Fix tests

### DIFF
--- a/tests/src/class.spec.ts
+++ b/tests/src/class.spec.ts
@@ -304,7 +304,7 @@ export = () => {
 			constructor(arr?: ReadonlyArray<number>) {
 				super();
 				if (arr) {
-					super.push(...arr.sort((a, b) => b - a));
+					super.push(...[...arr].sort());
 				}
 			}
 			public unshift() {

--- a/tests/src/spread.spec.ts
+++ b/tests/src/spread.spec.ts
@@ -18,7 +18,7 @@ export = () => {
 
 	it("should work with generic types", () => {
 		function f<T extends Array<unknown>>(...args: T) {
-			expect([...args].pop()!).to.equal("Hi!");
+			expect([...args][0]).to.equal("Hi!");
 		}
 
 		f("Hi!");

--- a/tests/src/tuple.spec.ts
+++ b/tests/src/tuple.spec.ts
@@ -159,7 +159,7 @@ export = () => {
 	});
 
 	it("should allow LuaTuples to have Array<> inside", () => {
-		function foo(): LuaTuple<[number, number, ...Array<string | undefined>] | Array<undefined>> {
+		function foo(): LuaTuple<[number, number, ...Array<string>] | []> {
 			return [1, 2, "3"];
 		}
 


### PR DESCRIPTION
- update use of array.sort to match new implementation
- remove attempt to do `(Array<unknown>).pop()`. In this case, we can substitute this for `args[0]`. In general, however, I think this is smart because `Array<unknown>` could have holes and the .pop() function wouldn't necessarily work as intended. Developers could use `Object.values(args)` to make an array guaranteed to not have holes. (or use `Array<{}>` as a type instead)
- Note in the case of `[number, number, ...Array<string | undefined>] | Array<undefined>` becoming `[number, number, ...Array<string>] | []`, I think the latter is actually a much better definition, since `...Array<string>` can be of any length, including 0. It's good that the changes to the types have made us rethink type definitions which were less than ideal.