### PR TITLE
Check temp id name for normal identifier

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -51,8 +51,8 @@ export function getDiagnosticId(diagnostic: ts.Diagnostic): number {
  */
 export const errors = {
 	// reserved identifiers
-	noReservedIdentifier: error(`Reserved Lua keywords cannot be used as identifiers!`),
-	noClassMetamethods: error(`Metamethods cannot be used in class definitions!`),
+	noReservedIdentifier: error("A reserved Luau keyword or `_N` cannot be used as an identifier!"),
+	noClassMetamethods: error("Metamethods cannot be used in class definitions!"),
 
 	// banned statements
 	noForInStatement: error("for-in loop statements are not supported!"),

--- a/src/Shared/util/isValidLuauIdentifier.ts
+++ b/src/Shared/util/isValidLuauIdentifier.ts
@@ -23,8 +23,9 @@ const LUAU_RESERVED_KEYWORDS = new Set([
 ]);
 
 const LUAU_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const TEMP_IDENTIFIER_REGEX = /_\d+/;
 
 /** Returns true if the given string is a valid Luau identifier */
 export function isValidLuauIdentifier(id: string) {
-	return !LUAU_RESERVED_KEYWORDS.has(id) && LUAU_IDENTIFIER_REGEX.test(id);
+	return !LUAU_RESERVED_KEYWORDS.has(id) && !TEMP_IDENTIFIER_REGEX.test(id) && LUAU_IDENTIFIER_REGEX.test(id);
 }

--- a/src/Shared/util/isValidLuauIdentifier.ts
+++ b/src/Shared/util/isValidLuauIdentifier.ts
@@ -25,7 +25,7 @@ const LUAU_RESERVED_KEYWORDS = new Set([
 const LUAU_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const TEMP_IDENTIFIER_REGEX = /_\d+/;
 
-/** Returns true if the given string is a valid Luau identifier */
+/** Returns true if the given string is a valid Luau identifier, and does not conflict with a temporary identifier */
 export function isValidLuauIdentifier(id: string) {
 	return !LUAU_RESERVED_KEYWORDS.has(id) && !TEMP_IDENTIFIER_REGEX.test(id) && LUAU_IDENTIFIER_REGEX.test(id);
 }


### PR DESCRIPTION
Adds a diagnostic when the user creates a variable in the form of `_N`, for example
```ts
for (let _0 = 0; 1 > _0; _0++) {}
```
which leads to invalid output and unexpected behaviour, in this case the `for` loop never ending.
```lua
do
	local _0 = 0
	while 1 > _0 do
		local _0 = _0
		_0 = _0
		_0 += 1
	end
end
```