### PR TITLE
Support void expressions

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -72,7 +72,6 @@ export const diagnostics = {
 		"`typeof` operator is not supported!",
 		suggestion("Use `typeIs(value, type)` or `typeOf(value)` instead."),
 	),
-	noVoidExpression: diagnostic("`void` operator is not supported!"),
 	noRegex: diagnostic("Regular expressions are not supported!"),
 
 	// banned features

--- a/src/TSTransformer/README.md
+++ b/src/TSTransformer/README.md
@@ -47,6 +47,7 @@ In other words, TS AST -> Luau AST
 -   [x] OmittedExpression
 -   [x] ThisExpression
 -   [x] SuperExpression
+-   [x] VoidExpression
 -   [x] JsxSelfClosingElement
 -   [x] JsxExpression
 

--- a/src/TSTransformer/nodes/expressions/transformExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformExpression.ts
@@ -32,6 +32,7 @@ import {
 	transformPostfixUnaryExpression,
 	transformPrefixUnaryExpression,
 } from "TSTransformer/nodes/expressions/transformUnaryExpression";
+import { transformVoidExpression } from "TSTransformer/nodes/expressions/transformVoidExpression";
 import { getKindName } from "TSTransformer/util/getKindName";
 import { transformJsxElement } from "TSTransformer/nodes/expressions/transformJsxElement";
 import { transformJsxSelfClosingElement } from "TSTransformer/nodes/expressions/transformJsxSelfClosingElement";
@@ -50,7 +51,6 @@ const TRANSFORMER_BY_KIND = new Map<ts.SyntaxKind, ExpressionTransformer>([
 	[ts.SyntaxKind.NullKeyword, DIAGNOSTIC(diagnostics.noNullLiteral)],
 	[ts.SyntaxKind.PrivateIdentifier, DIAGNOSTIC(diagnostics.noPrivateIdentifier)],
 	[ts.SyntaxKind.TypeOfExpression, DIAGNOSTIC(diagnostics.noTypeOfExpression)],
-	[ts.SyntaxKind.VoidExpression, DIAGNOSTIC(diagnostics.noVoidExpression)],
 	[ts.SyntaxKind.RegularExpressionLiteral, DIAGNOSTIC(diagnostics.noRegex)],
 
 	// regular transforms
@@ -83,6 +83,7 @@ const TRANSFORMER_BY_KIND = new Map<ts.SyntaxKind, ExpressionTransformer>([
 	[ts.SyntaxKind.TemplateExpression, transformTemplateExpression],
 	[ts.SyntaxKind.ThisKeyword, transformThisExpression],
 	[ts.SyntaxKind.TrueKeyword, transformTrueKeyword],
+	[ts.SyntaxKind.VoidExpression, transformVoidExpression],
 ]);
 
 export function transformExpression(state: TransformState, node: ts.Expression): luau.Expression {

--- a/src/TSTransformer/nodes/expressions/transformVoidExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformVoidExpression.ts
@@ -1,0 +1,10 @@
+import ts from "byots";
+import luau from "LuauAST";
+import { TransformState } from "TSTransformer";
+import { transformExpressionStatementInner } from "TSTransformer/nodes/statements/transformExpressionStatement";
+import { skipDownwards } from "TSTransformer/util/traversal";
+
+export function transformVoidExpression(state: TransformState, node: ts.VoidExpression) {
+	state.prereqList(transformExpressionStatementInner(state, skipDownwards(node.expression)));
+	return luau.create(luau.SyntaxKind.NilLiteral, {});
+}


### PR DESCRIPTION
Support [void expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void) (to increase coverage over the TS language).

Example usage:
```ts
arr.forEach(val => f(val));      // (1)  the return values of `f(val)` are propagated (
arr.forEach(val => { f(val); }); // (2)  okay
arr.forEach(val => void f(val)); // (3)  okay
```