### PR TITLE
Add support for ts.DeleteExpression

### DIFF
--- a/src/TSTransformer/nodes/expressions/transformDeleteExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformDeleteExpression.ts
@@ -1,0 +1,7 @@
+import ts from "byots";
+import { TransformState } from "TSTransformer";
+import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
+
+export function transformDeleteExpression(state: TransformState, node: ts.DeleteExpression) {
+	return transformExpression(state, node.expression);
+}

--- a/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
@@ -7,6 +7,7 @@ import { transformOptionalChain } from "TSTransformer/nodes/transformOptionalCha
 import { addOneIfArrayType } from "TSTransformer/util/addOneIfArrayType";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { isMethod } from "TSTransformer/util/isMethod";
+import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import { offset } from "TSTransformer/util/offset";
 import { getFirstDefinedSymbol, isLuaTupleType } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
@@ -79,7 +80,11 @@ export function transformElementAccessExpressionInner(
 				right: luau.nil(),
 			}),
 		);
-		return luau.bool(true);
+		if (isUsedAsStatement(node.parent)) {
+			return luau.nil();
+		} else {
+			return luau.bool(true);
+		}
 	}
 
 	return luau.create(luau.SyntaxKind.ComputedIndexExpression, {

--- a/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
@@ -82,11 +82,7 @@ export function transformElementAccessExpressionInner(
 				right: luau.nil(),
 			}),
 		);
-		if (isUsedAsStatement(parent)) {
-			return luau.nil();
-		} else {
-			return luau.bool(true);
-		}
+		return isUsedAsStatement(parent) ? luau.nil() : luau.bool(true);
 	}
 
 	return luau.create(luau.SyntaxKind.ComputedIndexExpression, {

--- a/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
@@ -68,6 +68,20 @@ export function transformElementAccessExpressionInner(
 		return luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression });
 	}
 
+	if (ts.isDeleteExpression(node.parent)) {
+		state.prereq(
+			luau.create(luau.SyntaxKind.Assignment, {
+				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+					expression: convertToIndexableExpression(expression),
+					index: addOneIfArrayType(state, expType, index),
+				}),
+				operator: "=",
+				right: luau.nil(),
+			}),
+		);
+		return luau.bool(true);
+	}
+
 	return luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 		expression: convertToIndexableExpression(expression),
 		index: addOneIfArrayType(state, expType, index),

--- a/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
@@ -9,6 +9,7 @@ import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexa
 import { isMethod } from "TSTransformer/util/isMethod";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import { offset } from "TSTransformer/util/offset";
+import { skipUpwards } from "TSTransformer/util/traversal";
 import { getFirstDefinedSymbol, isLuaTupleType } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 
@@ -69,7 +70,8 @@ export function transformElementAccessExpressionInner(
 		return luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression });
 	}
 
-	if (ts.isDeleteExpression(node.parent)) {
+	const parent = skipUpwards(node).parent;
+	if (ts.isDeleteExpression(parent)) {
 		state.prereq(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
@@ -80,7 +82,7 @@ export function transformElementAccessExpressionInner(
 				right: luau.nil(),
 			}),
 		);
-		if (isUsedAsStatement(node.parent)) {
+		if (isUsedAsStatement(parent)) {
 			return luau.nil();
 		} else {
 			return luau.bool(true);

--- a/src/TSTransformer/nodes/expressions/transformExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformExpression.ts
@@ -11,6 +11,7 @@ import { transformFalseKeyword, transformTrueKeyword } from "TSTransformer/nodes
 import { transformCallExpression } from "TSTransformer/nodes/expressions/transformCallExpression";
 import { transformClassExpression } from "TSTransformer/nodes/expressions/transformClassExpression";
 import { transformConditionalExpression } from "TSTransformer/nodes/expressions/transformConditionalExpression";
+import { transformDeleteExpression } from "TSTransformer/nodes/expressions/transformDeleteExpression";
 import { transformElementAccessExpression } from "TSTransformer/nodes/expressions/transformElementAccessExpression";
 import { transformFunctionExpression } from "TSTransformer/nodes/expressions/transformFunctionExpression";
 import { transformIdentifier } from "TSTransformer/nodes/expressions/transformIdentifier";
@@ -46,7 +47,6 @@ type ExpressionTransformer = (state: TransformState, node: any) => luau.Expressi
 
 const TRANSFORMER_BY_KIND = new Map<ts.SyntaxKind, ExpressionTransformer>([
 	// banned expressions
-	[ts.SyntaxKind.DeleteExpression, DIAGNOSTIC(diagnostics.noDeleteExpression)],
 	[ts.SyntaxKind.NullKeyword, DIAGNOSTIC(diagnostics.noNullLiteral)],
 	[ts.SyntaxKind.PrivateIdentifier, DIAGNOSTIC(diagnostics.noPrivateIdentifier)],
 	[ts.SyntaxKind.TypeOfExpression, DIAGNOSTIC(diagnostics.noTypeOfExpression)],
@@ -61,6 +61,7 @@ const TRANSFORMER_BY_KIND = new Map<ts.SyntaxKind, ExpressionTransformer>([
 	[ts.SyntaxKind.CallExpression, transformCallExpression],
 	[ts.SyntaxKind.ClassExpression, transformClassExpression],
 	[ts.SyntaxKind.ConditionalExpression, transformConditionalExpression],
+	[ts.SyntaxKind.DeleteExpression, transformDeleteExpression],
 	[ts.SyntaxKind.ElementAccessExpression, transformElementAccessExpression],
 	[ts.SyntaxKind.FalseKeyword, transformFalseKeyword],
 	[ts.SyntaxKind.FunctionExpression, transformFunctionExpression],

--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -5,6 +5,7 @@ import { TransformState } from "TSTransformer";
 import { transformOptionalChain } from "TSTransformer/nodes/transformOptionalChain";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { isMethod } from "TSTransformer/util/isMethod";
+import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import { getFirstDefinedSymbol } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 
@@ -49,7 +50,11 @@ export function transformPropertyAccessExpressionInner(
 				right: luau.nil(),
 			}),
 		);
-		return luau.bool(true);
+		if (isUsedAsStatement(node.parent)) {
+			return luau.nil();
+		} else {
+			return luau.bool(true);
+		}
 	}
 
 	return luau.create(luau.SyntaxKind.PropertyAccessExpression, {

--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -52,11 +52,7 @@ export function transformPropertyAccessExpressionInner(
 				right: luau.nil(),
 			}),
 		);
-		if (isUsedAsStatement(parent)) {
-			return luau.nil();
-		} else {
-			return luau.bool(true);
-		}
+		return isUsedAsStatement(parent) ? luau.nil() : luau.bool(true);
 	}
 
 	return luau.create(luau.SyntaxKind.PropertyAccessExpression, {

--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -6,6 +6,7 @@ import { transformOptionalChain } from "TSTransformer/nodes/transformOptionalCha
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { isMethod } from "TSTransformer/util/isMethod";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
+import { skipUpwards } from "TSTransformer/util/traversal";
 import { getFirstDefinedSymbol } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 
@@ -39,7 +40,8 @@ export function transformPropertyAccessExpressionInner(
 		return typeof constantValue === "string" ? luau.string(constantValue) : luau.number(constantValue);
 	}
 
-	if (ts.isDeleteExpression(node.parent)) {
+	const parent = skipUpwards(node).parent;
+	if (ts.isDeleteExpression(parent)) {
 		state.prereq(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.PropertyAccessExpression, {
@@ -50,7 +52,7 @@ export function transformPropertyAccessExpressionInner(
 				right: luau.nil(),
 			}),
 		);
-		if (isUsedAsStatement(node.parent)) {
+		if (isUsedAsStatement(parent)) {
 			return luau.nil();
 		} else {
 			return luau.bool(true);

--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -38,6 +38,20 @@ export function transformPropertyAccessExpressionInner(
 		return typeof constantValue === "string" ? luau.string(constantValue) : luau.number(constantValue);
 	}
 
+	if (ts.isDeleteExpression(node.parent)) {
+		state.prereq(
+			luau.create(luau.SyntaxKind.Assignment, {
+				left: luau.create(luau.SyntaxKind.PropertyAccessExpression, {
+					expression: convertToIndexableExpression(expression),
+					name,
+				}),
+				operator: "=",
+				right: luau.nil(),
+			}),
+		);
+		return luau.bool(true);
+	}
+
 	return luau.create(luau.SyntaxKind.PropertyAccessExpression, {
 		expression: convertToIndexableExpression(expression),
 		name,


### PR DESCRIPTION
```TS
declare const obj1: { a: { b?: number } };
declare const obj2: { a?: { b?: number } };
```

```Lua
-- delete obj1.a.b;
obj1.a.b = nil
-- print(delete obj1.a.b);
obj1.a.b = nil
print(true)
-- delete obj1["a"]["b"];
obj1.a.b = nil
-- print(delete obj1["a"]["b"]);
obj1.a.b = nil
print(true)
-- delete obj2.a?.b;
local _0 = obj2.a
if _0 ~= nil then
	_0.b = nil
end
-- print(delete obj2.a?.b);
local _1 = obj2.a
if _1 ~= nil then
	_1.b = nil
	_1 = true
end
print(_1)
-- delete obj2["a"]?.["b"];
local _2 = obj2.a
if _2 ~= nil then
	_2.b = nil
end
-- print(delete obj2["a"]?.["b"]);
local _3 = obj2.a
if _3 ~= nil then
	_3.b = nil
	_3 = true
end
print(_3)
```