### PR TITLE
Implement FS orphan file cleanup

### DIFF
--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -55,7 +55,7 @@ export = ts.identity<yargs.CommandModule<{}, Partial<ProjectOptions> & CLIOption
 				describe: "Manually select Rojo configuration file",
 			}),
 
-	handler: argv => {
+	handler: async argv => {
 		// Attempt to retrieve TypeScript configuration JSON path
 		let tsConfigPath: string | undefined = path.resolve(argv.project);
 		if (!fs.existsSync(tsConfigPath) || !fs.statSync(tsConfigPath).isFile()) {
@@ -77,7 +77,7 @@ export = ts.identity<yargs.CommandModule<{}, Partial<ProjectOptions> & CLIOption
 			try {
 				// Attempt to build the project
 				const project = new Project(tsConfigPath, projectOptions);
-				project.cleanup();
+				await project.cleanup();
 				project.compile();
 			} catch (e) {
 				// Catch recognized errors

--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -77,6 +77,7 @@ export = ts.identity<yargs.CommandModule<{}, Partial<ProjectOptions> & CLIOption
 			try {
 				// Attempt to build the project
 				const project = new Project(tsConfigPath, projectOptions);
+				project.cleanup();
 				project.compile();
 			} catch (e) {
 				// Catch recognized errors

--- a/src/Project/Project.ts
+++ b/src/Project/Project.ts
@@ -17,6 +17,7 @@ import {
 	transformSourceFile,
 	TransformState,
 } from "TSTransformer";
+import { cleanupDirRecursively } from "Shared/fsUtil";
 
 const DEFAULT_PROJECT_OPTIONS: ProjectOptions = {
 	includePath: "include",
@@ -146,6 +147,18 @@ export class Project {
 
 		// Create `PathTranslator` to ensure paths of input, output, and include paths are relative to project
 		this.pathTranslator = new PathTranslator(this.rootDir, this.outDir);
+	}
+
+	/**
+	 * Cleans up 'orphaned' files - Files which don't belong to any source file
+	 * in the out directory.
+	 */
+	public async cleanup() {
+		if (fs.pathExists(this.outDir)) {
+			await cleanupDirRecursively(this.pathTranslator, this.rootDir, this.outDir);
+		} else {
+			console.log("Fresh compile, skipping cleanup step");
+		}
 	}
 
 	/**

--- a/src/Shared/fsUtil.ts
+++ b/src/Shared/fsUtil.ts
@@ -1,4 +1,6 @@
 import path from "path";
+import fs from "fs-extra";
+import { PathTranslator } from "Shared/PathTranslator";
 
 /**
  * Checks if the `filePath` path is a descendant of the `dirPath` path.
@@ -7,4 +9,43 @@ import path from "path";
  */
 export function isPathDescendantOf(filePath: string, dirPath: string) {
 	return dirPath === filePath || !path.relative(dirPath, filePath).startsWith("..");
+}
+
+export async function isOutputFileOrphaned(translator: PathTranslator, filePath: string) {
+	const inputPaths = translator.getInputPaths(filePath);
+	for (const path of inputPaths) {
+		if (await fs.pathExists(path)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Cleanup a directory recursively
+ * @param src
+ * @param dest
+ * @param shouldClean
+ * @param dir
+ */
+export async function cleanupDirRecursively(
+	translator: PathTranslator,
+	src: string,
+	dest: string,
+	shouldClean: (translator: PathTranslator, itemPath: string) => Promise<boolean> = isOutputFileOrphaned,
+	dir = dest,
+) {
+	if (await fs.pathExists(dir)) {
+		for (const name of await fs.readdir(dir)) {
+			const itemPath = path.join(dir, name);
+			if ((await fs.stat(itemPath)).isDirectory()) {
+				await cleanupDirRecursively(translator, src, dest, shouldClean, itemPath);
+			}
+			if (await shouldClean(translator, itemPath)) {
+				await fs.remove(itemPath);
+				console.log("remove", itemPath);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Cleans out any files or folders that don't have a matching file/folder in `rootDir`. 

Basic working implementation, subject to change.