### PR TITLE
Array and string improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -932,7 +932,7 @@
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
@@ -1139,7 +1139,7 @@
 		"eslint-formatter-pretty": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
-			"integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+			"integrity": "sha1-mF2eQcH4R19KCQxdvS388oIdYH4=",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^2.0.0",
@@ -1259,7 +1259,7 @@
 		"fast-diff": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
 			"dev": true
 		},
 		"fast-glob": {
@@ -1599,7 +1599,7 @@
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
 			"dev": true
 		},
 		"http-signature": {
@@ -1624,7 +1624,7 @@
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
 			"dev": true
 		},
 		"import-fresh": {
@@ -1781,7 +1781,7 @@
 		"is-absolute": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+			"integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
 			"requires": {
 				"is-relative": "^1.0.0",
 				"is-windows": "^1.0.1"
@@ -1884,7 +1884,7 @@
 		"is-relative": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+			"integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
@@ -1912,7 +1912,7 @@
 		"is-unc-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+			"integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
 			"requires": {
 				"unc-path-regex": "^0.1.2"
 			}
@@ -2046,7 +2046,7 @@
 		"jest-docblock": {
 			"version": "21.2.0",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+			"integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
 			"dev": true
 		},
 		"js-tokens": {
@@ -2148,7 +2148,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
@@ -2170,7 +2170,7 @@
 		"locate-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
 			"dev": true,
 			"requires": {
 				"p-locate": "^3.0.0",
@@ -2198,7 +2198,7 @@
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
@@ -2293,7 +2293,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -2359,12 +2359,12 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -2517,7 +2517,7 @@
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
 			"dev": true
 		},
 		"node-environment-flags": {
@@ -2549,7 +2549,7 @@
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
@@ -2769,7 +2769,7 @@
 		"p-locate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
 			"dev": true,
 			"requires": {
 				"p-limit": "^2.0.0"
@@ -2916,7 +2916,7 @@
 		"prettylint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettylint/-/prettylint-1.0.0.tgz",
-			"integrity": "sha512-IjIAoGeIve8NQR6WbslnMs5rcnEVbJkZN/IXm302wNlSEo+3pIyxroy+3bkEFLP14prz1Aq1GGlKsX0UXHXuEQ==",
+			"integrity": "sha1-txcgrZcz4Jj92OvqkMYc2jM3GqE=",
 			"dev": true,
 			"requires": {
 				"eslint-formatter-pretty": "^1.3.0",
@@ -2940,7 +2940,7 @@
 				},
 				"globby": {
 					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
@@ -2953,7 +2953,7 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
@@ -3010,7 +3010,7 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
@@ -3258,7 +3258,7 @@
 		"spdx-correct": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"integrity": "sha1-GbtAnpG0exrVQVkkP3MSqFjbPC4=",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -3268,13 +3268,13 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
 			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -3284,7 +3284,7 @@
 		"spdx-license-ids": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-			"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+			"integrity": "sha1-pZ78CXhMKlutoTz+r1x13SFARNI=",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -3312,7 +3312,7 @@
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
@@ -3435,7 +3435,7 @@
 			"dependencies": {
 				"load-json-file": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
@@ -3665,7 +3665,7 @@
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
 			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
@@ -3685,7 +3685,7 @@
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
@@ -3784,7 +3784,7 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
 		},
 		"yallist": {
 			"version": "2.1.2",

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -15,7 +15,7 @@ import {
 	isIdentifierDefinedInExportLet,
 	isMethodDeclaration,
 	isValidLuaIdentifier,
-	shouldCompileAsSpreadableList,
+	shouldCompileAsSpreadableList
 } from ".";
 import { CompilerState, PrecedingStatementContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
@@ -32,10 +32,18 @@ import {
 	isTupleReturnTypeCall,
 	laxTypeConstraint,
 	shouldPushToPrecedingStatement,
-	superExpressionClassInheritsFromArray,
+	superExpressionClassInheritsFromArray
 } from "../utility/type";
 
-const STRING_MACRO_METHODS = new Set(["format", "gmatch", "gsub", "lower", "rep", "reverse", "upper"]);
+const STRING_MACRO_METHODS = new Set([
+	"format",
+	"gmatch",
+	"gsub",
+	"lower",
+	"rep",
+	"reverse",
+	"upper"
+]);
 
 export function shouldWrapExpression(subExp: ts.Node, strict: boolean) {
 	subExp = skipNodesDownwards(subExp);
@@ -69,14 +77,29 @@ function getPropertyCallParentIsExpressionStatement(subExp: ts.Expression) {
 	return ts.TypeGuards.isExpressionStatement(getLeftHandSideParent(subExp));
 }
 
-type ReplaceFunction = (state: CompilerState, params: Array<ts.Expression>) => string | undefined;
+type ReplaceFunction = (
+	state: CompilerState,
+	params: Array<ts.Expression>
+) => string | undefined;
 type ReplaceMap = Map<string, ReplaceFunction>;
 
-function wrapExpFunc(replacer: (accessPath: string) => string): ReplaceFunction {
-	return (state, params) => replacer(compileCallArgumentsAndSeparateAndJoinWrapped(state, params, true)[0]);
+function wrapExpFunc(
+	replacer: (accessPath: string) => string
+): ReplaceFunction {
+	return (state, params) =>
+		replacer(
+			compileCallArgumentsAndSeparateAndJoinWrapped(
+				state,
+				params,
+				true
+			)[0]
+		);
 }
 
-function compileCallArgumentsAndSeparateAndJoin(state: CompilerState, params: Array<ts.Expression>): [string, string] {
+function compileCallArgumentsAndSeparateAndJoin(
+	state: CompilerState,
+	params: Array<ts.Expression>
+): [string, string] {
 	const [accessPath, ...compiledArgs] = compileCallArguments(state, params);
 	return [accessPath, compiledArgs.join(", ")];
 }
@@ -85,9 +108,17 @@ function compileCallArgumentsAndSeparateWrapped(
 	state: CompilerState,
 	params: Array<ts.Expression>,
 	strict = false,
-	compile: (state: CompilerState, expression: ts.Expression) => string = compileExpression,
+	compile: (
+		state: CompilerState,
+		expression: ts.Expression
+	) => string = compileExpression
 ): [string, Array<string>] {
-	const [accessPath, ...compiledArgs] = compileCallArguments(state, params, undefined, compile);
+	const [accessPath, ...compiledArgs] = compileCallArguments(
+		state,
+		params,
+		undefined,
+		compile
+	);
 
 	// If we compile to a method call, we might need to wrap in parenthesis
 	// We are going to wrap in parenthesis just to be safe,
@@ -110,21 +141,28 @@ function compileCallArgumentsAndSeparateWrapped(
 function compileCallArgumentsAndSeparateAndJoinWrapped(
 	state: CompilerState,
 	params: Array<ts.Expression>,
-	strict = false,
+	strict = false
 ): [string, string] {
-	const [accessStr, compiledArgs] = compileCallArgumentsAndSeparateWrapped(state, params, strict);
+	const [accessStr, compiledArgs] = compileCallArgumentsAndSeparateWrapped(
+		state,
+		params,
+		strict
+	);
 	return [accessStr, compiledArgs.join(", ")];
 }
 
 function macroStringIndexFunction(
 	methodName: string,
 	incrementedArgs: Array<number>,
-	decrementedArgs: Array<number> = [],
+	decrementedArgs: Array<number> = []
 ): ReplaceFunction {
 	return (state, params) => {
 		let i = -1;
 		let wasIncrementing: boolean | undefined;
-		const [accessPath, compiledArgs] = compileCallArgumentsAndSeparateWrapped(
+		const [
+			accessPath,
+			compiledArgs
+		] = compileCallArgumentsAndSeparateWrapped(
 			state,
 			params,
 			true,
@@ -144,8 +182,14 @@ function macroStringIndexFunction(
 					ts.TypeGuards.isIdentifier(param) &&
 					ts.TypeGuards.isIdentifier(previousParam)
 				) {
-					const definitions = param.getDefinitions().map(def => def.getNode());
-					if (previousParam.getDefinitions().every((def, j) => definitions[j] === def.getNode())) {
+					const definitions = param
+						.getDefinitions()
+						.map(def => def.getNode());
+					if (
+						previousParam
+							.getDefinitions()
+							.every((def, j) => definitions[j] === def.getNode())
+					) {
 						wasIncrementing = incrementing;
 						return "";
 					}
@@ -166,27 +210,43 @@ function macroStringIndexFunction(
 					const valueNumber = Number(expStr);
 					if (!Number.isNaN(valueNumber)) {
 						if (incrementing) {
-							return (valueNumber >= 0 ? valueNumber + 1 : valueNumber).toString();
+							return (valueNumber >= 0
+								? valueNumber + 1
+								: valueNumber
+							).toString();
 						} else {
-							return (valueNumber < 0 ? valueNumber - 1 : valueNumber).toString();
+							return (valueNumber < 0
+								? valueNumber - 1
+								: valueNumber
+							).toString();
 						}
 					}
 				}
 
-				const currentContext = state.getCurrentPrecedingStatementContext(param);
-				const id = currentContext.isPushed ? expStr : state.pushPrecedingStatementToNewId(param, expStr);
+				const currentContext = state.getCurrentPrecedingStatementContext(
+					param
+				);
+				const id = currentContext.isPushed
+					? expStr
+					: state.pushPrecedingStatementToNewId(param, expStr);
 				const isNullable = isNullableType(getType(param));
 				if (incrementing) {
 					currentContext.push(
-						state.indent + `if ${isNullable ? `${id} and ` : ""}${id} >= 0 then ${id} = ${id} + 1; end\n`,
+						state.indent +
+							`if ${
+								isNullable ? `${id} and ` : ""
+							}${id} >= 0 then ${id} = ${id} + 1; end\n`
 					);
 				} else {
 					currentContext.push(
-						state.indent + `if ${isNullable ? `${id} and ` : ""}${id} < 0 then ${id} = ${id} - 1; end\n`,
+						state.indent +
+							`if ${
+								isNullable ? `${id} and ` : ""
+							}${id} < 0 then ${id} = ${id} - 1; end\n`
 					);
 				}
 				return id;
-			},
+			}
 		);
 		return `${accessPath}:${methodName}(${compiledArgs
 			.map((arg, j, args) => (arg === "" ? args[j - 1] : arg))
@@ -207,7 +267,8 @@ function padAmbiguous(state: CompilerState, params: Array<ts.Expression>) {
 
 	if (
 		!ts.TypeGuards.isStringLiteral(strParam) &&
-		(!ts.TypeGuards.isIdentifier(strParam) || isIdentifierDefinedInExportLet(strParam))
+		(!ts.TypeGuards.isIdentifier(strParam) ||
+			isIdentifierDefinedInExportLet(strParam))
 	) {
 		str = state.pushPrecedingStatementToNewId(strParam, str);
 	}
@@ -220,7 +281,10 @@ function padAmbiguous(state: CompilerState, params: Array<ts.Expression>) {
 	} else {
 		if (isNullableType(getType(fillStringParam))) {
 			fillString = `(${fillString} or " ")`;
-		} else if (!fillString.match(/^\(*_\d+\)*$/) && shouldWrapExpression(fillStringParam, true)) {
+		} else if (
+			!fillString.match(/^\(*_\d+\)*$/) &&
+			shouldWrapExpression(fillStringParam, true)
+		) {
 			fillString = `(${fillString})`;
 		}
 
@@ -236,10 +300,19 @@ function padAmbiguous(state: CompilerState, params: Array<ts.Expression>) {
 	let rawRepititions: number | undefined;
 	if (ts.TypeGuards.isStringLiteral(strParam)) {
 		if (maxLengthParam && ts.TypeGuards.isNumericLiteral(maxLengthParam)) {
-			const literalTargetLength = maxLengthParam.getLiteralValue() - strParam.getLiteralText().length;
+			const literalTargetLength =
+				maxLengthParam.getLiteralValue() -
+				strParam.getLiteralText().length;
 
-			if (fillStringParam === undefined || ts.TypeGuards.isStringLiteral(fillStringParam)) {
-				rawRepititions = literalTargetLength / (fillStringParam ? fillStringParam.getLiteralText().length : 1);
+			if (
+				fillStringParam === undefined ||
+				ts.TypeGuards.isStringLiteral(fillStringParam)
+			) {
+				rawRepititions =
+					literalTargetLength /
+					(fillStringParam
+						? fillStringParam.getLiteralText().length
+						: 1);
 				repititions = `${Math.ceil(rawRepititions)}`;
 			}
 
@@ -247,27 +320,35 @@ function padAmbiguous(state: CompilerState, params: Array<ts.Expression>) {
 		} else {
 			targetLength = `${maxLength} - ${strParam.getLiteralText().length}`;
 			if (fillStringLength !== "1") {
-				targetLength = state.pushPrecedingStatementToNewId(maxLengthParam, `${targetLength}`);
+				targetLength = state.pushPrecedingStatementToNewId(
+					maxLengthParam,
+					`${targetLength}`
+				);
 			}
 		}
 	} else {
 		targetLength = `${maxLength} - #${str}`;
 		if (fillStringLength !== "1") {
-			targetLength = state.pushPrecedingStatementToNewId(maxLengthParam, `${targetLength}`);
+			targetLength = state.pushPrecedingStatementToNewId(
+				maxLengthParam,
+				`${targetLength}`
+			);
 		}
 	}
 
 	const doNotTrim =
-		(rawRepititions !== undefined && rawRepititions === Math.ceil(rawRepititions)) || fillStringLength === "1";
+		(rawRepititions !== undefined &&
+			rawRepititions === Math.ceil(rawRepititions)) ||
+		fillStringLength === "1";
 
 	return [
 		`${fillString}:rep(${repititions ||
 			(fillStringLength === "1"
 				? targetLength
-				: `math.ceil(${targetLength} / ${fillStringLength ? fillStringLength : 1})`)})${
-			doNotTrim ? "" : `:sub(1, ${targetLength})`
-		}`,
-		str,
+				: `math.ceil(${targetLength} / ${
+						fillStringLength ? fillStringLength : 1
+				  })`)})${doNotTrim ? "" : `:sub(1, ${targetLength})`}`,
+		str
 	];
 }
 
@@ -278,19 +359,31 @@ const STRING_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			return appendDeclarationIfMissing(
 				state,
 				getLeftHandSideParent(params[0]),
-				`#${compileCallArgumentsAndSeparateAndJoinWrapped(state, params)[0]}`,
+				`#${
+					compileCallArgumentsAndSeparateAndJoinWrapped(
+						state,
+						params
+					)[0]
+				}`
 			);
-		},
+		}
 	],
 	["trim", wrapExpFunc(accessPath => `${accessPath}:match("^%s*(.-)%s*$")`)],
 	["trimLeft", wrapExpFunc(accessPath => `${accessPath}:match("^%s*(.-)$")`)],
-	["trimRight", wrapExpFunc(accessPath => `${accessPath}:match("^(.-)%s*$")`)],
+	[
+		"trimRight",
+		wrapExpFunc(accessPath => `${accessPath}:match("^(.-)%s*$")`)
+	],
 	[
 		"split",
 		(state, params) => {
-			const [str, args] = compileCallArgumentsAndSeparateAndJoinWrapped(state, params, true);
+			const [str, args] = compileCallArgumentsAndSeparateAndJoinWrapped(
+				state,
+				params,
+				true
+			);
 			return `string.split(${str}, ${args})`;
-		},
+		}
 	],
 	["slice", macroStringIndexFunction("sub", [1], [2])],
 	["sub", macroStringIndexFunction("sub", [1, 2])],
@@ -300,7 +393,7 @@ const STRING_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 		(state, params) => {
 			state.usesTSLibrary = true;
 			return `TS.string_find_wrap(${findMacro(state, params)!})`;
-		},
+		}
 	],
 	["match", macroStringIndexFunction("match", [2])],
 
@@ -310,27 +403,34 @@ const STRING_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			appendDeclarationIfMissing(
 				state,
 				getLeftHandSideParent(params[0]),
-				padAmbiguous(state, params).join(" .. "),
-			),
+				padAmbiguous(state, params).join(" .. ")
+			)
 	],
 
 	[
 		"padEnd",
 		(state, params) => {
 			const [a, b] = padAmbiguous(state, params);
-			return appendDeclarationIfMissing(state, getLeftHandSideParent(params[0]), [b, a].join(" .. "));
-		},
-	],
+			return appendDeclarationIfMissing(
+				state,
+				getLeftHandSideParent(params[0]),
+				[b, a].join(" .. ")
+			);
+		}
+	]
 ]);
 
-STRING_REPLACE_METHODS.set("trimStart", STRING_REPLACE_METHODS.get("trimLeft")!);
+STRING_REPLACE_METHODS.set(
+	"trimStart",
+	STRING_REPLACE_METHODS.get("trimLeft")!
+);
 STRING_REPLACE_METHODS.set("trimEnd", STRING_REPLACE_METHODS.get("trimRight")!);
 
 const isMapOrSetOrArrayEmpty: ReplaceFunction = (state, params) =>
 	appendDeclarationIfMissing(
 		state,
 		getLeftHandSideParent(params[0]),
-		`(next(${compileExpression(state, params[0])}) == nil)`,
+		`(next(${compileExpression(state, params[0])}) == nil)`
 	);
 
 const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
@@ -340,9 +440,14 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			return appendDeclarationIfMissing(
 				state,
 				getLeftHandSideParent(params[0]),
-				`#${compileCallArgumentsAndSeparateAndJoinWrapped(state, params)[0]}`,
+				`#${
+					compileCallArgumentsAndSeparateAndJoinWrapped(
+						state,
+						params
+					)[0]
+				}`
 			);
-		},
+		}
 	],
 	[
 		"pop",
@@ -354,17 +459,24 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				return `${accessPath}[#${accessPath}] = nil`;
 			} else {
 				const node = getLeftHandSideParent(subExp, 2);
-				const len = state.pushPrecedingStatementToNewId(subExp, `#${accessPath}`);
+				const len = state.pushPrecedingStatementToNewId(
+					subExp,
+					`#${accessPath}`
+				);
 				const place = `${accessPath}[${len}]`;
-				const nullSet = state.indent + `${place} = nil; -- ${subExp.getText()}.pop\n`;
+				const nullSet =
+					state.indent +
+					`${place} = nil; -- ${subExp.getText()}.pop\n`;
 				const id = state.pushToDeclarationOrNewId(node, place);
-				const context = state.getCurrentPrecedingStatementContext(subExp);
+				const context = state.getCurrentPrecedingStatementContext(
+					subExp
+				);
 				const { isPushed } = context;
 				state.pushPrecedingStatements(subExp, nullSet);
 				context.isPushed = isPushed;
 				return id;
 			}
-		},
+		}
 	],
 
 	[
@@ -375,14 +487,24 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			const accessPath = getReadableExpressionName(state, subExp);
 			let id: string;
 
-			const len = state.pushPrecedingStatementToNewId(subExp, `#${accessPath}`);
+			const len = state.pushPrecedingStatementToNewId(
+				subExp,
+				`#${accessPath}`
+			);
 			const lastPlace = `${accessPath}[${len}]`;
 
-			const isStatement = getPropertyCallParentIsExpressionStatement(subExp);
-			let removingIndex = addOneToArrayIndex(compileCallArguments(state, params.slice(1))[0]);
+			const isStatement = getPropertyCallParentIsExpressionStatement(
+				subExp
+			);
+			let removingIndex = addOneToArrayIndex(
+				compileCallArguments(state, params.slice(1))[0]
+			);
 
 			if (!isStatement && !isConstantExpression(params[1], 0)) {
-				removingIndex = state.pushPrecedingStatementToNewId(subExp, removingIndex);
+				removingIndex = state.pushPrecedingStatementToNewId(
+					subExp,
+					removingIndex
+				);
 			}
 
 			const removingPlace = `${accessPath}[${removingIndex}]`;
@@ -396,7 +518,8 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 
 			state.pushPrecedingStatements(
 				subExp,
-				state.indent + `${removingPlace} = ${lastPlace}; -- ${subExp.getText()}.unorderedRemove\n`,
+				state.indent +
+					`${removingPlace} = ${lastPlace}; -- ${subExp.getText()}.unorderedRemove\n`
 			);
 
 			const nullSet = state.indent + `${lastPlace} = nil`;
@@ -407,10 +530,14 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 
 			context.isPushed = isPushed;
 			return isStatement ? nullSet : id!;
-		},
+		}
 	],
 
-	["shift", (state, params) => `table.remove(${compileExpression(state, params[0])}, 1)`],
+	[
+		"shift",
+		(state, params) =>
+			`table.remove(${compileExpression(state, params[0])}, 1)`
+	],
 
 	[
 		"join",
@@ -424,19 +551,25 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 						? arrayType.getUnionTypes()
 						: [arrayType]
 					: subType.getTupleElements()
-				).every(validType => validType.isNumber() || validType.isString())
+				).every(
+					validType => validType.isNumber() || validType.isString()
+				)
 			) {
 				const argStrs = compileCallArguments(state, params);
-				return `table.concat(${argStrs[0]}, ${params[1] ? argStrs[1] : `","`})`;
+				return `table.concat(${argStrs[0]}, ${
+					params[1] ? argStrs[1] : `","`
+				})`;
 			}
-		},
+		}
 	],
 
 	[
 		"push",
 		(state, params) => {
 			const [subExp] = params;
-			const isStatement = getPropertyCallParentIsExpressionStatement(subExp);
+			const isStatement = getPropertyCallParentIsExpressionStatement(
+				subExp
+			);
 			const node = getLeftHandSideParent(subExp, 2);
 			const { length: numParams } = params;
 
@@ -444,11 +577,18 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 				state.usesTSLibrary = true;
 				let arrayStr = compileExpression(state, subExp);
 				state.enterPrecedingStatementContext();
-				const listStr = compileSpreadableListAndJoin(state, params.slice(1), false);
+				const listStr = compileSpreadableListAndJoin(
+					state,
+					params.slice(1),
+					false
+				);
 				const context = state.exitPrecedingStatementContext();
 
 				if (context.length > 0) {
-					arrayStr = state.pushPrecedingStatementToNewId(subExp, arrayStr);
+					arrayStr = state.pushPrecedingStatementToNewId(
+						subExp,
+						arrayStr
+					);
 					state.pushPrecedingStatements(subExp, ...context);
 				}
 
@@ -461,16 +601,25 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 					let accessor = `#${accessPath}${firstParam ? " + 1" : ""}`;
 					if (isStatement) {
 						return firstParam
-							? `${accessPath}[${accessor}] = ${compileExpression(state, firstParam)}`
+							? `${accessPath}[${accessor}] = ${compileExpression(
+									state,
+									firstParam
+							  )}`
 							: `local _ = ${accessor}`;
 					} else {
-						accessor = state.pushToDeclarationOrNewId(node, accessor);
+						accessor = state.pushToDeclarationOrNewId(
+							node,
+							accessor
+						);
 
 						if (firstParam) {
 							state.pushPrecedingStatements(
 								subExp,
 								state.indent +
-									`${accessPath}[${accessor}] = ${compileExpression(state, firstParam)};\n`,
+									`${accessPath}[${accessor}] = ${compileExpression(
+										state,
+										firstParam
+									)};\n`
 							);
 						}
 
@@ -478,10 +627,13 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 					}
 				} else {
 					state.usesTSLibrary = true;
-					return `TS.array_push_stack(${accessPath}, ${compileList(state, params.slice(1)).join(", ")})`;
+					return `TS.array_push_stack(${accessPath}, ${compileList(
+						state,
+						params.slice(1)
+					).join(", ")})`;
 				}
 			}
-		},
+		}
 	],
 
 	[
@@ -497,8 +649,13 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			let accessPath: string;
 			let paramStr: string;
 			// eslint-disable-next-line prefer-const
-			[accessPath, paramStr] = compileCallArgumentsAndSeparateAndJoin(state, params);
-			const isStatement = getPropertyCallParentIsExpressionStatement(subExp);
+			[accessPath, paramStr] = compileCallArgumentsAndSeparateAndJoin(
+				state,
+				params
+			);
+			const isStatement = getPropertyCallParentIsExpressionStatement(
+				subExp
+			);
 
 			if (length === 1) {
 				const result = `#${accessPath}`;
@@ -508,34 +665,68 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 					const expStr = `table.insert(${accessPath}, 1, ${paramStr})`;
 					return expStr;
 				} else {
-					accessPath = getReadableExpressionName(state, subExp, accessPath);
+					accessPath = getReadableExpressionName(
+						state,
+						subExp,
+						accessPath
+					);
 					state.pushPrecedingStatements(
 						subExp,
-						state.indent + `table.insert(${accessPath}, 1, ${paramStr});\n`,
+						state.indent +
+							`table.insert(${accessPath}, 1, ${paramStr});\n`
 					);
 					return `#${accessPath}`;
 				}
 			}
-		},
+		}
 	],
 
 	[
 		"insert",
 		(state, params) => {
-			const [accessPath, indexParamStr, valueParamStr] = compileCallArguments(state, params);
-			return `table.insert(${accessPath}, ${addOneToArrayIndex(indexParamStr)}, ${valueParamStr})`;
-		},
+			const [
+				accessPath,
+				indexParamStr,
+				valueParamStr
+			] = compileCallArguments(state, params);
+			return `table.insert(${accessPath}, ${addOneToArrayIndex(
+				indexParamStr
+			)}, ${valueParamStr})`;
+		}
 	],
 
 	[
 		"remove",
 		(state, params) => {
-			const [accessPath, indexParamStr] = compileCallArguments(state, params);
-			return `table.remove(${accessPath}, ${addOneToArrayIndex(indexParamStr)})`;
-		},
+			const [accessPath, indexParamStr] = compileCallArguments(
+				state,
+				params
+			);
+			return `table.remove(${accessPath}, ${addOneToArrayIndex(
+				indexParamStr
+			)})`;
+		}
 	],
 
-	["isEmpty", isMapOrSetOrArrayEmpty],
+	[
+		"indexOf",
+		(state, params) => {
+			const [accessPath, indexParamStr, fromIndex] = compileCallArguments(
+				state,
+				params
+			);
+
+			if (fromIndex !== undefined) {
+				return `(table.find(${accessPath}, ${indexParamStr}, ${addOneToArrayIndex(
+					fromIndex
+				)}) or 0) - 1`;
+			} else {
+				return `(table.find(${accessPath}, ${indexParamStr}) or 0) - 1`;				
+			}
+		}
+	],
+
+	["isEmpty", isMapOrSetOrArrayEmpty]
 ]);
 
 function getPropertyAccessExpressionRoot(root: ts.Expression) {
@@ -552,7 +743,8 @@ function getPropertyAccessExpressionRoot(root: ts.Expression) {
 function setKeyOfMapOrSet(kind: "map" | "set") {
 	const func: ReplaceFunction = (state, params) => {
 		const [subExp] = params;
-		const wasPushed = state.getCurrentPrecedingStatementContext(subExp).isPushed;
+		const wasPushed = state.getCurrentPrecedingStatementContext(subExp)
+			.isPushed;
 		const root: ts.Expression = getPropertyAccessExpressionRoot(subExp);
 		let accessStr: string;
 		let key: string;
@@ -564,7 +756,10 @@ function setKeyOfMapOrSet(kind: "map" | "set") {
 			const newKey = state.getNewId();
 			value = state.getNewId();
 
-			state.pushPrecedingStatements(subExp, state.indent + `local ${newKey}, ${value} = ${key};\n`);
+			state.pushPrecedingStatements(
+				subExp,
+				state.indent + `local ${newKey}, ${value} = ${key};\n`
+			);
 			key = newKey;
 		}
 		const expStr = `${accessPath}[${key}] = ${value || "true"}`;
@@ -575,10 +770,16 @@ function setKeyOfMapOrSet(kind: "map" | "set") {
 			const isPushed =
 				wasPushed ||
 				ts.TypeGuards.isNewExpression(root) ||
-				(ts.TypeGuards.isIdentifier(root) && isIdentifierDefinedInConst(root));
+				(ts.TypeGuards.isIdentifier(root) &&
+					isIdentifierDefinedInConst(root));
 
-			state.pushPrecedingStatements(subExp, state.indent + expStr + `;\n`);
-			state.getCurrentPrecedingStatementContext(subExp).isPushed = isPushed;
+			state.pushPrecedingStatements(
+				subExp,
+				state.indent + expStr + `;\n`
+			);
+			state.getCurrentPrecedingStatementContext(
+				subExp
+			).isPushed = isPushed;
 
 			return accessPath;
 		}
@@ -588,8 +789,15 @@ function setKeyOfMapOrSet(kind: "map" | "set") {
 }
 
 const hasKeyOfMapOrSet: ReplaceFunction = (state, params) => {
-	const [accessPath, key] = compileCallArgumentsAndSeparateAndJoinWrapped(state, params);
-	return appendDeclarationIfMissing(state, getLeftHandSideParent(params[0]), `(${accessPath}[${key}] ~= nil)`);
+	const [accessPath, key] = compileCallArgumentsAndSeparateAndJoinWrapped(
+		state,
+		params
+	);
+	return appendDeclarationIfMissing(
+		state,
+		getLeftHandSideParent(params[0]),
+		`(${accessPath}[${key}] ~= nil)`
+	);
 };
 
 const deleteKeyOfMapOrSet: ReplaceFunction = (state, params) => {
@@ -600,7 +808,10 @@ const deleteKeyOfMapOrSet: ReplaceFunction = (state, params) => {
 		return expStr;
 	} else {
 		const node = getLeftHandSideParent(subExp, 2);
-		const id = state.pushToDeclarationOrNewId(node, `${accessPath}[${key}] ~= nil`);
+		const id = state.pushToDeclarationOrNewId(
+			node,
+			`${accessPath}[${key}] ~= nil`
+		);
 		state.pushPrecedingStatements(subExp, state.indent + expStr + `;\n`);
 		state.getCurrentPrecedingStatementContext(subExp).isPushed = true;
 		return id;
@@ -615,30 +826,50 @@ const MAP_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 	[
 		"get",
 		(state, params) => {
-			const [accessPath, key] = compileCallArgumentsAndSeparateAndJoinWrapped(state, params);
-			return appendDeclarationIfMissing(state, getLeftHandSideParent(params[0]), `${accessPath}[${key}]`);
-		},
-	],
+			const [
+				accessPath,
+				key
+			] = compileCallArgumentsAndSeparateAndJoinWrapped(state, params);
+			return appendDeclarationIfMissing(
+				state,
+				getLeftHandSideParent(params[0]),
+				`${accessPath}[${key}]`
+			);
+		}
+	]
 ]);
 
 const SET_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 	["add", setKeyOfMapOrSet("set")],
 	["delete", deleteKeyOfMapOrSet],
 	["has", hasKeyOfMapOrSet],
-	["isEmpty", isMapOrSetOrArrayEmpty],
+	["isEmpty", isMapOrSetOrArrayEmpty]
 ]);
 
-const OBJECT_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>().set("isEmpty", (state, params) =>
+const OBJECT_REPLACE_METHODS: ReplaceMap = new Map<
+	string,
+	ReplaceFunction
+>().set("isEmpty", (state, params) =>
 	appendDeclarationIfMissing(
 		state,
 		getLeftHandSideParent(params[0]),
-		`(next(${compileCallArguments(state, params)[1]}) == nil)`,
-	),
+		`(next(${compileCallArguments(state, params)[1]}) == nil)`
+	)
 );
 
-const RBX_MATH_CLASSES = new Set(["CFrame", "UDim", "UDim2", "Vector2", "Vector2int16", "Vector3", "Vector3int16"]);
+const RBX_MATH_CLASSES = new Set([
+	"CFrame",
+	"UDim",
+	"UDim2",
+	"Vector2",
+	"Vector2int16",
+	"Vector3",
+	"Vector3int16"
+]);
 
-function makeGlobalExpressionMacro(compose: (arg1: string, arg2: string) => string): ReplaceFunction {
+function makeGlobalExpressionMacro(
+	compose: (arg1: string, arg2: string) => string
+): ReplaceFunction {
 	return (state, params) => {
 		const [subExp] = params;
 		let [obj, type] = compileCallArguments(state, params);
@@ -647,35 +878,65 @@ function makeGlobalExpressionMacro(compose: (arg1: string, arg2: string) => stri
 			const id = state.getNewId();
 			type = state.getNewId();
 
-			state.pushPrecedingStatements(subExp, state.indent + `local ${id}, ${type} = ${obj};\n`);
+			state.pushPrecedingStatements(
+				subExp,
+				state.indent + `local ${id}, ${type} = ${obj};\n`
+			);
 			obj = id;
 		}
 
-		const compiledStr = compose(obj, type);
+		const compiledStr = compose(
+			obj,
+			type
+		);
 
-		return appendDeclarationIfMissing(state, getLeftHandSideParent(subExp, 2), `(${compiledStr})`);
+		return appendDeclarationIfMissing(
+			state,
+			getLeftHandSideParent(subExp, 2),
+			`(${compiledStr})`
+		);
 	};
 }
 
 // This makes local testing easier
 const PRIMITIVE_LUA_TYPES = new Set(
-	["nil", "boolean", "string", "number", "table", "userdata", "function", "thread"].map(v => `"${v}"`),
+	[
+		"nil",
+		"boolean",
+		"string",
+		"number",
+		"table",
+		"userdata",
+		"function",
+		"thread"
+	].map(v => `"${v}"`)
 );
 
 const GLOBAL_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 	[
 		"typeIs",
 		makeGlobalExpressionMacro(
-			(obj, type) => `${PRIMITIVE_LUA_TYPES.has(type) ? "type" : "typeof"}(${obj}) == ${type}`,
-		),
+			(obj, type) =>
+				`${
+					PRIMITIVE_LUA_TYPES.has(type) ? "type" : "typeof"
+				}(${obj}) == ${type}`
+		)
 	],
-	["classIs", makeGlobalExpressionMacro((obj, className) => `${obj}.ClassName == ${className}`)],
+	[
+		"classIs",
+		makeGlobalExpressionMacro(
+			(obj, className) => `${obj}.ClassName == ${className}`
+		)
+	]
 ]);
 
 export function compileList(
 	state: CompilerState,
 	args: Array<ts.Expression>,
-	compile: (state: CompilerState, expression: ts.Expression) => string = compileExpression,
+	compile: (
+		state: CompilerState,
+		expression: ts.Expression
+	) => string = compileExpression
 ) {
 	const argStrs = new Array<string>();
 	let lastContextualIndex: number | undefined;
@@ -713,7 +974,10 @@ export function compileList(
 			}
 		}
 
-		state.pushPrecedingStatements(args[lastContextualIndex], ...cached[lastContextualIndex]);
+		state.pushPrecedingStatements(
+			args[lastContextualIndex],
+			...cached[lastContextualIndex]
+		);
 	}
 
 	return argStrs;
@@ -723,12 +987,22 @@ export function compileCallArguments(
 	state: CompilerState,
 	args: Array<ts.Expression>,
 	extraParameter?: string,
-	compile: (state: CompilerState, expression: ts.Expression) => string = compileExpression,
+	compile: (
+		state: CompilerState,
+		expression: ts.Expression
+	) => string = compileExpression
 ) {
 	let argStrs: Array<string>;
 
 	if (shouldCompileAsSpreadableList(args)) {
-		argStrs = [`unpack(${compileSpreadableListAndJoin(state, args, true, compile)})`];
+		argStrs = [
+			`unpack(${compileSpreadableListAndJoin(
+				state,
+				args,
+				true,
+				compile
+			)})`
+		];
 	} else {
 		argStrs = compileList(state, args, compile);
 	}
@@ -740,7 +1014,11 @@ export function compileCallArguments(
 	return argStrs;
 }
 
-export function compileCallArgumentsAndJoin(state: CompilerState, args: Array<ts.Expression>, extraParameter?: string) {
+export function compileCallArgumentsAndJoin(
+	state: CompilerState,
+	args: Array<ts.Expression>,
+	extraParameter?: string
+) {
 	return compileCallArguments(state, args, extraParameter).join(", ");
 }
 
@@ -749,7 +1027,7 @@ function checkNonImportExpression(exp: ts.LeftHandSideExpression) {
 		throw new CompilerError(
 			"Dynamic import expressions are not supported! Use 'require()' instead and assert the type.",
 			exp,
-			CompilerErrorType.NoDynamicImport,
+			CompilerErrorType.NoDynamicImport
 		);
 	}
 	return exp;
@@ -758,9 +1036,11 @@ function checkNonImportExpression(exp: ts.LeftHandSideExpression) {
 export function compileCallExpression(
 	state: CompilerState,
 	node: ts.CallExpression,
-	doNotWrapTupleReturn = !isTupleReturnTypeCall(node),
+	doNotWrapTupleReturn = !isTupleReturnTypeCall(node)
 ) {
-	const exp = skipNodesDownwards(checkNonAny(checkNonImportExpression(node.getExpression())));
+	const exp = skipNodesDownwards(
+		checkNonAny(checkNonImportExpression(node.getExpression()))
+	);
 	let result: string;
 
 	if (ts.TypeGuards.isPropertyAccessExpression(exp)) {
@@ -768,7 +1048,9 @@ export function compileCallExpression(
 	} else if (ts.TypeGuards.isElementAccessExpression(exp)) {
 		result = compileElementAccessCallExpression(state, node, exp);
 	} else {
-		const params = node.getArguments().map(arg => skipNodesDownwards(arg)) as Array<ts.Expression>;
+		const params = node
+			.getArguments()
+			.map(arg => skipNodesDownwards(arg)) as Array<ts.Expression>;
 
 		if (ts.TypeGuards.isSuperExpression(exp)) {
 			if (superExpressionClassInheritsFromArray(exp, false)) {
@@ -776,15 +1058,23 @@ export function compileCallExpression(
 					throw new CompilerError(
 						"Cannot call super() with arguments when extending from Array",
 						exp,
-						CompilerErrorType.SuperArrayCall,
+						CompilerErrorType.SuperArrayCall
 					);
 				}
 
-				return ts.TypeGuards.isExpressionStatement(skipNodesUpwards(node.getParent()!)) ? "" : "nil";
+				return ts.TypeGuards.isExpressionStatement(
+					skipNodesUpwards(node.getParent()!)
+				)
+					? ""
+					: "nil";
 			} else if (inheritsFromRoact(exp.getType())) {
 				return "";
 			} else {
-				return `super.constructor(${compileCallArgumentsAndJoin(state, params, "self")})`;
+				return `super.constructor(${compileCallArgumentsAndJoin(
+					state,
+					params,
+					"self"
+				)})`;
 			}
 		}
 
@@ -800,7 +1090,9 @@ export function compileCallExpression(
 
 		if (ts.TypeGuards.isIdentifier(exp)) {
 			for (const def of exp.getDefinitions()) {
-				const definitionParent = skipNodesUpwards(skipNodesUpwards(def.getNode()).getParent());
+				const definitionParent = skipNodesUpwards(
+					skipNodesUpwards(def.getNode()).getParent()
+				);
 
 				if (
 					definitionParent &&
@@ -808,11 +1100,14 @@ export function compileCallExpression(
 					isFunctionExpressionMethod(definitionParent)
 				) {
 					const alternative =
-						"this." + (skipNodesUpwards(definitionParent.getParent()) as ts.PropertyAssignment).getName();
+						"this." +
+						(skipNodesUpwards(
+							definitionParent.getParent()
+						) as ts.PropertyAssignment).getName();
 					throw new CompilerError(
 						`Cannot call local function expression \`${exp.getText()}\` (this is a foot-gun). Prefer \`${alternative}\``,
 						exp,
-						CompilerErrorType.BadFunctionExpressionMethodCall,
+						CompilerErrorType.BadFunctionExpressionMethodCall
 					);
 				}
 			}
@@ -841,7 +1136,7 @@ function compilePropertyMethod(
 	property: string,
 	params: Array<ts.Expression>,
 	className: string,
-	replaceMethods: ReplaceMap,
+	replaceMethods: ReplaceMap
 ) {
 	const isSubstitutableMethod = replaceMethods.get(property);
 
@@ -856,7 +1151,10 @@ function compilePropertyMethod(
 		params = params.slice(1);
 	}
 	state.usesTSLibrary = true;
-	return `TS.${className}_${property}(${compileCallArgumentsAndJoin(state, params)})`;
+	return `TS.${className}_${property}(${compileCallArgumentsAndJoin(
+		state,
+		params
+	)})`;
 }
 
 export const enum PropertyCallExpType {
@@ -872,12 +1170,12 @@ export const enum PropertyCallExpType {
 	RbxMathAdd,
 	RbxMathSub,
 	RbxMathMul,
-	RbxMathDiv,
+	RbxMathDiv
 }
 
 export function getPropertyAccessExpressionType(
 	state: CompilerState,
-	expression: ts.PropertyAccessExpression,
+	expression: ts.PropertyAccessExpression
 ): PropertyCallExpType {
 	checkApiAccess(state, expression.getNameNode());
 
@@ -952,7 +1250,7 @@ function getSymbolOrThrow(node: ts.Node, t: ts.Type) {
 		throw new CompilerError(
 			`Attempt to call non-method \`${node.getText()}\``,
 			node,
-			CompilerErrorType.BadMethodCall,
+			CompilerErrorType.BadMethodCall
 		);
 	}
 	return symbol;
@@ -968,7 +1266,10 @@ export function isDefinedAsMethod(node: ts.Node): boolean | undefined {
 
 		// we just use the laxTypeConstraint for easy iteration
 		laxTypeConstraint(type, t => {
-			for (const declaration of getSymbolOrThrow(node, t).getDeclarations()) {
+			for (const declaration of getSymbolOrThrow(
+				node,
+				t
+			).getDeclarations()) {
 				if (isMethodDeclaration(declaration)) {
 					hasMethodDefinition = true;
 				} else {
@@ -982,7 +1283,7 @@ export function isDefinedAsMethod(node: ts.Node): boolean | undefined {
 			throw new CompilerError(
 				"Attempted to define or call a function with mixed types! All definitions must either be a method or a callback.",
 				node,
-				CompilerErrorType.MixedMethodCall,
+				CompilerErrorType.MixedMethodCall
 			);
 		}
 
@@ -995,17 +1296,21 @@ export function isDefinedAsMethod(node: ts.Node): boolean | undefined {
 export function compileElementAccessCallExpression(
 	state: CompilerState,
 	node: ts.CallExpression,
-	expression: ts.ElementAccessExpression,
+	expression: ts.ElementAccessExpression
 ) {
 	const expExp = skipNodesDownwards(expression.getExpression());
-	const accessor = ts.TypeGuards.isSuperExpression(expExp) ? "super" : getReadableExpressionName(state, expExp);
+	const accessor = ts.TypeGuards.isSuperExpression(expExp)
+		? "super"
+		: getReadableExpressionName(state, expExp);
 
 	const accessedPath = compileElementAccessDataTypeExpression(
 		state,
 		expression,
-		accessor,
+		accessor
 	)(compileElementAccessBracketExpression(state, expression));
-	const params = node.getArguments().map(arg => skipNodesDownwards(arg)) as Array<ts.Expression>;
+	const params = node
+		.getArguments()
+		.map(arg => skipNodesDownwards(arg)) as Array<ts.Expression>;
 	const isMethod = isDefinedAsMethod(expression)!;
 
 	let paramsStr = compileCallArgumentsAndJoin(state, params);
@@ -1015,9 +1320,11 @@ export function compileElementAccessCallExpression(
 	} else {
 		if (ts.TypeGuards.isSuperExpression(expExp)) {
 			throw new CompilerError(
-				`\`${accessedPath}\` is not a real method! Prefer \`this${accessedPath.slice(5)}\` instead.`,
+				`\`${accessedPath}\` is not a real method! Prefer \`this${accessedPath.slice(
+					5
+				)}\` instead.`,
 				expExp,
-				CompilerErrorType.BadSuperCall,
+				CompilerErrorType.BadSuperCall
 			);
 		}
 	}
@@ -1028,42 +1335,85 @@ export function compileElementAccessCallExpression(
 export function compilePropertyCallExpression(
 	state: CompilerState,
 	node: ts.CallExpression,
-	expression: ts.PropertyAccessExpression,
+	expression: ts.PropertyAccessExpression
 ) {
 	checkApiAccess(state, expression.getNameNode());
 
 	let property = expression.getName();
 	const params = [
 		skipNodesDownwards(expression.getExpression()),
-		...node.getArguments().map(arg => skipNodesDownwards(arg)),
+		...node.getArguments().map(arg => skipNodesDownwards(arg))
 	] as Array<ts.Expression>;
 
 	switch (getPropertyAccessExpressionType(state, expression)) {
 		case PropertyCallExpType.Array: {
-			return compilePropertyMethod(state, property, params, "array", ARRAY_REPLACE_METHODS);
+			return compilePropertyMethod(
+				state,
+				property,
+				params,
+				"array",
+				ARRAY_REPLACE_METHODS
+			);
 		}
 		case PropertyCallExpType.String: {
-			return compilePropertyMethod(state, property, params, "string", STRING_REPLACE_METHODS);
+			return compilePropertyMethod(
+				state,
+				property,
+				params,
+				"string",
+				STRING_REPLACE_METHODS
+			);
 		}
 		case PropertyCallExpType.Map: {
-			return compilePropertyMethod(state, property, params, "map", MAP_REPLACE_METHODS);
+			return compilePropertyMethod(
+				state,
+				property,
+				params,
+				"map",
+				MAP_REPLACE_METHODS
+			);
 		}
 		case PropertyCallExpType.Set: {
-			return compilePropertyMethod(state, property, params, "set", SET_REPLACE_METHODS);
+			return compilePropertyMethod(
+				state,
+				property,
+				params,
+				"set",
+				SET_REPLACE_METHODS
+			);
 		}
 		case PropertyCallExpType.ObjectConstructor: {
-			return compilePropertyMethod(state, property, params, "Object", OBJECT_REPLACE_METHODS);
+			return compilePropertyMethod(
+				state,
+				property,
+				params,
+				"Object",
+				OBJECT_REPLACE_METHODS
+			);
 		}
 		case PropertyCallExpType.BuiltInStringMethod: {
-			const [accessPath, compiledArgs] = compileCallArgumentsAndSeparateAndJoinWrapped(state, params, true);
+			const [
+				accessPath,
+				compiledArgs
+			] = compileCallArgumentsAndSeparateAndJoinWrapped(
+				state,
+				params,
+				true
+			);
 			return `${accessPath}:${property}(${compiledArgs})`;
 		}
 		case PropertyCallExpType.PromiseThen: {
-			const [accessPath, compiledArgs] = compileCallArgumentsAndSeparateAndJoin(state, params);
+			const [
+				accessPath,
+				compiledArgs
+			] = compileCallArgumentsAndSeparateAndJoin(state, params);
 			return `${accessPath}:andThen(${compiledArgs})`;
 		}
 		case PropertyCallExpType.SymbolFor: {
-			const [accessPath, compiledArgs] = compileCallArgumentsAndSeparateAndJoin(state, params);
+			const [
+				accessPath,
+				compiledArgs
+			] = compileCallArgumentsAndSeparateAndJoin(state, params);
 			return `${accessPath}.getFor(${compiledArgs})`;
 		}
 		case PropertyCallExpType.RbxMathAdd: {
@@ -1071,7 +1421,7 @@ export function compilePropertyCallExpression(
 			return appendDeclarationIfMissing(
 				state,
 				skipNodesUpwards(node.getParent()!),
-				`(${argStrs[0]} + (${argStrs[1]}))`,
+				`(${argStrs[0]} + (${argStrs[1]}))`
 			);
 		}
 		case PropertyCallExpType.RbxMathSub: {
@@ -1079,7 +1429,7 @@ export function compilePropertyCallExpression(
 			return appendDeclarationIfMissing(
 				state,
 				skipNodesUpwards(node.getParent()!),
-				`(${argStrs[0]} - (${argStrs[1]}))`,
+				`(${argStrs[0]} - (${argStrs[1]}))`
 			);
 		}
 		case PropertyCallExpType.RbxMathMul: {
@@ -1087,7 +1437,7 @@ export function compilePropertyCallExpression(
 			return appendDeclarationIfMissing(
 				state,
 				skipNodesUpwards(node.getParent()!),
-				`(${argStrs[0]} * (${argStrs[1]}))`,
+				`(${argStrs[0]} * (${argStrs[1]}))`
 			);
 		}
 		case PropertyCallExpType.RbxMathDiv: {
@@ -1095,7 +1445,7 @@ export function compilePropertyCallExpression(
 			return appendDeclarationIfMissing(
 				state,
 				skipNodesUpwards(node.getParent()!),
-				`(${argStrs[0]} / (${argStrs[1]}))`,
+				`(${argStrs[0]} / (${argStrs[1]}))`
 			);
 		}
 	}
@@ -1104,7 +1454,10 @@ export function compilePropertyCallExpression(
 
 	let accessedPath: string;
 	let paramsStr: string;
-	[accessedPath, paramsStr] = compileCallArgumentsAndSeparateAndJoin(state, params);
+	[accessedPath, paramsStr] = compileCallArgumentsAndSeparateAndJoin(
+		state,
+		params
+	);
 	let sep: ":" | ".";
 	const [subExp] = params;
 
@@ -1123,7 +1476,7 @@ export function compilePropertyCallExpression(
 			throw new CompilerError(
 				`\`super.${property}\` is not a real method! Prefer \`this.${property}\` instead.`,
 				subExp,
-				CompilerErrorType.BadSuperCall,
+				CompilerErrorType.BadSuperCall
 			);
 		}
 	}
@@ -1136,10 +1489,15 @@ export function compilePropertyCallExpression(
 	} else {
 		if (sep === ":") {
 			if (!isValidLuaIdentifier(accessedPath)) {
-				accessedPath = state.pushPrecedingStatementToNewId(params[0], accessedPath);
+				accessedPath = state.pushPrecedingStatementToNewId(
+					params[0],
+					accessedPath
+				);
 			}
 
-			paramsStr = paramsStr ? accessedPath + ", " + paramsStr : accessedPath;
+			paramsStr = paramsStr
+				? accessedPath + ", " + paramsStr
+				: accessedPath;
 			property = `["${property}"]`;
 		} else {
 			if (shouldWrapExpression(subExp, false)) {

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -327,11 +327,9 @@ const STRING_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 		(state, params) => {
 			const [accessPath, matchParam, fromIndex] = compileCallArguments(state, params);
 
-			if (fromIndex !== undefined) {
-				return `(string.find(${accessPath}, ${matchParam}, ${addOneToArrayIndex(fromIndex)}, true) or 0) - 1`;
-			} else {
-				return `(string.find(${accessPath}, ${matchParam}, 1, true) or 0) - 1`;
-			}
+			return `((string.find(${accessPath}, ${matchParam}, ${addOneToArrayIndex(
+				fromIndex ?? "0",
+			)}, true) or 0) - 1)`;
 		},
 	],
 
@@ -340,11 +338,7 @@ const STRING_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 		(state, params) => {
 			const [accessPath, matchParam, fromIndex] = compileCallArguments(state, params);
 
-			if (fromIndex !== undefined) {
-				return `(string.find(${accessPath}, ${matchParam}, ${addOneToArrayIndex(fromIndex)}, true) ~= nil)`;
-			} else {
-				return `(string.find(${accessPath}, ${matchParam}, 1, true) ~= nil)`;
-			}
+			return `(string.find(${accessPath}, ${matchParam}, ${addOneToArrayIndex(fromIndex ?? "0")}, true) ~= nil)`;
 		},
 	],
 ]);

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -548,6 +548,19 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 		},
 	],
 
+	[
+		"includes",
+		(state, params) => {
+			const [accessPath, indexParamStr, fromIndex] = compileCallArguments(state, params);
+
+			if (fromIndex !== undefined) {
+				return `(not not table.find(${accessPath}, ${indexParamStr}, ${addOneToArrayIndex(fromIndex)}))`;
+			} else {
+				return `(not not table.find(${accessPath}, ${indexParamStr}))`;
+			}
+		},
+	],
+
 	["isEmpty", isMapOrSetOrArrayEmpty],
 ]);
 

--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -321,6 +321,32 @@ const STRING_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			return appendDeclarationIfMissing(state, getLeftHandSideParent(params[0]), [b, a].join(" .. "));
 		},
 	],
+
+	[
+		"indexOf",
+		(state, params) => {
+			const [accessPath, matchParam, fromIndex] = compileCallArguments(state, params);
+
+			if (fromIndex !== undefined) {
+				return `(string.find(${accessPath}, ${matchParam}, ${addOneToArrayIndex(fromIndex)}, true) or 0) - 1`;
+			} else {
+				return `(string.find(${accessPath}, ${matchParam}, 1, true) or 0) - 1`;
+			}
+		},
+	],
+
+	[
+		"includes",
+		(state, params) => {
+			const [accessPath, matchParam, fromIndex] = compileCallArguments(state, params);
+
+			if (fromIndex !== undefined) {
+				return `(string.find(${accessPath}, ${matchParam}, ${addOneToArrayIndex(fromIndex)}, true) ~= nil)`;
+			} else {
+				return `(string.find(${accessPath}, ${matchParam}, 1, true) ~= nil)`;
+			}
+		},
+	],
 ]);
 
 STRING_REPLACE_METHODS.set("trimStart", STRING_REPLACE_METHODS.get("trimLeft")!);
@@ -554,9 +580,9 @@ const ARRAY_REPLACE_METHODS: ReplaceMap = new Map<string, ReplaceFunction>([
 			const [accessPath, indexParamStr, fromIndex] = compileCallArguments(state, params);
 
 			if (fromIndex !== undefined) {
-				return `(not not table.find(${accessPath}, ${indexParamStr}, ${addOneToArrayIndex(fromIndex)}))`;
+				return `(table.find(${accessPath}, ${indexParamStr}, ${addOneToArrayIndex(fromIndex)}) ~= nil)`;
 			} else {
-				return `(not not table.find(${accessPath}, ${indexParamStr}))`;
+				return `(table.find(${accessPath}, ${indexParamStr}) ~= nil)`;
 			}
 		},
 	],

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -227,13 +227,9 @@ export function compileNewExpression(
 				result
 			);
 		} else if (args.length === 2) {
-			const [length, value] = args;
-			result =
-				"table.create(" +
-				compileExpression(state, length) +
-				", " +
-				compileExpression(state, value) +
-				")";
+			const [length, value] = compileCallArguments(state, args);
+
+			result = "table.create(" + length + ", " + value + ")";
 			return appendDeclarationIfMissing(
 				state,
 				skipNodesUpwards(node.getParent()),

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -157,8 +157,6 @@ function compileSetMapConstructorHelper(
 	}
 }
 
-const ARRAY_NIL_LIMIT = 10;
-
 export function compileNewExpression(state: CompilerState, node: ts.NewExpression) {
 	const expNode = skipNodesDownwards(node.getExpression());
 	const expressionType = getType(expNode);

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -5,11 +5,15 @@ import {
 	compileCallArgumentsAndJoin,
 	compileExpression,
 	getReadableExpressionName,
-	inheritsFromRoact,
+	inheritsFromRoact
 } from ".";
 import { CompilerState, DeclarationContext } from "../CompilerState";
 import { CompilerError, CompilerErrorType } from "../errors/CompilerError";
-import { joinIndentedLines, skipNodesDownwards, skipNodesUpwards } from "../utility/general";
+import {
+	joinIndentedLines,
+	skipNodesDownwards,
+	skipNodesUpwards
+} from "../utility/general";
 import { suggest } from "../utility/text";
 import { getType, inheritsFrom, isTupleType } from "../utility/type";
 
@@ -17,20 +21,27 @@ function compileMapElement(state: CompilerState, element: ts.Expression) {
 	if (ts.TypeGuards.isArrayLiteralExpression(element)) {
 		const [key, value] = compileCallArguments(
 			state,
-			element.getElements().map(e => skipNodesDownwards(e)),
+			element.getElements().map(e => skipNodesDownwards(e))
 		);
 		return `[${key}] = ${value};\n`;
-	} else if (ts.TypeGuards.isCallExpression(element) && isTupleType(element.getReturnType())) {
+	} else if (
+		ts.TypeGuards.isCallExpression(element) &&
+		isTupleType(element.getReturnType())
+	) {
 		const key = state.getNewId();
 		const value = state.getNewId();
 		state.pushPrecedingStatementToNewId(
 			element,
 			compileExpression(state, element).slice(2, -2),
-			`${key}, ${value}`,
+			`${key}, ${value}`
 		);
 		return `[${key}] = ${value};\n`;
 	} else {
-		const id = getReadableExpressionName(state, element, compileExpression(state, element));
+		const id = getReadableExpressionName(
+			state,
+			element,
+			compileExpression(state, element)
+		);
 		return `[${id}[1]] = ${id}[2];\n`;
 	}
 }
@@ -42,10 +53,13 @@ function compileSetElement(state: CompilerState, element: ts.Expression) {
 
 const compileMapSetElement = new Map<
 	"set" | "map",
-	{ addMethodName: string; compile: (state: CompilerState, element: ts.Expression) => string }
+	{
+		addMethodName: string;
+		compile: (state: CompilerState, element: ts.Expression) => string;
+	}
 >([
 	["map", { compile: compileMapElement, addMethodName: "set" }],
-	["set", { compile: compileSetElement, addMethodName: "add" }],
+	["set", { compile: compileSetElement, addMethodName: "add" }]
 ]);
 
 function compileSetMapConstructorHelper(
@@ -53,7 +67,7 @@ function compileSetMapConstructorHelper(
 	node: ts.NewExpression,
 	args: Array<ts.Expression>,
 	type: "set" | "map",
-	mode: "" | "k" | "v" | "kv" = "",
+	mode: "" | "k" | "v" | "kv" = ""
 ) {
 	const preDeclaration = mode ? "setmetatable(" : "";
 	const postDeclaration = mode ? `, { __mode = "${mode}" })` : "";
@@ -64,7 +78,7 @@ function compileSetMapConstructorHelper(
 		throw new CompilerError(
 			`Cannot create a ${type} with a nullable index!`,
 			node,
-			CompilerErrorType.NullableIndexOnMapOrSet,
+			CompilerErrorType.NullableIndexOnMapOrSet
 		);
 	}
 
@@ -72,9 +86,15 @@ function compileSetMapConstructorHelper(
 
 	let exp: ts.Node = node;
 	let parent = skipNodesUpwards(node.getParent());
-	const { compile: compileElement, addMethodName: addMethodName } = compileMapSetElement.get(type)!;
+	const {
+		compile: compileElement,
+		addMethodName: addMethodName
+	} = compileMapSetElement.get(type)!;
 
-	while (ts.TypeGuards.isPropertyAccessExpression(parent) && addMethodName === parent.getName()) {
+	while (
+		ts.TypeGuards.isPropertyAccessExpression(parent) &&
+		addMethodName === parent.getName()
+	) {
 		const grandparent = skipNodesUpwards(parent.getParent()!);
 		if (ts.TypeGuards.isCallExpression(grandparent)) {
 			exp = grandparent;
@@ -91,13 +111,16 @@ function compileSetMapConstructorHelper(
 	if (
 		firstParam &&
 		(!ts.TypeGuards.isArrayLiteralExpression(firstParam) ||
-			firstParam.getChildrenOfKind(ts.SyntaxKind.SpreadElement).length > 0)
+			firstParam.getChildrenOfKind(ts.SyntaxKind.SpreadElement).length >
+				0)
 	) {
 		state.usesTSLibrary = true;
 		const id = state.pushToDeclarationOrNewId(
 			exp,
-			preDeclaration + `TS.${type}_new(${compileCallArgumentsAndJoin(state, args)})` + postDeclaration,
-			pushCondition,
+			preDeclaration +
+				`TS.${type}_new(${compileCallArgumentsAndJoin(state, args)})` +
+				postDeclaration,
+			pushCondition
 		);
 		return id;
 	} else {
@@ -109,7 +132,10 @@ function compileSetMapConstructorHelper(
 			for (let element of firstParam.getElements()) {
 				element = skipNodesDownwards(element);
 				if (hasContext) {
-					state.pushPrecedingStatements(exp, id + compileElement(state, element));
+					state.pushPrecedingStatements(
+						exp,
+						id + compileElement(state, element)
+					);
 				} else {
 					state.enterPrecedingStatementContext();
 					const line = compileElement(state, element);
@@ -120,13 +146,15 @@ function compileSetMapConstructorHelper(
 						id = state.pushToDeclarationOrNewId(
 							exp,
 							preDeclaration + "{}" + postDeclaration,
-							declaration => declaration.isIdentifier,
+							declaration => declaration.isIdentifier
 						);
 						state.pushPrecedingStatements(
 							exp,
-							...lines.map(current => state.indent + id + current),
+							...lines.map(
+								current => state.indent + id + current
+							),
 							...context,
-							state.indent + id + line,
+							state.indent + id + line
 						);
 					} else {
 						lines.push(line);
@@ -142,14 +170,17 @@ function compileSetMapConstructorHelper(
 					? preDeclaration + "{}" + postDeclaration
 					: preDeclaration +
 							lines.reduce(
-								(result, line) => result + state.indent + joinIndentedLines([line], 1),
-								"{\n",
+								(result, line) =>
+									result +
+									state.indent +
+									joinIndentedLines([line], 1),
+								"{\n"
 							) +
 							state.indent +
 							"}" +
 							postDeclaration,
 
-				pushCondition,
+				pushCondition
 			);
 		}
 
@@ -157,20 +188,27 @@ function compileSetMapConstructorHelper(
 	}
 }
 
-export function compileNewExpression(state: CompilerState, node: ts.NewExpression) {
+export function compileNewExpression(
+	state: CompilerState,
+	node: ts.NewExpression
+) {
 	const expNode = skipNodesDownwards(node.getExpression());
 	const expressionType = getType(expNode);
 	const name = compileExpression(state, expNode);
 	const args = node.getFirstChildByKind(ts.SyntaxKind.OpenParenToken)
-		? (node.getArguments().map(arg => skipNodesDownwards(arg)) as Array<ts.Expression>)
+		? (node.getArguments().map(arg => skipNodesDownwards(arg)) as Array<
+				ts.Expression
+		  >)
 		: [];
 
 	if (inheritsFromRoact(expressionType)) {
 		throw new CompilerError(
 			`Roact components cannot be created using new\n` +
-				suggest(`Proper usage: Roact.createElement(${name}), <${name}></${name}> or <${name}/>`),
+				suggest(
+					`Proper usage: Roact.createElement(${name}), <${name}></${name}> or <${name}/>`
+				),
 			node,
-			CompilerErrorType.RoactNoNewComponentAllowed,
+			CompilerErrorType.RoactNoNewComponentAllowed
 		);
 	}
 
@@ -183,31 +221,58 @@ export function compileNewExpression(state: CompilerState, node: ts.NewExpressio
 		if (args.length === 1) {
 			const arg = args[0];
 			result = "table.create(" + compileExpression(state, arg) + ")";
-			return appendDeclarationIfMissing(state, skipNodesUpwards(node.getParent()), result);
+			return appendDeclarationIfMissing(
+				state,
+				skipNodesUpwards(node.getParent()),
+				result
+			);
+		} else if (args.length === 2) {
+			const [length, value] = args;
+			result =
+				"table.create(" +
+				compileExpression(state, length) +
+				", " +
+				compileExpression(state, value) +
+				")";
+			return appendDeclarationIfMissing(
+				state,
+				skipNodesUpwards(node.getParent()),
+				result
+			);
 		} else if (args.length !== 0) {
 			throw new CompilerError(
 				"Invalid arguments passed into ArrayConstructor!",
 				node,
-				CompilerErrorType.BadBuiltinConstructorCall,
+				CompilerErrorType.BadBuiltinConstructorCall
 			);
 		}
 
-		return appendDeclarationIfMissing(state, skipNodesUpwards(node.getParent()), result + `}`);
-	}
-
-	if (inheritsFrom(expressionType, "MapConstructor") || inheritsFrom(expressionType, "ReadonlyMapConstructor")) {
 		return appendDeclarationIfMissing(
 			state,
 			skipNodesUpwards(node.getParent()),
-			compileSetMapConstructorHelper(state, node, args, "map"),
+			result + `}`
 		);
 	}
 
-	if (inheritsFrom(expressionType, "SetConstructor") || inheritsFrom(expressionType, "ReadonlySetConstructor")) {
+	if (
+		inheritsFrom(expressionType, "MapConstructor") ||
+		inheritsFrom(expressionType, "ReadonlyMapConstructor")
+	) {
 		return appendDeclarationIfMissing(
 			state,
 			skipNodesUpwards(node.getParent()),
-			compileSetMapConstructorHelper(state, node, args, "set"),
+			compileSetMapConstructorHelper(state, node, args, "map")
+		);
+	}
+
+	if (
+		inheritsFrom(expressionType, "SetConstructor") ||
+		inheritsFrom(expressionType, "ReadonlySetConstructor")
+	) {
+		return appendDeclarationIfMissing(
+			state,
+			skipNodesUpwards(node.getParent()),
+			compileSetMapConstructorHelper(state, node, args, "set")
 		);
 	}
 
@@ -215,7 +280,7 @@ export function compileNewExpression(state: CompilerState, node: ts.NewExpressio
 		return appendDeclarationIfMissing(
 			state,
 			skipNodesUpwards(node.getParent()),
-			compileSetMapConstructorHelper(state, node, args, "map", "k"),
+			compileSetMapConstructorHelper(state, node, args, "map", "k")
 		);
 	}
 
@@ -223,7 +288,7 @@ export function compileNewExpression(state: CompilerState, node: ts.NewExpressio
 		return appendDeclarationIfMissing(
 			state,
 			skipNodesUpwards(node.getParent()),
-			compileSetMapConstructorHelper(state, node, args, "set", "k"),
+			compileSetMapConstructorHelper(state, node, args, "set", "k")
 		);
 	}
 

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -184,8 +184,8 @@ export function compileNewExpression(state: CompilerState, node: ts.NewExpressio
 
 		let result = `{`;
 		if (args.length === 1) {
-			const arg = args[0];
-			result = "table.create(" + compileExpression(state, arg) + ")";
+			const [length] = compileCallArguments(state, args);
+			result = "table.create(" + length + ")";
 			return appendDeclarationIfMissing(state, skipNodesUpwards(node.getParent()), result);
 		} else if (args.length === 2) {
 			const [length, value] = compileCallArguments(state, args);

--- a/src/compiler/new.ts
+++ b/src/compiler/new.ts
@@ -178,29 +178,11 @@ export function compileNewExpression(state: CompilerState, node: ts.NewExpressio
 	}
 
 	if (inheritsFrom(expressionType, "ArrayConstructor")) {
-		if (args.length === 0) {
-			return "{}";
-		}
-
-		let result = `{`;
-		if (args.length === 1) {
-			const [length] = compileCallArguments(state, args);
-			result = "table.create(" + length + ")";
-			return appendDeclarationIfMissing(state, skipNodesUpwards(node.getParent()), result);
-		} else if (args.length === 2) {
-			const [length, value] = compileCallArguments(state, args);
-
-			result = "table.create(" + length + ", " + value + ")";
-			return appendDeclarationIfMissing(state, skipNodesUpwards(node.getParent()), result);
-		} else if (args.length !== 0) {
-			throw new CompilerError(
-				"Invalid arguments passed into ArrayConstructor!",
-				node,
-				CompilerErrorType.BadBuiltinConstructorCall,
-			);
-		}
-
-		return appendDeclarationIfMissing(state, skipNodesUpwards(node.getParent()), result + `}`);
+		return appendDeclarationIfMissing(
+			state,
+			skipNodesUpwards(node.getParent()),
+			args.length === 0 ? "{}" : `table.create(${compileCallArgumentsAndJoin(state, args)})`,
+		);
 	}
 
 	if (inheritsFrom(expressionType, "MapConstructor") || inheritsFrom(expressionType, "ReadonlyMapConstructor")) {

--- a/tests/spec.lua
+++ b/tests/spec.lua
@@ -33,8 +33,7 @@ end
 
 -- pollyfill for table.find - lemur doesn't support this just yet
 function table.find(t, value, init)
-	init = init or 1
-	for i = init, #t do
+	for i = init or 1, #t do
 		if t[i] == value then
 			return i
 		end

--- a/tests/spec.lua
+++ b/tests/spec.lua
@@ -26,7 +26,7 @@ end
 function table.create(size, value)
 	local t = {}
 	for i = 1, size do
-		t[i] = value or nil
+		t[i] = value
 	end
 	return t
 end

--- a/tests/spec.lua
+++ b/tests/spec.lua
@@ -22,6 +22,27 @@ local function newFolder(name, parent, content)
 	return folder
 end
 
+-- polyfill for table.create - lemur doesn't support this yet.
+function table.create(size, value)
+	local t = {}
+	for i = 1, size do
+		t[i] = value or nil
+	end
+	return t
+end
+
+-- pollyfill for table.find - lemur doesn't support this just yet
+function table.find(t, value, init)
+	init = init or 1
+	for i = init, #t do
+		if t[i] == value then
+			return i
+		end
+	end
+
+	return nil
+end
+
 -- Roblox TS Stuff
 local robloxTsFolder = newFolder("include", ReplicatedStorage, "lib")
 
@@ -29,7 +50,7 @@ local robloxTsFolder = newFolder("include", ReplicatedStorage, "lib")
 local modulesFolder = newFolder("node_modules", robloxTsFolder)
 
 -- Roact
-newFolder("roact", modulesFolder, "tests/node_modules/@rbxts/roact");
+newFolder("roact", modulesFolder, "tests/node_modules/@rbxts/roact")
 
 -- TestEZ
 local testEZFolder = newFolder("TestEZ", ReplicatedStorage, "vendor/testez/lib")
@@ -41,7 +62,7 @@ local outFolder = newFolder("out", testsFolder, "tests/out")
 -- Load TestEZ and run our tests
 local TestEZ = habitat:require(testEZFolder)
 
-local results = TestEZ.TestBootstrap:run({ outFolder }, TestEZ.Reporters.TextReporter)
+local results = TestEZ.TestBootstrap:run({outFolder}, TestEZ.Reporters.TextReporter)
 
 -- Did something go wrong?
 if #results.errors > 0 or results.failureCount > 0 then


### PR DESCRIPTION
Changes
=======
## Array constructor
Now using `table.create` as it functionally does the exact same thing. Also added the second argument (value) of table.create to the array constructor.

Removes the limitation of only being able to use integer literals as an argument to the array constructor.

## Array indexOf, includes
Now uses `table.find`.

## String indexOf, includes
Now added.
Fixes #598
