### PR TITLE
Add `ReadonlyArray.indexOf()` and `ReadonlyArray.lastIndexOf()`

### DIFF
--- a/src/LuaAST/impl/globals.ts
+++ b/src/LuaAST/impl/globals.ts
@@ -37,6 +37,7 @@ export const globals = {
 		concat: property(TABLE_ID, "concat"),
 		create: property(TABLE_ID, "create"),
 		remove: property(TABLE_ID, "remove"),
+		find: property(TABLE_ID, "find"),
 	},
 	utf8: {
 		charpattern: property(UTF8_ID, "charpattern"),

--- a/src/TSTransformer/README.md
+++ b/src/TSTransformer/README.md
@@ -139,7 +139,7 @@ In other words, TS AST -> Lua AST
 -   [x] ReadonlyArray.join()
 -   [ ] ReadonlyArray.slice()
 -   [ ] ReadonlyArray.includes()
--   [ ] ReadonlyArray.indexOf()
+-   [x] ReadonlyArray.indexOf()
 -   [ ] ReadonlyArray.lastIndexOf()
 -   [x] ReadonlyArray.every()
 -   [x] ReadonlyArray.some()

--- a/src/TSTransformer/README.md
+++ b/src/TSTransformer/README.md
@@ -140,7 +140,7 @@ In other words, TS AST -> Lua AST
 -   [ ] ReadonlyArray.slice()
 -   [ ] ReadonlyArray.includes()
 -   [x] ReadonlyArray.indexOf()
--   [ ] ReadonlyArray.lastIndexOf()
+-   [x] ReadonlyArray.lastIndexOf()
 -   [x] ReadonlyArray.every()
 -   [x] ReadonlyArray.some()
 -   [x] ReadonlyArray.forEach()

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -430,10 +430,25 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 
 		return resultId;
 	},
-
+	indexOf: (state, node, expression) =>
+		lua.create(lua.SyntaxKind.ParenthesizedExpression, {
+			expression: lua.create(lua.SyntaxKind.BinaryExpression, {
+				left: lua.create(lua.SyntaxKind.ParenthesizedExpression, {
+					expression: lua.create(lua.SyntaxKind.BinaryExpression, {
+						left: lua.create(lua.SyntaxKind.CallExpression, {
+							expression: lua.globals.table.find,
+							args: lua.list.make(expression, transformExpression(state, node.arguments[0])),
+						}),
+						operator: "or",
+						right: lua.number(0),
+					}),
+				}),
+				operator: "-",
+				right: lua.number(1),
+			}),
+		}),
 	reduce: runtimeLib("array_reduce"),
 	findIndex: runtimeLib("array_findIndex"),
-	indexOf: runtimeLib("array_indexOf"),
 	find: runtimeLib("array_find"),
 };
 

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -432,8 +432,8 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	},
 	indexOf: (state, node, expression) =>
 		lua.create(lua.SyntaxKind.ParenthesizedExpression, {
-			expression: lua.create(lua.SyntaxKind.BinaryExpression, {
-				left: lua.create(lua.SyntaxKind.ParenthesizedExpression, {
+			expression: offset(
+				lua.create(lua.SyntaxKind.ParenthesizedExpression, {
 					expression: lua.create(lua.SyntaxKind.BinaryExpression, {
 						left: lua.create(lua.SyntaxKind.CallExpression, {
 							expression: lua.globals.table.find,
@@ -443,9 +443,8 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 						right: lua.number(0),
 					}),
 				}),
-				operator: "-",
-				right: lua.number(1),
-			}),
+				-1,
+			),
 		}),
 	lastIndexOf: (state, node, expression) => {
 		const nodeArgs = node.arguments;


### PR DESCRIPTION
```ts
let arr = [4, 5, 6, 7];
let b = arr.indexOf(2) * 2;
let c = arr.lastIndexOf(5);
let d = arr.lastIndexOf(5, 1);
```
```lua
local arr = { 4, 5, 6, 7 }
local b = ((table.find(arr, 2) or 0) - 1) * 2
-- ▼ ReadonlyArray.lastIndexOf ▼
local _0 = -1
for _1 = #arr, 1, -1 do
	if arr[_1] == 5 then
		_0 = _1 - 1
		break
	end
end
-- ▲ ReadonlyArray.lastIndexOf ▲
local c = _0
-- ▼ ReadonlyArray.lastIndexOf ▼
local _1 = -1
for _2 = 2, 1, -1 do
	if arr[_2] == 5 then
		_1 = _2 - 1
		break
	end
end
-- ▲ ReadonlyArray.lastIndexOf ▲
local d = _1
```