### PR TITLE
add string.includes macro

### DIFF
--- a/src/LuauAST/impl/globals.ts
+++ b/src/LuauAST/impl/globals.ts
@@ -29,6 +29,7 @@ export const globals = {
 		find: property(STRING_ID, "find"),
 		format: property(STRING_ID, "format"),
 		gmatch: property(STRING_ID, "gmatch"),
+		gsub: property(STRING_ID, "gsub"),
 		match: property(STRING_ID, "match"),
 		rep: property(STRING_ID, "rep"),
 		split: property(STRING_ID, "split"),

--- a/src/TSTransformer/README.md
+++ b/src/TSTransformer/README.md
@@ -206,7 +206,7 @@ In other words, TS AST -> Luau AST
 -   [ ] String.endsWith()
 -   [x] String.find()
 -   [x] String.format()
--   [ ] String.includes()
+-   [x] String.includes()
 -   [ ] String.indexOf()
 -   [ ] String.padEnd()
 -   [ ] String.padStart()

--- a/src/TSTransformer/README.md
+++ b/src/TSTransformer/README.md
@@ -207,7 +207,7 @@ In other words, TS AST -> Luau AST
 -   [x] String.find()
 -   [x] String.format()
 -   [x] String.includes()
--   [ ] String.indexOf()
+-   [x] String.indexOf()
 -   [ ] String.padEnd()
 -   [ ] String.padStart()
 -   [x] String.size()

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -259,37 +259,15 @@ function makeCopyMethod(iterator: luau.Identifier, makeExpression: PropertyCallM
 }
 
 const findMacro = makeStringCallback(luau.globals.string.find, [0, 1]);
-const findStringOccurenceMacro: PropertyCallMacro = (state, node, expression) => {
-	const tempId = luau.tempId();
-	const string = luau.create(luau.SyntaxKind.CallExpression, {
-		expression: luau.globals.string.gsub,
-		args: luau.list.make(
-			transformExpression(state, node.arguments[0]),
-			luau.string("%^%$%(%)%%%.%[%]%*%+%-%?"), // matches all literal magic characters
-			luau.create(luau.SyntaxKind.FunctionExpression, {
-				parameters: luau.list.make(tempId),
-				hasDotDotDot: false,
-				statements: luau.list.make(
-					luau.create(luau.SyntaxKind.ReturnStatement, {
-						expression: luau.binary(luau.string("%"), "..", tempId),
-					}),
-				),
-			}),
-		),
-	});
-	return luau.create(luau.SyntaxKind.CallExpression, {
+const findStringOccurenceMacro: PropertyCallMacro = (state, node, expression) =>
+	luau.create(luau.SyntaxKind.CallExpression, {
 		expression: luau.globals.string.find,
 		args: luau.list.make(
-			node.arguments[1]
-				? luau.create(luau.SyntaxKind.CallExpression, {
-						expression: luau.globals.string.sub,
-						args: luau.list.make(expression, offset(transformExpression(state, node.arguments[1]), 1)),
-				  })
-				: expression,
-			string,
+			expression, // base string
+			transformExpression(state, node.arguments[0]), // search string
+			node.arguments[1] ? offset(transformExpression(state, node.arguments[1]), 1) : luau.number(1),
 		),
 	});
-};
 
 const STRING_CALLBACKS: MacroList<PropertyCallMacro> = {
 	size,
@@ -313,8 +291,13 @@ const STRING_CALLBACKS: MacroList<PropertyCallMacro> = {
 			right: luau.nil(),
 		}),
 	indexOf: (state, node, expression) => {
+		// pushToVar to avoid LuaTuple unpacking into the usage of the result
 		const result = state.pushToVar(findStringOccurenceMacro(state, node, expression));
-		return luau.binary(luau.binary(result, "~=", luau.nil()), "and", luau.binary(result, "or", luau.number(-1)));
+		return luau.binary(
+			luau.binary(result, "~=", luau.nil()),
+			"and",
+			luau.binary(offset(result, -1), "or", luau.number(-1)),
+		);
 	},
 };
 

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -266,6 +266,7 @@ const findStringOccurenceMacro: PropertyCallMacro = (state, node, expression) =>
 			expression, // base string
 			transformExpression(state, node.arguments[0]), // search string
 			node.arguments[1] ? offset(transformExpression(state, node.arguments[1]), 1) : luau.number(1),
+			luau.bool(true),
 		),
 	});
 


### PR DESCRIPTION
Replicates native node.js behaviour (types do that too)
`print("abc".includes("%b", 2))` will compile to
```lua
print(string.find(string.sub("abc", 3), string.gsub("%b", "%^%$%(%)%%%.%[%]%*%+%-%?", function(_0)
	return "%" .. _0
end)) ~= nil)
```
`string.sub("abc", 3)` is offset 1 of the second argument, which is "indexFrom". As usual, JS is 0-based, lua is 1-based.
```
string.gsub("%b", "%^%$%(%)%%%.%[%]%*%+%-%?", function(_0)
	return "%" .. _0
end))
```
This is a little bit of magic, what it does is prefix all the magic characters in the substring with `%` to escape them, so they're treated as the literal characters.
Then `string.find(...) ~= nil` checks if any match was found.
