### PR TITLE
Fix operator precedence bugs

### DIFF
--- a/src/LuauRenderer/nodes/expressions/renderBinaryExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderBinaryExpression.ts
@@ -1,6 +1,13 @@
 import luau from "LuauAST";
 import { render, RenderState } from "LuauRenderer";
+import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
 export function renderBinaryExpression(state: RenderState, node: luau.BinaryExpression) {
-	return `${render(state, node.left)} ${node.operator} ${render(state, node.right)}`;
+	let result = `${render(state, node.left)} ${node.operator} ${render(state, node.right)}`;
+
+	if (needsParentheses(node)) {
+		result = `(${result})`;
+	}
+
+	return result;
 }

--- a/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
@@ -8,11 +8,6 @@ function needsInnerParentheses(node: luau.UnaryExpression) {
 		return true;
 	}
 
-	// we should do -(a + b) instead of -a + b
-	if (luau.isBinaryExpression(node.expression)) {
-		return true;
-	}
-
 	return false;
 }
 

--- a/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
@@ -1,28 +1,29 @@
 import luau from "LuauAST";
 import { render, RenderState } from "LuauRenderer";
+import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
-function needsParentheses(expression: luau.Expression, operator: luau.UnaryOperator) {
+function needsInnerParentheses(node: luau.UnaryExpression) {
 	// #{} and -{} are invalid
-	if ((operator === "#" || operator === "-") && luau.isTable(expression)) {
+	if ((node.operator === "#" || node.operator === "-") && luau.isTable(node.expression)) {
 		return true;
 	}
 
 	// we should do -(a + b) instead of -a + b
-	if (luau.isBinaryExpression(expression)) {
+	if (luau.isBinaryExpression(node.expression)) {
 		return true;
 	}
 
 	return false;
 }
 
-function needsSpace(expression: luau.Expression, operator: luau.UnaryOperator) {
+function needsSpace(node: luau.UnaryExpression) {
 	// not always needs a space
-	if (operator === "not") {
+	if (node.operator === "not") {
 		return true;
 	}
 
 	// "--" will create a comment!
-	if (luau.isUnaryExpression(expression) && expression.operator === "-") {
+	if (luau.isUnaryExpression(node.expression) && node.expression.operator === "-") {
 		// previous expression was also "-"
 		return true;
 	}
@@ -34,13 +35,19 @@ export function renderUnaryExpression(state: RenderState, node: luau.UnaryExpres
 	let expStr = render(state, node.expression);
 	let opStr = node.operator;
 
-	if (needsSpace(node.expression, node.operator)) {
+	if (needsSpace(node)) {
 		opStr += " ";
 	}
 
-	if (needsParentheses(node.expression, node.operator)) {
+	if (needsInnerParentheses(node)) {
 		expStr = `(${expStr})`;
 	}
 
-	return `${opStr}${expStr}`;
+	let result = `${opStr}${expStr}`;
+
+	if (needsParentheses(node)) {
+		result = `(${result})`;
+	}
+
+	return result;
 }

--- a/src/LuauRenderer/util/needsParentheses.ts
+++ b/src/LuauRenderer/util/needsParentheses.ts
@@ -1,0 +1,47 @@
+import luau from "LuauAST";
+
+// https://www.lua.org/manual/5.1/manual.html#2.5.6
+/*
+	1. or
+	2. and
+	3. <     >     <=    >=    ~=    ==
+	4. ..
+	5. +     -
+	6. *     /     %
+	7. not   #     - (unary)
+	8. ^
+*/
+
+const UNARY_OPERATOR_PRECEDENCE: { [K in luau.UnaryOperator]: number } = {
+	not: 7,
+	"#": 7,
+	"-": 7,
+};
+
+const BINARY_OPERATOR_PRECEDENCE: { [K in luau.BinaryOperator]: number } = {
+	or: 1,
+	and: 2,
+	"<": 3,
+	">": 3,
+	"<=": 3,
+	">=": 3,
+	"~=": 3,
+	"==": 3,
+	"..": 4,
+	"+": 5,
+	"-": 5,
+	"*": 6,
+	"/": 6,
+	"%": 6,
+	"^": 8,
+};
+
+export function needsParentheses(node: luau.BinaryExpression | luau.UnaryExpression) {
+	if (node.parent && luau.isBinaryExpression(node.parent)) {
+		const precedence = luau.isBinaryExpression(node)
+			? BINARY_OPERATOR_PRECEDENCE[node.operator]
+			: UNARY_OPERATOR_PRECEDENCE[node.operator];
+		return precedence < BINARY_OPERATOR_PRECEDENCE[node.parent.operator];
+	}
+	return false;
+}

--- a/src/LuauRenderer/util/needsParentheses.ts
+++ b/src/LuauRenderer/util/needsParentheses.ts
@@ -36,12 +36,17 @@ const BINARY_OPERATOR_PRECEDENCE: { [K in luau.BinaryOperator]: number } = {
 	"^": 8,
 };
 
+function getPrecedence(node: luau.BinaryExpression | luau.UnaryExpression) {
+	if (luau.isBinaryExpression(node)) {
+		return BINARY_OPERATOR_PRECEDENCE[node.operator];
+	} else {
+		return UNARY_OPERATOR_PRECEDENCE[node.operator];
+	}
+}
+
 export function needsParentheses(node: luau.BinaryExpression | luau.UnaryExpression) {
-	if (node.parent && luau.isBinaryExpression(node.parent)) {
-		const precedence = luau.isBinaryExpression(node)
-			? BINARY_OPERATOR_PRECEDENCE[node.operator]
-			: UNARY_OPERATOR_PRECEDENCE[node.operator];
-		return precedence < BINARY_OPERATOR_PRECEDENCE[node.parent.operator];
+	if (node.parent && (luau.isBinaryExpression(node.parent) || luau.isUnaryExpression(node.parent))) {
+		return getPrecedence(node) < getPrecedence(node.parent);
 	}
 	return false;
 }

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -9,13 +9,6 @@ import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import { offset } from "TSTransformer/util/offset";
 
-function wrapParenthesesIfBinary(expression: luau.Expression) {
-	if (luau.isBinaryExpression(expression)) {
-		return luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression });
-	}
-	return expression;
-}
-
 function ipairs(expression: luau.Expression): luau.Expression {
 	return luau.create(luau.SyntaxKind.CallExpression, {
 		expression: luau.globals.ipairs,
@@ -48,7 +41,7 @@ function makeMathMethod(operator: luau.BinaryOperator): PropertyCallMacro {
 		const [right, prereqs] = state.capture(() => transformExpression(state, node.arguments[0]));
 		const left = luau.list.isEmpty(prereqs) ? expression : state.pushToVar(expression);
 		state.prereqList(prereqs);
-		return luau.binary(wrapParenthesesIfBinary(left), operator, wrapParenthesesIfBinary(right));
+		return luau.binary(left, operator, right);
 	};
 }
 


### PR DESCRIPTION
Adds parentheses when needed to avoid operator precedence bugs.


## Input
```TS
print([1, 2].size() ** 3);
print(`abc: ${undefined || "a"}`);
```

## Before (Broken)
```Lua
print(#({ 1, 2 }) ^ 3)
print("abc: " .. nil or "a")
```

## After (Fixed)
```Lua
print((#({ 1, 2 })) ^ 3)
print("abc: " .. (nil or "a"))
```

Fixes #1095 