### PR TITLE
Improve Generators

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -196,6 +196,26 @@ function TS.async(callback)
 	end
 end
 
+function TS.generator(c)
+	c = coroutine.create(c)
+
+	local o = {
+		next = function(...)
+			if coroutine.status(c) == "dead" then
+				return { done = true }
+			else
+				local success, value = coroutine.resume(c, ...)
+				if success == false then error(value, 2) end
+				return { value = value, done = coroutine.status(c) == "dead" }
+			end
+		end
+	}
+
+	o[TS.Symbol_iterator] = function() return o end
+
+	return o
+end
+
 local function package(...)
 	return select("#", ...), {...}
 end

--- a/src/compiler/function.ts
+++ b/src/compiler/function.ts
@@ -212,16 +212,10 @@ function compileFunction(
 		isGeneratorType(node.getReturnType());
 		results.push("\n");
 		state.pushIndent();
-		results.push(state.indent, `return {\n`);
-		state.pushIndent();
+		results.push(state.indent, `return TS.generator(function()`);
 		state.usesTSLibrary = true;
-		results.push(state.indent, `[TS.Symbol_iterator] = function(self) return self; end;\n`);
-		results.push(state.indent, `next = coroutine.wrap(function()`);
 		results.push(compileFunctionBody(state, body, node, initializers));
-		results.push(`\twhile true do coroutine.yield({ done = true }) end;\n`);
-		results.push(state.indent, `end);\n`);
-		state.popIndent();
-		results.push(state.indent, `};\n`);
+		results.push(`end);\n`);
 		state.popIndent();
 		results.push(state.indent);
 	} else {

--- a/src/compiler/yield.ts
+++ b/src/compiler/yield.ts
@@ -25,15 +25,6 @@ export function compileYieldExpression(state: CompilerState, node: ts.YieldExpre
 		state.popIdStack();
 		return result;
 	} else {
-		state.enterPrecedingStatementContext();
-		const value = exp ? compileExpression(state, exp) : "nil";
-		let result = state.exitPrecedingStatementContextAndJoin();
-		result += state.indent + `coroutine.yield({\n`;
-		state.pushIndent();
-		result += state.indent + `value = ${value};\n`;
-		result += state.indent + `done = false;\n`;
-		state.popIndent();
-		result += state.indent + `})`;
-		return result;
+		return `coroutine.yield(${exp ? compileExpression(state, exp) : ""})`;
 	}
 }

--- a/src/compiler/yield.ts
+++ b/src/compiler/yield.ts
@@ -18,8 +18,8 @@ export function compileYieldExpression(state: CompilerState, node: ts.YieldExpre
 		const id = state.getNewId();
 		let result = `for ${id} in ${compileExpression(state, exp!)}.next do\n`;
 		state.pushIndent();
-		result += state.indent + `if ${id}.done then break end;\n`;
-		result += state.indent + `coroutine.yield(${id});\n`;
+		result += state.indent + `if ${id}.done then break; end;\n`;
+		result += state.indent + `coroutine.yield(${id}.value);\n`;
 		state.popIndent();
 		result += state.indent + `end`;
 		state.popIdStack();


### PR DESCRIPTION
- Move Generator logic into `TS.generator` function
    - This should make declaring Generators shorter, and should also allow full support of returning from generators :)
- Make yield a simple coroutine.yield call.

Fixes https://github.com/roblox-ts/roblox-ts/issues/556