### PR TITLE
Disallow func?.()

### DIFF
--- a/src/compiler/call.ts
+++ b/src/compiler/call.ts
@@ -853,6 +853,10 @@ export function compileCallExpression(
 	node: ts.CallExpression,
 	doNotWrapTupleReturn = !isTupleReturnTypeCall(node),
 ) {
+	if (node.hasQuestionDotToken()) {
+		throw new CompilerError("TS 3.7 features are not supported yet!", node, CompilerErrorType.TS37);
+	}
+
 	const exp = skipNodesDownwards(checkNonAny(checkNonImportExpression(node.getExpression())));
 	let result: string;
 


### PR DESCRIPTION
Temporarily disallows:
```ts
declare function foo(): void;
foo?.();
```