### PR TITLE
Add RenderState.line(), adds indent, semis and "\n" automatically.

### DIFF
--- a/src/LuaRenderer/RenderState.ts
+++ b/src/LuaRenderer/RenderState.ts
@@ -74,16 +74,32 @@ export class RenderState {
 	}
 
 	/**
+	 * Adds a newline to the end of the string.
+	 * @param text The text.
+	 */
+	public newline(text: string) {
+		return text + "\n";
+	}
+
+	/**
+	 * Prefixes the text with the current indent.
+	 * @param text The text.
+	 */
+	public indented(text: string) {
+		return this.indent + text;
+	}
+
+	/**
 	 * Renders a line, adding the current indent, a semicolon if necessary, and "\n".
 	 * @param text The content of the line.
 	 * @param endNode Node used to determine if a semicolon should be added. Undefined means no semi will be added.
 	 */
 	public line(text: string, endNode?: lua.Statement) {
-		let result = this.indent + text;
+		let result = this.indented(text);
 		if (endNode) {
 			result += getEnding(this, endNode);
 		}
-		result += "\n";
+		result = this.newline(result);
 		return result;
 	}
 

--- a/src/LuaRenderer/RenderState.ts
+++ b/src/LuaRenderer/RenderState.ts
@@ -74,8 +74,9 @@ export class RenderState {
 	}
 
 	/**
-	 * Renders a line, adding the current indent and "\n".
-	 * @param text The content of the line
+	 * Renders a line, adding the current indent, a semicolon if necessary, and "\n".
+	 * @param text The content of the line.
+	 * @param endNode Node used to determine if a semicolon should be added. Undefined means no semi will be added.
 	 */
 	public line(text: string, endNode?: lua.Statement) {
 		let result = this.indent + text;

--- a/src/LuaRenderer/RenderState.ts
+++ b/src/LuaRenderer/RenderState.ts
@@ -1,12 +1,14 @@
 import * as lua from "LuaAST";
 import { assert } from "Shared/util/assert";
 import { getOrSetDefault } from "Shared/util/getOrSetDefault";
+import { getEnding } from "LuaRenderer/util/getEnding";
 
+const INDENT_CHARACTER = "\t";
 /**
  * Represents the state of a rendering process.
  */
 export class RenderState {
-	public indent = "";
+	private indent = "";
 	private scopeStack: Array<number> = [0];
 	private seenTempNodes = new Map<lua.TemporaryIdentifier, string>();
 	private readonly listNodesStack = new Array<lua.ListNode<lua.Statement>>();
@@ -15,14 +17,14 @@ export class RenderState {
 	 * Pushes an indent to the current indent level.
 	 */
 	private pushIndent() {
-		this.indent += "\t";
+		this.indent += INDENT_CHARACTER;
 	}
 
 	/**
 	 * Pops an indent from the current indent level.
 	 */
 	private popIndent() {
-		this.indent = this.indent.substr(1);
+		this.indent = this.indent.substr(INDENT_CHARACTER.length);
 	}
 
 	/**
@@ -69,6 +71,19 @@ export class RenderState {
 	 */
 	public popListNode() {
 		return this.listNodesStack.pop();
+	}
+
+	/**
+	 * Renders a line, adding the current indent and "\n".
+	 * @param text The content of the line
+	 */
+	public line(text: string, endNode?: lua.Statement) {
+		let result = this.indent + text;
+		if (endNode) {
+			result += getEnding(this, endNode);
+		}
+		result += "\n";
+		return result;
 	}
 
 	/**

--- a/src/LuaRenderer/RenderState.ts
+++ b/src/LuaRenderer/RenderState.ts
@@ -4,6 +4,8 @@ import { getOrSetDefault } from "Shared/util/getOrSetDefault";
 import { getEnding } from "LuaRenderer/util/getEnding";
 
 const INDENT_CHARACTER = "\t";
+const INDENT_CHARACTER_LENGTH = INDENT_CHARACTER.length;
+
 /**
  * Represents the state of a rendering process.
  */
@@ -24,7 +26,7 @@ export class RenderState {
 	 * Pops an indent from the current indent level.
 	 */
 	private popIndent() {
-		this.indent = this.indent.substr(INDENT_CHARACTER.length);
+		this.indent = this.indent.substr(INDENT_CHARACTER_LENGTH);
 	}
 
 	/**

--- a/src/LuaRenderer/nodes/expressions/renderFunctionExpression.ts
+++ b/src/LuaRenderer/nodes/expressions/renderFunctionExpression.ts
@@ -9,8 +9,8 @@ export function renderFunctionExpression(state: RenderState, node: lua.FunctionE
 	}
 
 	let result = "";
-	result += `function(${renderParameters(state, node)})\n`;
+	result += state.newline(`function(${renderParameters(state, node)})`);
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + `end`;
+	result += state.indented(`end`);
 	return result;
 }

--- a/src/LuaRenderer/nodes/expressions/renderMap.ts
+++ b/src/LuaRenderer/nodes/expressions/renderMap.ts
@@ -8,8 +8,8 @@ export function renderMap(state: RenderState, node: lua.Map) {
 
 	let result = "{\n";
 	state.block(() => {
-		lua.list.forEach(node.fields, field => (result += state.indent + `${render(state, field)},\n`));
+		lua.list.forEach(node.fields, field => (result += state.line(`${render(state, field)},`)));
 	});
-	result += state.indent + "}";
+	result += state.indented("}");
 	return result;
 }

--- a/src/LuaRenderer/nodes/expressions/renderMixedTable.ts
+++ b/src/LuaRenderer/nodes/expressions/renderMixedTable.ts
@@ -8,8 +8,8 @@ export function renderMixedTable(state: RenderState, node: lua.MixedTable) {
 
 	let result = "{\n";
 	state.block(() => {
-		lua.list.forEach(node.fields, field => (result += state.indent + `${render(state, field)},\n`));
+		lua.list.forEach(node.fields, field => (result += state.line(`${render(state, field)},`)));
 	});
-	result += state.indent + "}";
+	result += state.indented("}");
 	return result;
 }

--- a/src/LuaRenderer/nodes/expressions/renderSet.ts
+++ b/src/LuaRenderer/nodes/expressions/renderSet.ts
@@ -8,8 +8,8 @@ export function renderSet(state: RenderState, node: lua.Set) {
 
 	let result = "{\n";
 	state.block(() => {
-		lua.list.forEach(node.members, member => (result += state.indent + `[${render(state, member)}] = true,\n`));
+		lua.list.forEach(node.members, member => (result += state.line(`[${render(state, member)}] = true,`)));
 	});
-	result += state.indent + "}";
+	result += state.indented("}");
 	return result;
 }

--- a/src/LuaRenderer/nodes/expressions/renderUnaryExpression.ts
+++ b/src/LuaRenderer/nodes/expressions/renderUnaryExpression.ts
@@ -23,6 +23,7 @@ function needsSpace(expression: lua.Expression, operator: lua.UnaryOperator) {
 
 	// "--" will create a comment!
 	if (lua.isUnaryExpression(expression) && expression.operator === "-") {
+		// previous expression was also "-"
 		return true;
 	}
 

--- a/src/LuaRenderer/nodes/statements/renderAssignment.ts
+++ b/src/LuaRenderer/nodes/statements/renderAssignment.ts
@@ -1,11 +1,10 @@
 import * as lua from "LuaAST";
 import { render, RenderState } from "LuaRenderer";
-import { getEnding } from "LuaRenderer/util/getEnding";
 
 export function renderAssignment(state: RenderState, node: lua.Assignment) {
 	const leftStr = lua.list.isList(node.left)
 		? lua.list.mapToArray(node.left, id => render(state, id)).join(", ")
 		: render(state, node.left);
 	const rightStr = render(state, node.right);
-	return state.indent + `${leftStr} = ${rightStr}${getEnding(state, node)}\n`;
+	return state.line(`${leftStr} = ${rightStr}`, node);
 }

--- a/src/LuaRenderer/nodes/statements/renderBreakStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderBreakStatement.ts
@@ -2,5 +2,5 @@ import * as lua from "LuaAST";
 import { RenderState } from "LuaRenderer";
 
 export function renderBreakStatement(state: RenderState, node: lua.BreakStatement) {
-	return state.indent + `break\n`;
+	return state.line(`break`);
 }

--- a/src/LuaRenderer/nodes/statements/renderCallStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderCallStatement.ts
@@ -1,7 +1,6 @@
 import * as lua from "LuaAST";
 import { render, RenderState } from "LuaRenderer";
-import { getEnding } from "LuaRenderer/util/getEnding";
 
 export function renderCallStatement(state: RenderState, node: lua.CallStatement) {
-	return state.indent + `${render(state, node.expression)}${getEnding(state, node)}\n`;
+	return state.line(`${render(state, node.expression)}`, node);
 }

--- a/src/LuaRenderer/nodes/statements/renderComment.ts
+++ b/src/LuaRenderer/nodes/statements/renderComment.ts
@@ -4,6 +4,6 @@ import { RenderState } from "LuaRenderer";
 export function renderComment(state: RenderState, node: lua.Comment) {
 	return node.text
 		.split("\n")
-		.map(value => state.indent + `--${value}\n`)
+		.map(value => state.line(`--${value}`))
 		.join("");
 }

--- a/src/LuaRenderer/nodes/statements/renderContinueStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderContinueStatement.ts
@@ -2,5 +2,5 @@ import * as lua from "LuaAST";
 import { RenderState } from "LuaRenderer";
 
 export function renderContinueStatement(state: RenderState, node: lua.ContinueStatement) {
-	return state.indent + `continue\n`;
+	return state.line(`continue`);
 }

--- a/src/LuaRenderer/nodes/statements/renderDoStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderDoStatement.ts
@@ -4,8 +4,8 @@ import { renderStatements } from "LuaRenderer/util/renderStatements";
 
 export function renderDoStatement(state: RenderState, node: lua.DoStatement) {
 	let result = "";
-	result += state.indent + "do\n";
+	result += state.line("do");
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + "end\n";
+	result += state.line("end");
 	return result;
 }

--- a/src/LuaRenderer/nodes/statements/renderForStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderForStatement.ts
@@ -11,9 +11,9 @@ export function renderForStatement(state: RenderState, node: lua.ForStatement) {
 	const expStr = render(state, node.expression);
 
 	let result = "";
-	result += state.indent + `for ${idsStr} in ${expStr} do\n`;
+	result += state.line(`for ${idsStr} in ${expStr} do`);
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + `end\n`;
+	result += state.line(`end`);
 
 	state.popScope();
 	return result;

--- a/src/LuaRenderer/nodes/statements/renderFunctionDeclaration.ts
+++ b/src/LuaRenderer/nodes/statements/renderFunctionDeclaration.ts
@@ -1,16 +1,17 @@
 import * as lua from "LuaAST";
+import { assert } from "Shared/util/assert";
 import { render, RenderState } from "LuaRenderer";
 import { renderParameters } from "LuaRenderer/util/renderParameters";
 import { renderStatements } from "LuaRenderer/util/renderStatements";
 
 export function renderFunctionDeclaration(state: RenderState, node: lua.FunctionDeclaration) {
-	const hasLocal = node.localize && lua.isAnyIdentifier(node.name);
+	const hasLocal = node.localize && assert(lua.isAnyIdentifier(node.name), "local function cannot be a property");
 	const nameStr = render(state, node.name);
 	const paramStr = renderParameters(state, node);
 
 	let result = "";
-	result += state.indent + `${hasLocal ? "local " : ""}function ${nameStr}(${paramStr})\n`;
+	result += state.line(`${hasLocal ? "local " : ""}function ${nameStr}(${paramStr})`);
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + `end\n`;
+	result += state.line(`end`);
 	return result;
 }

--- a/src/LuaRenderer/nodes/statements/renderIfStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderIfStatement.ts
@@ -4,7 +4,7 @@ import { renderStatements } from "LuaRenderer/util/renderStatements";
 
 function renderShorthandIfStatement(state: RenderState, node: lua.IfStatement) {
 	const statementStr = renderStatements(state, node.statements).trim();
-	return state.indent + `if ${render(state, node.condition)} then ${statementStr} end\n`;
+	return state.line(`if ${render(state, node.condition)} then ${statementStr} end`);
 }
 
 /** must be if X == nil then X = Y end */
@@ -30,7 +30,7 @@ export function renderIfStatement(state: RenderState, node: lua.IfStatement) {
 
 	let result = "";
 
-	result += state.indent + `if ${render(state, node.condition)} then\n`;
+	result += state.line(`if ${render(state, node.condition)} then`);
 	if (node.statements) {
 		result += state.scope(() => renderStatements(state, node.statements));
 	}
@@ -38,18 +38,18 @@ export function renderIfStatement(state: RenderState, node: lua.IfStatement) {
 	let currentElseBody = node.elseBody;
 	while (lua.isNode(currentElseBody)) {
 		const statements = currentElseBody.statements;
-		result += state.indent + `elseif ${render(state, currentElseBody.condition)} then\n`;
+		result += state.line(`elseif ${render(state, currentElseBody.condition)} then`);
 		result += state.scope(() => renderStatements(state, statements));
 		currentElseBody = currentElseBody.elseBody;
 	}
 
 	if (currentElseBody && currentElseBody.head) {
-		result += state.indent + `else\n`;
+		result += state.line(`else`);
 		const statements = currentElseBody;
 		result += state.scope(() => renderStatements(state, statements));
 	}
 
-	result += state.indent + `end\n`;
+	result += state.line(`end`);
 
 	return result;
 }

--- a/src/LuaRenderer/nodes/statements/renderMethodDeclaration.ts
+++ b/src/LuaRenderer/nodes/statements/renderMethodDeclaration.ts
@@ -5,9 +5,8 @@ import { renderStatements } from "LuaRenderer/util/renderStatements";
 
 export function renderMethodDeclaration(state: RenderState, node: lua.MethodDeclaration) {
 	let result = "";
-	result +=
-		state.indent + `function ${render(state, node.expression)}:${node.name}(${renderParameters(state, node)})\n`;
+	result += state.line(`function ${render(state, node.expression)}:${node.name}(${renderParameters(state, node)})`);
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + `end\n`;
+	result += state.line(`end`);
 	return result;
 }

--- a/src/LuaRenderer/nodes/statements/renderNumericForStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderNumericForStatement.ts
@@ -17,9 +17,9 @@ export function renderNumericForStatement(state: RenderState, node: lua.NumericF
 	}
 
 	let result = "";
-	result += state.indent + `for ${idStr} = ${predicateStr} do\n`;
+	result += state.line(`for ${idStr} = ${predicateStr} do`);
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + `end\n`;
+	result += state.line(`end`);
 
 	state.popScope();
 	return result;

--- a/src/LuaRenderer/nodes/statements/renderRepeatStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderRepeatStatement.ts
@@ -4,8 +4,8 @@ import { renderStatements } from "LuaRenderer/util/renderStatements";
 
 export function renderRepeatStatement(state: RenderState, node: lua.RepeatStatement) {
 	let result = "";
-	result += state.indent + `repeat\n`;
+	result += state.line(`repeat`);
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + `until ${render(state, node.condition)}\n`;
+	result += state.line(`until ${render(state, node.condition)}`);
 	return result;
 }

--- a/src/LuaRenderer/nodes/statements/renderReturnStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderReturnStatement.ts
@@ -5,5 +5,5 @@ export function renderReturnStatement(state: RenderState, node: lua.ReturnStatem
 	const expStr = lua.list.isList(node.expression)
 		? lua.list.mapToArray(node.expression, exp => render(state, exp)).join(", ")
 		: render(state, node.expression);
-	return state.indent + `return ${expStr}\n`;
+	return state.line(`return ${expStr}`);
 }

--- a/src/LuaRenderer/nodes/statements/renderVariableDeclaration.ts
+++ b/src/LuaRenderer/nodes/statements/renderVariableDeclaration.ts
@@ -1,6 +1,5 @@
 import * as lua from "LuaAST";
 import { render, RenderState } from "LuaRenderer";
-import { getEnding } from "LuaRenderer/util/getEnding";
 
 export function renderVariableDeclaration(state: RenderState, node: lua.VariableDeclaration) {
 	const leftStr = lua.list.isList(node.left)
@@ -8,8 +7,8 @@ export function renderVariableDeclaration(state: RenderState, node: lua.Variable
 		: render(state, node.left);
 	if (node.right) {
 		const rightStr = render(state, node.right);
-		return state.indent + `local ${leftStr} = ${rightStr}${getEnding(state, node)}\n`;
+		return state.line(`local ${leftStr} = ${rightStr}`, node);
 	} else {
-		return state.indent + `local ${leftStr}${getEnding(state, node)}\n`;
+		return state.line(`local ${leftStr}`, node);
 	}
 }

--- a/src/LuaRenderer/nodes/statements/renderWhileStatement.ts
+++ b/src/LuaRenderer/nodes/statements/renderWhileStatement.ts
@@ -4,8 +4,8 @@ import { renderStatements } from "LuaRenderer/util/renderStatements";
 
 export function renderWhileStatement(state: RenderState, node: lua.WhileStatement) {
 	let result = "";
-	result += state.indent + `while ${render(state, node.condition)} do\n`;
+	result += state.line(`while ${render(state, node.condition)} do`);
 	result += state.scope(() => renderStatements(state, node.statements));
-	result += state.indent + `end\n`;
+	result += state.line(`end`);
 	return result;
 }


### PR DESCRIPTION
Indents made more centralised. Only touched inside RenderState.
Semicolons (determined by util/getEnding) also only used in one place.