### PR TITLE
Do not overwrite symbolic links

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -540,6 +540,9 @@ export class Project {
 			overwrite: true,
 			filter: src => {
 				const ext = path.extname(src);
+				if (fs.lstatSync(src).isSymbolicLink()) {
+					return false;
+				}
 				if (ext === TS_EXT) {
 					const basename = path.basename(src, ext);
 					const subext = path.extname(basename);


### PR DESCRIPTION
This change just adds an extra check to `Project.copyFiles()` so that symbolic links are explicitly **NOT** overwritten.

## Motivation

When copying files after compiling, roblox-ts will overwrite everything. This is usually not a problem. However, when crossing on symlinks, the situation becomes complicated:

![image](https://user-images.githubusercontent.com/45321798/73978402-29f82500-4924-11ea-879c-8f61720281ee.png)

```
Starting initial compile..
[Error: EPERM: operation not permitted, symlink 'C:\Users\davness\Documents\Git\roblox-ts-skeleton\Places\global\src' -> 'C:\Users\davness\Documents\Git\roblox-ts-skeleton\Places\test1\lua\global'] {
  errno: -4048,
  code: 'EPERM',
  syscall: 'symlink',
  path: 'C:\\Users\\davness\\Documents\\Git\\roblox-ts-skeleton\\Places\\global\\src',
  dest: 'C:\\Users\\davness\\Documents\\Git\\roblox-ts-skeleton\\Places\\test1\\lua\\global'
}
```

If we run the command again:

![image](https://user-images.githubusercontent.com/45321798/73978574-89563500-4924-11ea-919c-a4ada4a7fca5.png)

```
Running in watch mode..
Starting initial compile..
[Error: EEXIST: file already exists, symlink 'C:\Users\davness\Documents\Git\roblox-ts-skeleton\Places\global\src' -> 'C:\Users\davness\Documents\Git\roblox-ts-skeleton\Places\test1\lua\global'] {
  errno: -4075,
  code: 'EEXIST',
  syscall: 'symlink',
  path: 'C:\\Users\\davness\\Documents\\Git\\roblox-ts-skeleton\\Places\\global\\src',
  dest: 'C:\\Users\\davness\\Documents\\Git\\roblox-ts-skeleton\\Places\\test1\\lua\\global'
}
```

For context:

`global/src` - TS scripts shared across all places.
`test1/lua/global` - Lua scripts shared across all places. This should point to `global/lua`...

The target directory ends up getting deleted (or it will point to something else now, or it will become a regular folder), and the compiler stops.

**Note:** I find it unlikely that overwriting the symlink (or a folder) is desired behavior. In fact, we probably want to traverse it.