### PR TITLE
Add macros for object.entries, keys and values

### DIFF
--- a/src/TSTransformer/README.md
+++ b/src/TSTransformer/README.md
@@ -120,9 +120,9 @@ In other words, TS AST -> Lua AST
 
 ### Object Macros
 
--   [ ] Object.keys()
--   [ ] Object.values()
--   [ ] Object.entries()
+-   [x] Object.keys()
+-   [x] Object.values()
+-   [x] Object.entries()
 -   [ ] Object.assign()
 -   [x] Object.copy()
 -   [ ] Object.deepCopy()

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -771,13 +771,14 @@ const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 		}),
 };
 
-function makeKeysValuesEntriesMethod(
-	generator: (key: lua.AnyIdentifier, value: lua.AnyIdentifier) => lua.Expression,
+function makeKeysValuesEntriesMethod<T extends [lua.AnyIdentifier, lua.AnyIdentifier]>(
+	loopIds: T,
+	generator: (...loopIds: T) => lua.Expression,
 ): PropertyCallMacro {
 	return (state, node, expression) => {
 		const valuesId = state.pushToVar(lua.array());
-		const keyId = lua.tempId();
-		const valueId = lua.tempId();
+		const keyId = loopIds[0];
+		const valueId = loopIds[1];
 
 		const size = lua.create(lua.SyntaxKind.UnaryExpression, {
 			operator: "#",
@@ -818,11 +819,9 @@ const OBJECT_METHODS: MacroList<PropertyCallMacro> = {
 	fromEntries: runtimeLib("Object_fromEntries", true),
 	isEmpty: runtimeLib("Object_isEmpty", true),
 
-	keys: makeKeysValuesEntriesMethod((key, value) => key),
-
-	values: makeKeysValuesEntriesMethod((key, value) => value),
-
-	entries: makeKeysValuesEntriesMethod((key, value) => lua.array([key, value])),
+	keys: makeKeysValuesEntriesMethod([lua.tempId()], (key) => key),
+	values: makeKeysValuesEntriesMethod([lua.emptyId(), lua.tempId()], (_, value) => value),
+	entries: makeKeysValuesEntriesMethod([lua.tempId(), lua.tempId()], (key, value) => lua.array([key, value])),
 
 	copy: (state, node, expression) => {
 		const objectCopyId = state.pushToVar(lua.map());

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -771,14 +771,12 @@ const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 		}),
 };
 
-function makeKeysValuesEntriesMethod<T extends [lua.AnyIdentifier, lua.AnyIdentifier]>(
-	loopIds: T,
-	generator: (...loopIds: T) => lua.Expression,
+function makeKeysValuesEntriesMethod(
+	loopIds: Array<lua.AnyIdentifier>,
+	generator: (...loopIds: Array<lua.AnyIdentifier>) => lua.Expression,
 ): PropertyCallMacro {
 	return (state, node, expression) => {
 		const valuesId = state.pushToVar(lua.array());
-		const keyId = loopIds[0];
-		const valueId = loopIds[1];
 
 		const size = lua.create(lua.SyntaxKind.UnaryExpression, {
 			operator: "#",
@@ -787,7 +785,7 @@ function makeKeysValuesEntriesMethod<T extends [lua.AnyIdentifier, lua.AnyIdenti
 
 		state.prereq(
 			lua.create(lua.SyntaxKind.ForStatement, {
-				ids: lua.list.make(keyId, valueId),
+				ids: lua.list.make(...loopIds),
 				expression: lua.create(lua.SyntaxKind.CallExpression, {
 					expression: lua.globals.pairs,
 					args: lua.list.make(transformExpression(state, node.arguments[0])),
@@ -802,7 +800,7 @@ function makeKeysValuesEntriesMethod<T extends [lua.AnyIdentifier, lua.AnyIdenti
 								right: lua.number(1),
 							}),
 						}),
-						right: generator(keyId, valueId),
+						right: generator(...loopIds),
 					}),
 				),
 			}),
@@ -819,7 +817,7 @@ const OBJECT_METHODS: MacroList<PropertyCallMacro> = {
 	fromEntries: runtimeLib("Object_fromEntries", true),
 	isEmpty: runtimeLib("Object_isEmpty", true),
 
-	keys: makeKeysValuesEntriesMethod([lua.tempId()], (key) => key),
+	keys: makeKeysValuesEntriesMethod([lua.tempId()], key => key),
 	values: makeKeysValuesEntriesMethod([lua.emptyId(), lua.tempId()], (_, value) => value),
 	entries: makeKeysValuesEntriesMethod([lua.tempId(), lua.tempId()], (key, value) => lua.array([key, value])),
 

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -123,7 +123,6 @@ function makeEveryOrSomeMethod(
 		valueId: lua.TemporaryIdentifier,
 		expression: lua.Expression,
 	) => lua.List<lua.Expression>,
-	commentText: string,
 	initialState: boolean,
 ): PropertyCallMacro {
 	return (state, node, expression) => {
@@ -178,9 +177,8 @@ function makeEveryMethod(
 		valueId: lua.TemporaryIdentifier,
 		expression: lua.Expression,
 	) => lua.List<lua.Expression>,
-	className: string,
 ): PropertyCallMacro {
-	return makeEveryOrSomeMethod(iterator, callbackArgsListMaker, `${className}.every`, true);
+	return makeEveryOrSomeMethod(iterator, callbackArgsListMaker, true);
 }
 
 function makeSomeMethod(
@@ -190,9 +188,8 @@ function makeSomeMethod(
 		valueId: lua.TemporaryIdentifier,
 		expression: lua.Expression,
 	) => lua.List<lua.Expression>,
-	className: string,
 ): PropertyCallMacro {
-	return makeEveryOrSomeMethod(iterator, callbackArgsListMaker, `${className}.some`, false);
+	return makeEveryOrSomeMethod(iterator, callbackArgsListMaker, false);
 }
 
 const ARRAY_LIKE_METHODS: MacroList<PropertyCallMacro> = {
@@ -215,16 +212,12 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		});
 	},
 
-	every: makeEveryMethod(
-		lua.globals.ipairs,
-		(keyId, valueId, expression) => lua.list.make(valueId, offset(keyId, -1), expression),
-		"ReadonlyArray",
+	every: makeEveryMethod(lua.globals.ipairs, (keyId, valueId, expression) =>
+		lua.list.make(valueId, offset(keyId, -1), expression),
 	),
 
-	some: makeSomeMethod(
-		lua.globals.ipairs,
-		(keyId, valueId, expression) => lua.list.make(valueId, offset(keyId, -1), expression),
-		"ReadonlyArray",
+	some: makeSomeMethod(lua.globals.ipairs, (keyId, valueId, expression) =>
+		lua.list.make(valueId, offset(keyId, -1), expression),
 	),
 
 	forEach: (state, node, expression) => {
@@ -778,15 +771,58 @@ const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 		}),
 };
 
+function makeKeysValuesEntriesMethod(
+	generator: (key: lua.AnyIdentifier, value: lua.AnyIdentifier) => lua.Expression,
+): PropertyCallMacro {
+	return (state, node, expression) => {
+		const valuesId = state.pushToVar(lua.array());
+		const keyId = lua.tempId();
+		const valueId = lua.tempId();
+
+		const size = lua.create(lua.SyntaxKind.UnaryExpression, {
+			operator: "#",
+			expression: valuesId,
+		});
+
+		state.prereq(
+			lua.create(lua.SyntaxKind.ForStatement, {
+				ids: lua.list.make(keyId, valueId),
+				expression: lua.create(lua.SyntaxKind.CallExpression, {
+					expression: lua.globals.pairs,
+					args: lua.list.make(transformExpression(state, node.arguments[0])),
+				}),
+				statements: lua.list.make(
+					lua.create(lua.SyntaxKind.Assignment, {
+						left: lua.create(lua.SyntaxKind.ComputedIndexExpression, {
+							expression: convertToIndexableExpression(valuesId),
+							index: lua.create(lua.SyntaxKind.BinaryExpression, {
+								left: size,
+								operator: "+",
+								right: lua.number(1),
+							}),
+						}),
+						right: generator(keyId, valueId),
+					}),
+				),
+			}),
+		);
+
+		return valuesId;
+	};
+}
+
 const OBJECT_METHODS: MacroList<PropertyCallMacro> = {
 	assign: runtimeLib("Object_assign", true),
 	deepCopy: runtimeLib("Object_deepCopy", true),
 	deepEquals: runtimeLib("Object_deepEquals", true),
-	entries: runtimeLib("Object_entries", true),
 	fromEntries: runtimeLib("Object_fromEntries", true),
 	isEmpty: runtimeLib("Object_isEmpty", true),
-	keys: runtimeLib("Object_keys", true),
-	values: runtimeLib("Object_values", true),
+
+	keys: makeKeysValuesEntriesMethod((key, value) => key),
+
+	values: makeKeysValuesEntriesMethod((key, value) => value),
+
+	entries: makeKeysValuesEntriesMethod((key, value) => lua.array([key, value])),
 
 	copy: (state, node, expression) => {
 		const objectCopyId = state.pushToVar(lua.map());


### PR DESCRIPTION
Also removed classname property in every and some, not used since automated comments were added.
Credits to @Dog2puppy for the base implementation.