### PR TITLE
Update Object.deepCopy to not crash on recursive objects

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -232,16 +232,27 @@ local function copy(object)
 	return result
 end
 
-local function deepCopy(object)
+local function deepCopyHelper(object, encountered)
 	local result = {}
+	encountered[object] = result
+
 	for k, v in pairs(object) do
-		if type(v) == "table" then
-			result[k] = deepCopy(v)
-		else
-			result[k] = v
+		if type(k) == "table" then
+			k = encountered[k] or deepCopyHelper(k, encountered)
 		end
+
+		if type(v) == "table" then
+			v = encountered[v] or deepCopyHelper(v, encountered)
+		end
+
+		result[k] = v
 	end
+
 	return result
+end
+
+local function deepCopy(object)
+	return deepCopyHelper(object, {})
 end
 
 local function deepEquals(a, b)


### PR DESCRIPTION
Use cases:
  - Sometimes circular references are necessary, for example, `parent` -> `child` -> `parent` situations

Fixes:
  - Make it so recursive objects can be properly cloned

Changes:
  - Allows keys of type "table" to get deepCopied as well.
    - Bad practice, but imo anything returned by deepCopy should always be completely divorced from the original object tree

Question: Should we handle metatables, and if so, how? We could optionally add something like this:
```lua
local mt = getmetatable(object)

if type(mt) == "table" then
	setmetatable(result, mt)
end
```