### PR TITLE
make build CI separate task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,17 @@ jobs:
       - name: Run ESLint
         run: npm run eslint
 
+  build:
+    if: contains(github.event.commits[0].message, '[skip ci]') == false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - uses: bahmutov/npm-install@v1
+
       - name: Build
-        run: npm run build
+        run: npm run prepare


### PR DESCRIPTION
I'm not sure if this is necessary, after package.json was changed to `prepare` script. Which runs on local `npm install`, so does the install action take care of it inside the lint task? IMO that would be undesirable behaviour