### PR TITLE
Simplify map constructor macro

### DIFF
--- a/src/LuaAST/types/nodes.d.ts
+++ b/src/LuaAST/types/nodes.d.ts
@@ -99,8 +99,8 @@ export interface UnaryExpression extends lua.Expression<lua.SyntaxKind.UnaryExpr
 	expression: lua.Expression;
 }
 
-export interface Array extends lua.Expression<lua.SyntaxKind.Array> {
-	members: lua.List<lua.Expression>;
+export interface Array<T extends lua.Expression = lua.Expression> extends lua.Expression<lua.SyntaxKind.Array> {
+	members: lua.List<T>;
 }
 
 export interface Map extends lua.Expression<lua.SyntaxKind.Map> {

--- a/src/TSTransformer/macros/constructorMacros.ts
+++ b/src/TSTransformer/macros/constructorMacros.ts
@@ -12,7 +12,7 @@ function wrapWeak(state: TransformState, node: ts.NewExpression, macro: Construc
 	});
 }
 
-function isFlatMap(expression: lua.Expression): expression is lua.Array<lua.Array<lua.Expression>> {
+function isFlatMap(expression: lua.Expression): expression is lua.Array<lua.Array> {
 	if (lua.isArray(expression)) {
 		return lua.list.every(expression.members, member => lua.isArray(member));
 	}


### PR DESCRIPTION
added a type generic to lua.Array, defaults to lua.Expression which creates same behaviour as before.
`lua.id("value")` may conflict with already scoped variables, better to use a tempid.