### PR TITLE
Try/catch/finally support

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -974,9 +974,9 @@ function TS.opcall(func, ...)
 	end
 end
 
-TS.TRY_RETURN = {}
-TS.TRY_BREAK = {}
-TS.TRY_CONTINUE = {}
+TS.TRY_RETURN = 1
+TS.TRY_BREAK = 2
+TS.TRY_CONTINUE = 3
 
 function TS.try(func, catch, finally)
 	local err, traceback

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -974,4 +974,32 @@ function TS.opcall(func, ...)
 	end
 end
 
+TS.TRY_RETURN = 1
+TS.TRY_BREAK = 2
+TS.TRY_CONTINUE = 3
+
+function TS.try(func, catch, finally)
+	local err, traceback
+	local success, exit_type, returns = xpcall(
+		func,
+		function(err_inner)
+			err = err_inner
+			traceback = debug.traceback()
+		end
+	)
+	if not success and catch then
+		local new_exit_type, new_returns = catch(err, traceback)
+		if new_exit_type then
+			exit_type, returns = new_exit_type, new_returns
+		end
+	end
+	if finally then
+		local new_exit_type, new_returns = finally()
+		if new_exit_type then
+			exit_type, returns = new_exit_type, new_returns
+		end
+	end
+	return exit_type, returns
+end
+
 return TS

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -974,32 +974,32 @@ function TS.opcall(func, ...)
 	end
 end
 
-TS.TRY_RETURN = 1
-TS.TRY_BREAK = 2
-TS.TRY_CONTINUE = 3
+TS.TRY_RETURN = {}
+TS.TRY_BREAK = {}
+TS.TRY_CONTINUE = {}
 
 function TS.try(func, catch, finally)
 	local err, traceback
-	local success, exit_type, returns = xpcall(
+	local success, exitType, returns = xpcall(
 		func,
-		function(err_inner)
-			err = err_inner
+		function(errInner)
+			err = errInner
 			traceback = debug.traceback()
 		end
 	)
 	if not success and catch then
-		local new_exit_type, new_returns = catch(err, traceback)
-		if new_exit_type then
-			exit_type, returns = new_exit_type, new_returns
+		local newExitType, newReturns = catch(err, traceback)
+		if newExitType then
+			exitType, returns = newExitType, newReturns
 		end
 	end
 	if finally then
-		local new_exit_type, new_returns = finally()
-		if new_exit_type then
-			exit_type, returns = new_exit_type, new_returns
+		local newExitType, newReturns = finally()
+		if newExitType then
+			exitType, returns = newExitType, newReturns
 		end
 	end
-	return exit_type, returns
+	return exitType, returns
 end
 
 return TS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1822,7 +1822,7 @@
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -16,6 +16,12 @@ import originalTS from "typescript";
  */
 const RUNTIME_LIB_ID = lua.id("TS");
 
+export type TryUses = {
+	usesReturn: boolean;
+	usesBreak: boolean;
+	usesContinue: boolean;
+};
+
 /**
  * Represents the state of the transformation between TS -> lua AST.
  */
@@ -47,6 +53,37 @@ export class TransformState {
 		public readonly sourceFile: ts.SourceFile,
 	) {
 		this.sourceFileText = sourceFile.getFullText();
+	}
+
+	public readonly tryUsesStack = new Array<TryUses>();
+
+	/**
+	 * Pushes tryUses information onto the tryUses stack and returns it.
+	 */
+	public pushTryUsesStack() {
+		const tryUses = {
+			usesReturn: false,
+			usesBreak: false,
+			usesContinue: false,
+		};
+		this.tryUsesStack.push(tryUses);
+		return tryUses;
+	}
+
+	/**
+	 * Marks the current try statement as exiting with return, break, or continue statements.
+	 */
+	public markTryUses(property: "usesReturn" | "usesBreak" | "usesContinue") {
+		if (this.tryUsesStack.length !== 0) {
+			this.tryUsesStack[this.tryUsesStack.length - 1][property] = true;
+		}
+	}
+
+	/**
+	 * Pops tryUses information from the tryUses stack
+	 */
+	public popTryUsesStack() {
+		this.tryUsesStack.pop();
 	}
 
 	public readonly prereqStatementsStack = new Array<lua.List<lua.Statement>>();

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -73,7 +73,7 @@ export class TransformState {
 	/**
 	 * Marks the current try statement as exiting with return, break, or continue statements.
 	 */
-	public markTryUses(property: "usesReturn" | "usesBreak" | "usesContinue") {
+	public markTryUses(property: keyof TryUses) {
 		if (this.tryUsesStack.length !== 0) {
 			this.tryUsesStack[this.tryUsesStack.length - 1][property] = true;
 		}

--- a/src/TSTransformer/nodes/binding/transformBindingName.ts
+++ b/src/TSTransformer/nodes/binding/transformBindingName.ts
@@ -1,0 +1,30 @@
+import ts from "byots";
+import * as lua from "LuaAST";
+import { TransformState } from "TSTransformer";
+import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
+import { transformArrayBindingPattern } from "TSTransformer/nodes/binding/transformArrayBindingPattern";
+import { transformObjectBindingPattern } from "TSTransformer/nodes/binding/transformObjectBindingPattern";
+
+export function transformBindingName(
+	state: TransformState,
+	name: ts.BindingName,
+	initializers: lua.List<lua.Statement>,
+) {
+	let id: lua.AnyIdentifier;
+	if (ts.isIdentifier(name)) {
+		id = transformIdentifierDefined(state, name);
+	} else {
+		id = lua.tempId();
+		lua.list.pushList(
+			initializers,
+			state.capturePrereqs(() => {
+				if (ts.isArrayBindingPattern(name)) {
+					transformArrayBindingPattern(state, name, id);
+				} else {
+					transformObjectBindingPattern(state, name, id);
+				}
+			}),
+		);
+	}
+	return id;
+}

--- a/src/TSTransformer/nodes/expressions/transformIdentifier.ts
+++ b/src/TSTransformer/nodes/expressions/transformIdentifier.ts
@@ -34,7 +34,12 @@ function checkIdentifierHoist(state: TransformState, node: ts.Identifier, symbol
 	}
 
 	const declarationStatement = getAncestor(declaration, ts.isStatement);
-	if (!declarationStatement || ts.isForStatement(declarationStatement) || ts.isForOfStatement(declarationStatement)) {
+	if (
+		!declarationStatement ||
+		ts.isForStatement(declarationStatement) ||
+		ts.isForOfStatement(declarationStatement) ||
+		ts.isTryStatement(declarationStatement)
+	) {
 		return;
 	}
 

--- a/src/TSTransformer/nodes/statements/transformBreakStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformBreakStatement.ts
@@ -2,11 +2,22 @@ import ts from "byots";
 import * as lua from "LuaAST";
 import { diagnostics } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
+import { isBreakBlockedByTryStatement } from "TSTransformer/util/isBlockedByTryStatement";
 
 export function transformBreakStatement(state: TransformState, node: ts.BreakStatement) {
 	if (node.label) {
 		state.addDiagnostic(diagnostics.noLabeledStatement(node.label));
 		return lua.list.make<lua.Statement>();
+	}
+
+	if (isBreakBlockedByTryStatement(node)) {
+		state.markTryUses("usesBreak");
+
+		return lua.list.make(
+			lua.create(lua.SyntaxKind.ReturnStatement, {
+				expression: state.TS("TRY_BREAK"),
+			}),
+		);
 	}
 
 	return lua.list.make(lua.create(lua.SyntaxKind.BreakStatement, {}));

--- a/src/TSTransformer/nodes/statements/transformContinueStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformContinueStatement.ts
@@ -2,11 +2,22 @@ import ts from "byots";
 import * as lua from "LuaAST";
 import { diagnostics } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
+import { isBreakBlockedByTryStatement } from "TSTransformer/util/isBlockedByTryStatement";
 
 export function transformContinueStatement(state: TransformState, node: ts.ContinueStatement) {
 	if (node.label) {
 		state.addDiagnostic(diagnostics.noLabeledStatement(node.label));
 		return lua.list.make<lua.Statement>();
+	}
+
+	if (isBreakBlockedByTryStatement(node)) {
+		state.markTryUses("usesContinue");
+
+		return lua.list.make(
+			lua.create(lua.SyntaxKind.ReturnStatement, {
+				expression: state.TS("TRY_CONTINUE"),
+			}),
+		);
 	}
 
 	return lua.list.make(lua.create(lua.SyntaxKind.ContinueStatement, {}));

--- a/src/TSTransformer/nodes/statements/transformStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformStatement.ts
@@ -22,6 +22,7 @@ import { transformModuleDeclaration } from "TSTransformer/nodes/statements/trans
 import { transformReturnStatement } from "TSTransformer/nodes/statements/transformReturnStatement";
 import { transformSwitchStatement } from "TSTransformer/nodes/statements/transformSwitchStatement";
 import { transformThrowStatement } from "TSTransformer/nodes/statements/transformThrowStatement";
+import { transformTryStatement } from "TSTransformer/nodes/statements/transformTryStatement";
 import { transformVariableStatement } from "TSTransformer/nodes/statements/transformVariableStatement";
 import { transformWhileStatement } from "TSTransformer/nodes/statements/transformWhileStatement";
 import { getKindName } from "TSTransformer/util/getKindName";
@@ -46,7 +47,6 @@ const TRANSFORMER_BY_KIND = new Map<ts.SyntaxKind, StatementTransformer>([
 	[ts.SyntaxKind.EmptyStatement, NO_EMIT],
 
 	// banned statements
-	[ts.SyntaxKind.TryStatement, DIAGNOSTIC(diagnostics.noTryStatement)],
 	[ts.SyntaxKind.ForInStatement, DIAGNOSTIC(diagnostics.noForInStatement)],
 	[ts.SyntaxKind.LabeledStatement, DIAGNOSTIC(diagnostics.noLabeledStatement)],
 	[ts.SyntaxKind.DebuggerStatement, DIAGNOSTIC(diagnostics.noDebuggerStatement)],
@@ -71,6 +71,7 @@ const TRANSFORMER_BY_KIND = new Map<ts.SyntaxKind, StatementTransformer>([
 	[ts.SyntaxKind.ReturnStatement, transformReturnStatement],
 	[ts.SyntaxKind.SwitchStatement, transformSwitchStatement],
 	[ts.SyntaxKind.ThrowStatement, transformThrowStatement],
+	[ts.SyntaxKind.TryStatement, transformTryStatement],
 	[ts.SyntaxKind.VariableStatement, transformVariableStatement],
 	[ts.SyntaxKind.WhileStatement, transformWhileStatement],
 ]);

--- a/src/TSTransformer/nodes/statements/transformTryStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformTryStatement.ts
@@ -1,0 +1,211 @@
+import ts from "byots";
+import * as lua from "LuaAST";
+import { TransformState, TryUses } from "TSTransformer";
+import { transformStatementList } from "TSTransformer/nodes/transformStatementList";
+import {
+	isBreakBlockedByTryStatement,
+	isReturnBlockedByTryStatement,
+} from "TSTransformer/util/isBlockedByTryStatement";
+import { transformBindingName } from "TSTransformer/nodes/binding/transformBindingName";
+
+function transformCatchClause(state: TransformState, node: ts.CatchClause) {
+	const parameters = lua.list.make<lua.AnyIdentifier>();
+	const statements = lua.list.make<lua.Statement>();
+
+	if (node.variableDeclaration) {
+		lua.list.push(parameters, transformBindingName(state, node.variableDeclaration.name, statements));
+	}
+
+	lua.list.pushList(statements, transformStatementList(state, node.block.statements));
+
+	const catchFunction = lua.create(lua.SyntaxKind.FunctionExpression, {
+		parameters: parameters,
+		hasDotDotDot: false,
+		statements: statements,
+	});
+
+	return catchFunction;
+}
+
+function transformIntoTryCall(
+	state: TransformState,
+	node: ts.TryStatement,
+	exitTypeId: lua.TemporaryIdentifier,
+	returnsId: lua.TemporaryIdentifier,
+	tryUses: TryUses,
+) {
+	const tryCallArgs = lua.list.make<lua.Expression>();
+
+	lua.list.push(
+		tryCallArgs,
+		lua.create(lua.SyntaxKind.FunctionExpression, {
+			parameters: lua.list.make(),
+			hasDotDotDot: false,
+			statements: transformStatementList(state, node.tryBlock.statements),
+		}),
+	);
+
+	if (node.catchClause) {
+		lua.list.push(tryCallArgs, transformCatchClause(state, node.catchClause));
+	} else if (node.finallyBlock) {
+		lua.list.push(tryCallArgs, lua.nil());
+	}
+
+	if (node.finallyBlock) {
+		lua.list.push(
+			tryCallArgs,
+			lua.create(lua.SyntaxKind.FunctionExpression, {
+				parameters: lua.list.make(),
+				hasDotDotDot: false,
+				statements: transformStatementList(state, node.finallyBlock.statements),
+			}),
+		);
+	}
+
+	if (!tryUses.usesReturn && !tryUses.usesBreak && !tryUses.usesContinue) {
+		return lua.create(lua.SyntaxKind.CallStatement, {
+			expression: lua.create(lua.SyntaxKind.CallExpression, {
+				expression: state.TS("try"),
+				args: tryCallArgs,
+			}),
+		});
+	}
+
+	return lua.create(lua.SyntaxKind.VariableDeclaration, {
+		left: lua.list.make(exitTypeId, returnsId),
+		right: lua.create(lua.SyntaxKind.CallExpression, {
+			expression: state.TS("try"),
+			args: tryCallArgs,
+		}),
+	});
+}
+
+function createFlowControlCondition(
+	state: TransformState,
+	exitTypeId: lua.TemporaryIdentifier,
+	flowControlConstant: string,
+) {
+	return lua.create(lua.SyntaxKind.BinaryExpression, {
+		left: exitTypeId,
+		operator: "==",
+		right: state.TS(flowControlConstant),
+	});
+}
+
+type FlowControlCase = { condition?: lua.Expression; statements: lua.List<lua.Statement> };
+
+function collapseFlowControlCases(exitTypeId: lua.TemporaryIdentifier, cases: Array<FlowControlCase>) {
+	if (cases.length === 0) {
+		return lua.list.make<lua.Statement>();
+	} else {
+		let nextStatements = lua.create(lua.SyntaxKind.IfStatement, {
+			condition: exitTypeId,
+			statements: cases[cases.length - 1].statements,
+			elseBody: lua.list.make(),
+		});
+		for (let i = cases.length - 2; i >= 0; i--) {
+			nextStatements = lua.create(lua.SyntaxKind.IfStatement, {
+				condition: cases[i].condition || exitTypeId,
+				statements: cases[i].statements,
+				elseBody: nextStatements,
+			});
+		}
+		return lua.list.make(nextStatements);
+	}
+}
+
+function transformFlowControl(
+	state: TransformState,
+	node: ts.TryStatement,
+	exitTypeId: lua.TemporaryIdentifier,
+	returnsId: lua.TemporaryIdentifier,
+	tryUses: TryUses,
+) {
+	const flowControlCases = new Array<FlowControlCase>();
+
+	if (!tryUses.usesReturn && !tryUses.usesBreak && !tryUses.usesContinue) {
+		return lua.list.make();
+	}
+
+	const returnBlocked = isReturnBlockedByTryStatement(node.parent);
+	const breakBlocked = isBreakBlockedByTryStatement(node.parent);
+
+	if (tryUses.usesReturn && returnBlocked) {
+		state.markTryUses("usesReturn");
+	}
+	if (tryUses.usesBreak && breakBlocked) {
+		state.markTryUses("usesBreak");
+	}
+	if (tryUses.usesContinue && breakBlocked) {
+		state.markTryUses("usesContinue");
+	}
+
+	if (tryUses.usesReturn) {
+		if (returnBlocked) {
+			flowControlCases.push({
+				condition: createFlowControlCondition(state, exitTypeId, "TRY_RETURN"),
+				statements: lua.list.make(
+					lua.create(lua.SyntaxKind.ReturnStatement, {
+						expression: lua.list.make(exitTypeId, returnsId),
+					}),
+				),
+			});
+			if (breakBlocked) {
+				return collapseFlowControlCases(exitTypeId, flowControlCases);
+			}
+		} else {
+			flowControlCases.push({
+				condition: createFlowControlCondition(state, exitTypeId, "TRY_RETURN"),
+				statements: lua.list.make(
+					lua.create(lua.SyntaxKind.ReturnStatement, {
+						expression: lua.create(lua.SyntaxKind.CallExpression, {
+							expression: lua.globals.unpack,
+							args: lua.list.make<lua.Expression>(returnsId),
+						}),
+					}),
+				),
+			});
+		}
+	}
+
+	if (tryUses.usesBreak || tryUses.usesContinue) {
+		if (breakBlocked) {
+			flowControlCases.push({
+				statements: lua.list.make(
+					lua.create(lua.SyntaxKind.ReturnStatement, {
+						expression: exitTypeId,
+					}),
+				),
+			});
+		} else {
+			if (tryUses.usesBreak) {
+				flowControlCases.push({
+					condition: createFlowControlCondition(state, exitTypeId, "TRY_BREAK"),
+					statements: lua.list.make(lua.create(lua.SyntaxKind.BreakStatement, {})),
+				});
+			}
+			if (tryUses.usesContinue) {
+				flowControlCases.push({
+					condition: createFlowControlCondition(state, exitTypeId, "TRY_CONTINUE"),
+					statements: lua.list.make(lua.create(lua.SyntaxKind.ContinueStatement, {})),
+				});
+			}
+		}
+	}
+
+	return collapseFlowControlCases(exitTypeId, flowControlCases);
+}
+
+export function transformTryStatement(state: TransformState, node: ts.TryStatement) {
+	const statements = lua.list.make<lua.Statement>();
+	const exitTypeId = lua.tempId();
+	const returnsId = lua.tempId();
+
+	const tryUses = state.pushTryUsesStack();
+	lua.list.push(statements, transformIntoTryCall(state, node, exitTypeId, returnsId, tryUses));
+	state.popTryUsesStack();
+
+	lua.list.pushList(statements, transformFlowControl(state, node, exitTypeId, returnsId, tryUses));
+
+	return statements;
+}

--- a/src/TSTransformer/util/isBlockedByTryStatement.ts
+++ b/src/TSTransformer/util/isBlockedByTryStatement.ts
@@ -1,0 +1,17 @@
+import ts from "byots";
+
+export function isReturnBlockedByTryStatement(node: ts.Node) {
+	const ancestor = ts.findAncestor(node, ancestor => {
+		return ts.isTryStatement(ancestor) || ts.isFunctionLikeDeclaration(ancestor);
+	});
+	return ancestor && ts.isTryStatement(ancestor);
+}
+
+export function isBreakBlockedByTryStatement(node: ts.Node) {
+	const ancestor = ts.findAncestor(node, ancestor => {
+		return (
+			ts.isTryStatement(ancestor) || ts.isIterationStatement(ancestor, false) || ts.isSwitchStatement(ancestor)
+		);
+	});
+	return ancestor && ts.isTryStatement(ancestor);
+}


### PR DESCRIPTION
This PR adds support for try/catch/finally.

Implementation Details:
* try/catch/finally is emulated using xpcall, a helper function (`TS.try`), and helper constants (`TRY_RETURN`, `TRY_BREAK`, `TRY_CONTINUE`)
* return/break/continue are supported by replacing "top level" return/break/continue calls with return statements. return/break/continue are then added outside of the `TS.try` call to pass those statements "through" the function call boundary.
* `finally` is supported. If it returns/breaks/continues, then the statement replaces the existing one from try/catch. return/break/continue are only processed once the `TS.try` call finishes.
* `TS.try` currently passes the error traceback to the `catch` callback, but the compiled lua callback function does not include a parameter for it. We can easily add support for this in the future as a "global" variable or by taking advantage of destructuring in the catch variable declaration.
* Most of the generated code is added conditionally dependent on if it can be triggered.
* This handles nested loops, switches, functions, and `try`s.

Side note: this implementation should work fine with regular pcall too. I only used xpcall here because it supports getting the full traceback from an error, which I think we should support eventually as it's an important part of making useful errors.

Don't feel shy to point out anything that can be improved! 🙂 

[Here is a side-by-side typescript try/catch/finally and the generated Lua code](https://gist.github.com/Corecii/91e9062fdb7ea4276f91581af79b08b1)
