### PR TITLE
Fix iterating over an IterableFunction without destructuring + tests

### DIFF
--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -380,7 +380,7 @@ export = () => {
 	});
 
 	it("should support iterator function with single return when indexing tuple as array", () => {
-		const shortIterator: IterableFunction<LuaTuple<string[]>> = (() => {}) as never;
+		const shortIterator: IterableFunction<LuaTuple<string[]>> = (() => true) as never;
 
 		for (const tuple of shortIterator) {
 			expect(tuple.size()).to.equal(1);
@@ -389,7 +389,8 @@ export = () => {
 	})
 
 	it("should support iterator function with multiple returns when indexing tuple as array", () => {
-		const longiterator: IterableFunction<LuaTuple<[string, LuaTuple<[Part, Attachment]>, Player, Model, GamePassService, boolean]>> = (() => {}) as never;
+		const longiterator: IterableFunction<LuaTuple<[string, LuaTuple<[Part, Attachment]>, Player, Model, GamePassService, boolean]>> =
+		(() => [true, true, true, true, true, true] as unknown as LuaTuple<[string, LuaTuple<[Part, Attachment]>, Player, Model, GamePassService, boolean]>) as never;
 		for (const tuple of longiterator) {
 			expect(tuple.size()).to.equal(6);
 			break;

--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -366,4 +366,33 @@ export = () => {
 			expect(d).to.equal("o");
 		}
 	});
+
+	it("should support indexing tuple as array", () => {
+		const table = {
+			a:1,
+			b:2,
+			c:3,
+		}
+
+		for (const tuple of pairs(table)) {
+			expect(tuple[1]).to.equal(table[tuple[0]]);
+		}
+	});
+
+	it("should support iterator function with single return when indexing tuple as array", () => {
+		const shortIterator: IterableFunction<LuaTuple<string[]>> = (() => {}) as never;
+
+		for (const tuple of shortIterator) {
+			expect(tuple.size()).to.equal(1);
+			break;
+		}
+	})
+
+	it("should support iterator function with multiple returns when indexing tuple as array", () => {
+		const longiterator: IterableFunction<LuaTuple<[string, LuaTuple<[Part, Attachment]>, Player, Model, GamePassService, boolean]>> = (() => {}) as never;
+		for (const tuple of longiterator) {
+			expect(tuple.size()).to.equal(6);
+			break;
+		}
+	})
 };

--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -380,7 +380,7 @@ export = () => {
 	});
 
 	it("should support iterator function with single return when indexing tuple as array", () => {
-		const shortIterator: IterableFunction<LuaTuple<string[]>> = (() => true) as never;
+		const shortIterator: IterableFunction<LuaTuple<boolean>> = (() => [true] as LuaTuple<[boolean]>) as never;
 
 		for (const tuple of shortIterator) {
 			expect(tuple.size()).to.equal(1);
@@ -389,9 +389,9 @@ export = () => {
 	})
 
 	it("should support iterator function with multiple returns when indexing tuple as array", () => {
-		const longiterator: IterableFunction<LuaTuple<[string, LuaTuple<[Part, Attachment]>, Player, Model, GamePassService, boolean]>> =
-		(() => [true, true, true, true, true, true] as unknown as LuaTuple<[string, LuaTuple<[Part, Attachment]>, Player, Model, GamePassService, boolean]>) as never;
-		for (const tuple of longiterator) {
+		const longIterator: IterableFunction<LuaTuple<[boolean, boolean, boolean, boolean, boolean, boolean]>> =
+		(() => [true, true, true, true, true, true] as LuaTuple<[boolean, boolean, boolean, boolean, boolean, boolean]>) as never;
+		for (const tuple of longIterator) {
 			expect(tuple.size()).to.equal(6);
 			break;
 		}

--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -380,7 +380,7 @@ export = () => {
 	});
 
 	it("should support iterator function with single return when indexing tuple as array", () => {
-		const shortIterator: IterableFunction<LuaTuple<boolean>> = (() => [true] as LuaTuple<[boolean]>) as never;
+		const shortIterator: IterableFunction<LuaTuple<[boolean]>> = (() => [true] as LuaTuple<[boolean]>) as never;
 
 		for (const tuple of shortIterator) {
 			expect(tuple.size()).to.equal(1);


### PR DESCRIPTION
Fixes iterating over iterable functions when assigning the output tuple to a variable like this:
```ts
for (const tuple of pairs({})) {
    print(tuple[0], tuple[1])
}
```