### PR TITLE
[draft] simplify conditionalExpression

### DIFF
--- a/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
@@ -28,7 +28,7 @@ export function transformConditionalExpression(state: TransformState, node: ts.C
 			}),
 		});
 	}
-	
+
 	const tempId = lua.tempId();
 	state.prereq(
 		lua.create(lua.SyntaxKind.VariableDeclaration, {

--- a/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
@@ -1,12 +1,35 @@
 import ts from "byots";
+import * as tsst from "ts-simple-type";
 import * as lua from "LuaAST";
 import { TransformState } from "TSTransformer";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { createTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
 
-export function transformConditionalExpression(state: TransformState, node: ts.ConditionalExpression) {
-	const tempId = lua.tempId();
+function isBooleanType(type: tsst.SimpleType) {
+	return type.kind === tsst.SimpleTypeKind.BOOLEAN || type.kind === tsst.SimpleTypeKind.BOOLEAN_LITERAL;
+}
 
+declare function canBeFalsy(node: ts.Expression): boolean;
+export function transformConditionalExpression(state: TransformState, node: ts.ConditionalExpression) {
+	if (isBooleanType(state.getSimpleTypeFromNode(node)) && !canBeFalsy(node.whenTrue)) {
+		return lua.create(lua.SyntaxKind.ParenthesizedExpression, {
+			expression: lua.create(lua.SyntaxKind.BinaryExpression, {
+				left: lua.create(lua.SyntaxKind.BinaryExpression, {
+					left: createTruthinessChecks(
+						state,
+						transformExpression(state, node.condition),
+						state.getType(node.condition),
+					),
+					right: transformExpression(state, node.whenTrue),
+					operator: "and",
+				}),
+				right: transformExpression(state, node.whenFalse),
+				operator: "or",
+			}),
+		});
+	}
+	
+	const tempId = lua.tempId();
 	state.prereq(
 		lua.create(lua.SyntaxKind.VariableDeclaration, {
 			left: tempId,

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -111,3 +111,7 @@ export function isObjectType(type: ts.Type) {
 export function getTypeArguments(state: TransformState, type: ts.Type) {
 	return state.typeChecker.getTypeArguments(type as ts.TypeReference) ?? [];
 }
+
+export function canTypeBeFalsy(type: ts.Type) {
+	return isSomeType(type, t => !!(t.flags & ts.TypeFlags.PossiblyFalsy));
+}

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -1,4 +1,5 @@
 import ts from "byots";
+import * as tsst from "ts-simple-type";
 import { SYMBOL_NAMES, TransformState } from "TSTransformer";
 
 function typeConstraint(type: ts.Type, callback: (type: ts.Type) => boolean): boolean {
@@ -112,6 +113,12 @@ export function getTypeArguments(state: TransformState, type: ts.Type) {
 	return state.typeChecker.getTypeArguments(type as ts.TypeReference) ?? [];
 }
 
-export function canTypeBeFalsy(type: ts.Type) {
-	return isSomeType(type, t => !!(t.flags & ts.TypeFlags.PossiblyFalsy));
+/**
+ * Uses ts-simple-type to check if a type is assignable to `false` or `undefined`
+ */
+export function canTypeBeLuaFalsy(state: TransformState, type: ts.Type) {
+	const simpleType = state.getSimpleType(type);
+	const isAssignableToFalse = tsst.isAssignableToValue(simpleType, false);
+	const isAssignableToUndefined = tsst.isAssignableToSimpleTypeKind(simpleType, tsst.SimpleTypeKind.UNDEFINED);
+	return isAssignableToFalse || isAssignableToUndefined;
 }


### PR DESCRIPTION
makes it use "condition and trueValue or falseValue", where available. Needs implementation of `canBeFalsy`, but I'm not familiar with types.