### PR TITLE
Write only changed

### DIFF
--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -82,6 +82,10 @@ export = ts.identity<yargs.CommandModule<{}, Partial<ProjectOptions> & ProjectFl
 				default: false,
 				describe: "logs changes to truthiness evaluation from Lua truthiness rules",
 			})
+			.option("writeOnlyChanged", {
+				boolean: true,
+				default: false,
+			})
 			// DO NOT PROVIDE DEFAULTS BELOW HERE, USE DEFAULT_PROJECT_OPTIONS
 			.option("type", {
 				choices: [ProjectType.Game, ProjectType.Model, ProjectType.Package] as const,
@@ -120,7 +124,7 @@ export = ts.identity<yargs.CommandModule<{}, Partial<ProjectOptions> & ProjectFl
 				const services = createProjectServices(program, data);
 				cleanup(services.pathTranslator);
 				copyInclude(data);
-				copyFiles(services, new Set(getRootDirs(program.getCompilerOptions())));
+				copyFiles(data, services, new Set(getRootDirs(program.getCompilerOptions())));
 				const emitResult = compileFiles(program.getProgram(), data, services, getChangedSourceFiles(program));
 				for (const diagnostic of emitResult.diagnostics) {
 					diagnosticReporter(diagnostic);

--- a/src/CLI/commands/init.ts
+++ b/src/CLI/commands/init.ts
@@ -234,6 +234,7 @@ async function init(argv: yargs.Arguments<InitOptions>, mode: InitMode) {
 				usePolling: false,
 				verbose: false,
 				watch: false,
+				writeOnlyChanged: false,
 				$0: argv.$0,
 				_: argv._,
 			}) as never,

--- a/src/CLI/test.ts
+++ b/src/CLI/test.ts
@@ -22,6 +22,7 @@ describe("should compile tests project", () => {
 			usePolling: false,
 			verbose: false,
 			watch: false,
+			writeOnlyChanged: false,
 		},
 	);
 	const program = createProjectProgram(data);
@@ -29,7 +30,8 @@ describe("should compile tests project", () => {
 
 	it("should copy include files", () => copyInclude(data));
 
-	it("should copy non-compiled files", () => copyFiles(services, new Set(getRootDirs(program.getCompilerOptions()))));
+	it("should copy non-compiled files", () =>
+		copyFiles(data, services, new Set(getRootDirs(program.getCompilerOptions()))));
 
 	for (const sourceFile of getChangedSourceFiles(program)) {
 		const fileName = path.relative(process.cwd(), sourceFile.fileName);

--- a/src/Project/classes/VirtualProject.ts
+++ b/src/Project/classes/VirtualProject.ts
@@ -50,6 +50,7 @@ export class VirtualProject {
 			projectPath: PROJECT_DIR,
 			rojoConfigPath: undefined,
 			tsConfigPath: "",
+			writeOnlyChanged: false,
 		};
 
 		this.compilerOptions = {

--- a/src/Project/functions/compileFiles.ts
+++ b/src/Project/functions/compileFiles.ts
@@ -140,7 +140,9 @@ export function compileFiles(
 		benchmarkIfVerbose("writing compiled files", () => {
 			for (const { sourceFile, source } of fileWriteQueue) {
 				const outPath = services.pathTranslator.getOutputPath(sourceFile.fileName);
-				fs.outputFileSync(outPath, source);
+				if (!fs.pathExistsSync(outPath) || fs.readFileSync(outPath).toString() !== source) {
+					fs.outputFileSync(outPath, source);
+				}
 				if (compilerOptions.declaration) {
 					program.emit(sourceFile, ts.sys.writeFile, undefined, true, {
 						afterDeclarations: [transformTypeReferenceDirectives, transformPaths],

--- a/src/Project/functions/compileFiles.ts
+++ b/src/Project/functions/compileFiles.ts
@@ -140,7 +140,11 @@ export function compileFiles(
 		benchmarkIfVerbose("writing compiled files", () => {
 			for (const { sourceFile, source } of fileWriteQueue) {
 				const outPath = services.pathTranslator.getOutputPath(sourceFile.fileName);
-				if (!fs.pathExistsSync(outPath) || fs.readFileSync(outPath).toString() !== source) {
+				if (
+					!data.writeOnlyChanged ||
+					!fs.pathExistsSync(outPath) ||
+					fs.readFileSync(outPath).toString() !== source
+				) {
 					fs.outputFileSync(outPath, source);
 				}
 				if (compilerOptions.declaration) {

--- a/src/Project/functions/copyFiles.ts
+++ b/src/Project/functions/copyFiles.ts
@@ -1,11 +1,11 @@
 import { copyItem } from "Project/functions/copyItem";
-import { ProjectServices } from "Project/types";
+import { ProjectData, ProjectServices } from "Project/types";
 import { benchmarkIfVerbose } from "Shared/util/benchmark";
 
-export function copyFiles(services: ProjectServices, sources: Set<string>) {
+export function copyFiles(data: ProjectData, services: ProjectServices, sources: Set<string>) {
 	benchmarkIfVerbose("copy non-compiled files", () => {
 		for (const source of sources) {
-			copyItem(services, source);
+			copyItem(data, services, source);
 		}
 	});
 }

--- a/src/Project/functions/copyItem.ts
+++ b/src/Project/functions/copyItem.ts
@@ -1,11 +1,12 @@
 import fs from "fs-extra";
-import { ProjectServices } from "Project";
+import { ProjectData, ProjectServices } from "Project";
 import { isCompilableFile } from "Project/util/isCompilableFile";
 
-export function copyItem(services: ProjectServices, item: string) {
+export function copyItem(data: ProjectData, services: ProjectServices, item: string) {
 	fs.copySync(item, services.pathTranslator.getOutputPath(item), {
 		filter: (src, dest) => {
 			if (
+				data.writeOnlyChanged &&
 				fs.pathExistsSync(dest) &&
 				!fs.lstatSync(src).isDirectory() &&
 				fs.readFileSync(src).toString() === fs.readFileSync(dest).toString()

--- a/src/Project/functions/copyItem.ts
+++ b/src/Project/functions/copyItem.ts
@@ -4,7 +4,16 @@ import { isCompilableFile } from "Project/util/isCompilableFile";
 
 export function copyItem(services: ProjectServices, item: string) {
 	fs.copySync(item, services.pathTranslator.getOutputPath(item), {
-		filter: src => !isCompilableFile(src),
+		filter: (src, dest) => {
+			if (
+				fs.pathExistsSync(dest) &&
+				!fs.lstatSync(src).isDirectory() &&
+				fs.readFileSync(src).toString() === fs.readFileSync(dest).toString()
+			) {
+				return false;
+			}
+			return !isCompilableFile(src);
+		},
 		dereference: true,
 	});
 }

--- a/src/Project/functions/createProjectData.ts
+++ b/src/Project/functions/createProjectData.ts
@@ -66,6 +66,8 @@ export function createProjectData(
 		rojoConfigPath = RojoResolver.findRojoConfigFilePath(projectPath);
 	}
 
+	const writeOnlyChanged = flags.writeOnlyChanged;
+
 	return {
 		tsConfigPath,
 		includePath,
@@ -78,5 +80,6 @@ export function createProjectData(
 		projectOptions,
 		projectPath,
 		rojoConfigPath,
+		writeOnlyChanged,
 	};
 }

--- a/src/Project/functions/setupProjectWatchProgram.ts
+++ b/src/Project/functions/setupProjectWatchProgram.ts
@@ -82,7 +82,7 @@ export function setupProjectWatchProgram(data: ProjectData, usePolling: boolean)
 		assert(program && services);
 		cleanup(services.pathTranslator);
 		copyInclude(data);
-		copyFiles(services, new Set(getRootDirs(options)));
+		copyFiles(data, services, new Set(getRootDirs(options)));
 		const sourceFiles = getChangedSourceFiles(program);
 		const emitResult = compileFiles(program.getProgram(), data, services, sourceFiles);
 		if (!hasErrors(emitResult.diagnostics)) {
@@ -131,7 +131,7 @@ export function setupProjectWatchProgram(data: ProjectData, usePolling: boolean)
 			tryRemoveOutput(services.pathTranslator, services.pathTranslator.getOutputPath(fsPath));
 		}
 		for (const fsPath of filesToCopy) {
-			copyItem(services, fsPath);
+			copyItem(data, services, fsPath);
 		}
 		const sourceFiles = getChangedSourceFiles(program, options.incremental ? undefined : [...filesToCompile]);
 		const emitResult = compileFiles(program.getProgram(), data, services, sourceFiles);

--- a/src/Project/types.d.ts
+++ b/src/Project/types.d.ts
@@ -16,6 +16,7 @@ export interface ProjectFlags {
 	usePolling: boolean;
 	verbose: boolean;
 	watch: boolean;
+	writeOnlyChanged: boolean;
 }
 
 export interface ProjectServices {
@@ -37,4 +38,5 @@ export interface ProjectData {
 	projectPath: string;
 	rojoConfigPath: string | undefined;
 	tsConfigPath: string;
+	writeOnlyChanged: boolean;
 }


### PR DESCRIPTION
This fix resolves the issue with Rojo crashing on MacOS from being overloaded with too many file changes