### PR TITLE
Ban `...` for items with a custom Symbol.iterator

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -83,6 +83,7 @@ export const diagnostics = {
 	noSpreadDestructuring: diagnostic("Operator `...` is not supported for destructuring!"),
 	noFunctionExpressionName: diagnostic("Function expression names are not supported!"),
 	noPrecedingSpreadElement: diagnostic("Spread element must come last in a list of arguments!"),
+	noCustomIteratorSpread: diagnostic("Spread elements with a custom [Symbol.iterator]() method are not supported!"),
 	noDestructureAssignmentExpression: diagnostic(
 		"Cannot destructure LuaTuple<T> expression outside of an ExpressionStatement!",
 	),

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -63,6 +63,10 @@ export function isLuaTupleType(state: TransformState, type: ts.Type) {
 	return type.aliasSymbol === state.macroManager.getSymbolOrThrow(SYMBOL_NAMES.LuaTuple);
 }
 
+export function isSpreadableType(state: TransformState, type: ts.Type) {
+	return isLuaTupleType(state, type) || isArrayType(state, type);
+}
+
 export function isNumberType(type: ts.Type) {
 	return isSomeType(
 		type,


### PR DESCRIPTION
examples: string, or any class with a custom \[Symbol.iterator]()
Can be implemented later. Solves https://discordapp.com/channels/476080952636997633/494540040991539200/719847328588103781