### PR TITLE
Change build from "prepublishOnly" to "prepare"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"test": "npm run build && npm run test-compile && npm run test-run",
 		"ci": "npm run build && npm run test-compile-ci && npm run test-run",
 		"coverage": "nyc report --reporter=lcov",
-		"prepublishOnly": "npm run build",
+		"prepare": "npm run build",
 		"types": "cd tests && npm install @rbxts/types",
 		"devlink": "cd devlink && npm link"
 	},


### PR DESCRIPTION
This is good practice, [as stated by NPM](https://docs.npmjs.com/misc/scripts). Currently, if using roblox-ts from the github repo 
{"roblox-ts": "git://github.com/roblox-ts/roblox-ts.git#master"}
then the `out` directory will not exist, and the install will fail.
To fix this, `prepare` will run tsc when installing the library from github.
Another solution would be to keep the `out` directory on github.