### PR TITLE
Don't copy files that should be compiled over to out dir

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -530,9 +530,7 @@ export class Project {
 		if (isPathAncestorOf(this.rootPath, filePath)) {
 			await fs.copy(filePath, path.join(this.outPath, path.relative(this.rootPath, filePath)), {
 				overwrite: true,
-				filter: src => {
-					return !shouldCompileFile(this.project, src);
-				},
+				filter: src => !shouldCompileFile(this.project, src),
 			});
 		}
 	}

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -530,6 +530,9 @@ export class Project {
 		if (isPathAncestorOf(this.rootPath, filePath)) {
 			await fs.copy(filePath, path.join(this.outPath, path.relative(this.rootPath, filePath)), {
 				overwrite: true,
+				filter: src => {
+					return !shouldCompileFile(this.project, src);
+				},
 			});
 		}
 	}


### PR DESCRIPTION
Fixes #934

When copying a directory from `rootDir` to `outDir`, all files except the ones the compiler tags as to-be-compiled will be copied over.