### PR TITLE
Symlink behavior rework

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -531,15 +531,13 @@ export class Project {
 			if (fs.lstatSync(filePath).isSymbolicLink()) {
 				// Don't copy the symlink (that's undesired behavior because the target is not what we want)
 				// Instead just create a directory with a new name.
-				fs.promises
-					.mkdir(path.join(this.outPath, path.relative(this.rootPath, filePath)), { recursive: true })
-					.catch(_ => {});
-			} else {
-				await fs.copy(filePath, path.join(this.outPath, path.relative(this.rootPath, filePath)), {
-					overwrite: true,
-					filter: src => !shouldCompileFile(this.project, src),
-				});
+				fs.promises.mkdir(path.join(this.outPath, path.relative(this.rootPath, filePath)), {}).catch(_ => {});
 			}
+			await fs.copy(filePath, path.join(this.outPath, path.relative(this.rootPath, filePath)), {
+				overwrite: true,
+				dereference: true,
+				filter: src => !shouldCompileFile(this.project, src),
+			});
 		}
 	}
 

--- a/src/utility/fs.ts
+++ b/src/utility/fs.ts
@@ -15,7 +15,8 @@ export async function cleanDirRecursive(
 	if (await fs.pathExists(dir)) {
 		for (const name of await fs.readdir(dir)) {
 			const itemPath = path.join(dir, name);
-			if ((await fs.stat(itemPath)).isDirectory()) {
+			const stats = await fs.lstat(itemPath);
+			if (stats.isDirectory() && !stats.isSymbolicLink()) {
 				await cleanDirRecursive(src, dest, shouldClean, itemPath);
 			}
 			if (await shouldClean(src, dest, itemPath)) {
@@ -32,7 +33,6 @@ export async function copyLuaFiles(
 	shouldClean: (src: string, dest: string, itemPath: string) => Promise<boolean> = shouldCleanRelative,
 ) {
 	await cleanDirRecursive(src, dest, shouldClean);
-
 	const foldersContainingLua = new Set<string>();
 
 	async function checkContainsLua(dir: string): Promise<boolean> {


### PR DESCRIPTION
Fixes #928 

This avoids some permission issues and others related to symlink copying (which should not be done)

## Note about commit 1de73681cec45355bfda523cf28dfbe33448c77a

This is essentially an hacky way to patch chokidar's current behavior, and so I'm unsure about whether it's adequate to be merged:

I have a symlink
I rename the symlink

chokidar reports unlink of symlink and it's contents (all good)
chokidar reports the new symlink to be added (all good)

chokidar doesn't report the symlink's contents to be added, even with `followSymlinks` set to `true`.

I'll look into filing an issue with them, but at the moment, **here's what is done:**

Calling `Watcher.start()` a second time will stop the current watcher and initialize a new one. An optional argument was added to suppress the "Starting initial compile..." logs. However, this means the whole project is still going to be recompiled.

Essentially, `Watcher.start(true)` is now invoked if a symlink is added into the project.