### PR TITLE
200+ Locals Fix

### DIFF
--- a/src/LuaAST/impl/List.ts
+++ b/src/LuaAST/impl/List.ts
@@ -260,4 +260,11 @@ export namespace list {
 			newNode.next = origNext;
 		}
 	}
+
+	export function findTail<T extends lua.Node>(node: lua.ListNode<T>) {
+		while (node.next) {
+			node = node.next;
+		}
+		return node;
+	}
 }

--- a/src/LuaRenderer/nodes/expressions/renderFunctionExpression.ts
+++ b/src/LuaRenderer/nodes/expressions/renderFunctionExpression.ts
@@ -10,7 +10,9 @@ export function renderFunctionExpression(state: RenderState, node: lua.FunctionE
 
 	let result = "";
 	result += state.newline(`function(${renderParameters(state, node)})`);
+	state.pushLocalStack();
 	result += state.scope(() => renderStatements(state, node.statements));
+	state.popLocalStack();
 	result += state.indented(`end`);
 	return result;
 }

--- a/src/LuaRenderer/nodes/statements/renderFunctionDeclaration.ts
+++ b/src/LuaRenderer/nodes/statements/renderFunctionDeclaration.ts
@@ -13,7 +13,9 @@ export function renderFunctionDeclaration(state: RenderState, node: lua.Function
 
 	let result = "";
 	result += state.line(`${node.localize ? "local " : ""}function ${nameStr}(${paramStr})`);
+	state.pushLocalStack();
 	result += state.scope(() => renderStatements(state, node.statements));
+	state.popLocalStack();
 	result += state.line(`end`);
 	return result;
 }

--- a/src/LuaRenderer/nodes/statements/renderMethodDeclaration.ts
+++ b/src/LuaRenderer/nodes/statements/renderMethodDeclaration.ts
@@ -6,7 +6,9 @@ import { renderStatements } from "LuaRenderer/util/renderStatements";
 export function renderMethodDeclaration(state: RenderState, node: lua.MethodDeclaration) {
 	let result = "";
 	result += state.line(`function ${render(state, node.expression)}:${node.name}(${renderParameters(state, node)})`);
+	state.pushLocalStack();
 	result += state.scope(() => renderStatements(state, node.statements));
+	state.popLocalStack();
 	result += state.line(`end`);
 	return result;
 }

--- a/src/LuaRenderer/util/renderStatements.ts
+++ b/src/LuaRenderer/util/renderStatements.ts
@@ -2,6 +2,17 @@ import * as lua from "LuaAST";
 import { render, RenderState } from "LuaRenderer";
 import { assert } from "Shared/util/assert";
 
+const MAX_LOCALS = 200;
+
+function countLocals(statement: lua.Statement) {
+	if (lua.isVariableDeclaration(statement)) {
+		return lua.list.isList(statement.left) ? lua.list.size(statement.left) : 1;
+	} else if (lua.isFunctionDeclaration(statement)) {
+		return statement.localize ? 1 : 0;
+	}
+	return 0;
+}
+
 /**
  * Renders the given list of statements.
  *
@@ -15,12 +26,45 @@ export function renderStatements(state: RenderState, statements: lua.List<lua.St
 	let canAddNewStatement = true;
 	while (listNode !== undefined) {
 		assert(canAddNewStatement, "Cannot render statement after break or return!");
+
+		let amtLocals = countLocals(listNode.value);
+		if (state.getLocals() + amtLocals > MAX_LOCALS) {
+			// reset amtLocals, because this is now a doStatement
+			amtLocals = 0;
+			statements.tail = listNode.prev;
+
+			const innerStatements = lua.list.make<lua.Statement>();
+			innerStatements.head = listNode;
+			innerStatements.tail = lua.list.findTail(listNode);
+
+			lua.list.push(
+				statements,
+				lua.create(lua.SyntaxKind.CallStatement, {
+					expression: lua.create(lua.SyntaxKind.CallExpression, {
+						expression: lua.create(lua.SyntaxKind.ParenthesizedExpression, {
+							expression: lua.create(lua.SyntaxKind.FunctionExpression, {
+								hasDotDotDot: false,
+								parameters: lua.list.make(),
+								statements: innerStatements,
+							}),
+						}),
+						args: lua.list.make(),
+					}),
+				}),
+			);
+
+			listNode = statements.tail!;
+		}
+
+		state.addLocals(amtLocals);
+
 		state.pushListNode(listNode);
 		const statement = listNode.value;
 		result += render(state, statement);
+		state.popListNode();
+
 		canAddNewStatement = !lua.isFinalStatement(statement);
 		listNode = listNode.next;
-		state.popListNode();
 	}
 	return result;
 }


### PR DESCRIPTION
Attempts to "solve" the 200+ locals problem by creating nested immediately invoked function expressions (IIFEs). This seems to work for now, but fails under an edge case:

```TS
export {};
print([1, 2, 3].pop());
const v1 = 0;
// const v2-v455 = 0;
const v456 = 0;
print(v456);
```
```Lua
-- Compiled with roblox-ts v0.4.0
local _0 = { 1, 2, 3 }
-- ▼ Array.pop ▼
local _1 = #_0
local _2 = _0[_1]
_0[_1] = nil
-- ▲ Array.pop ▲
print(_2)
local v1 = 0
-- local v2-196 = 0
local v197 = 0
(function()
    local v198 = 0
    -- local v199-396 = 0
    local v397 = 0
    (function()
        local v398 = 0
        -- local v399-455 = 0
        local v456 = 0
        print(v456)
    end)()
end)()
```

If you hit the 200+ marker inside of a loop, `break`/`continue` will not work if they come after that point (because they're now inside a different function).

Making this work completely might be tricky.. but this is better than nothing?