### PR TITLE
Fix export let diagnostic

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -89,7 +89,7 @@ export const diagnostics = {
 	noDestructureAssignmentExpression: diagnostic(
 		"Cannot destructure LuaTuple<T> expression outside of an ExpressionStatement!",
 	),
-	noExportAssignmentLet: diagnostic("Cannot use `export =` on a `let` variable!", suggestion("Use `const` instead.")),
+	noExportAssignmentLet: diagnostic("Cannot use `export` on a `let` variable!", suggestion("Use `const` instead.")),
 	noExportLetAlias: diagnostic("Exports defined with `let` cannot use aliases!"),
 	noGlobalThis: diagnostic("`globalThis` is not supported!"),
 	noArguments: diagnostic("`arguments` is not supported!"),


### PR DESCRIPTION
Also thrown on `export default a`, so the `export =` causes confusion