### PR TITLE
Update default.project.json

### DIFF
--- a/templates/game/default.project.json
+++ b/templates/game/default.project.json
@@ -28,6 +28,18 @@
 					"$path": "out/client"
 				}
 			}
+		},
+		"HttpService": {
+			"$className": "HttpService",
+			"$properties": {
+				"HttpEnabled": true
+			}
+		},
+		"SoundService": {
+			"$className": "SoundService",
+			"$properties": {
+				"RespectFilteringEnabled": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
`SoundService.RespectFilteringEnabled` should be true for all new projects so a client cannot arbitrarily play a sound that all other clients can hear.

`HttpService.HttpEnabled` should *probably* be true for all new projects since it is common that `rojo serve` to be used, specifically after the first `rojo build`.

Should default Lighting properties also be specified to be consistent with what a default Roblox place file specifies when created in Roblox Studio?