### PR TITLE
Fix export * as

### DIFF
--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -53,7 +53,7 @@ function getIgnoredExportSymbols(state: TransformState, sourceFile: ts.SourceFil
 				}
 			} else if (ts.isNamespaceExport(statement.exportClause)) {
 				// export * as id from "./module";
-				const idSymbol = state.getOriginalSymbol(statement.exportClause.name);
+				const idSymbol = state.typeChecker.getSymbolAtLocation(statement.exportClause.name);
 				if (idSymbol) {
 					ignoredSymbols.add(idSymbol);
 				}


### PR DESCRIPTION
```ts
export * as foo from "@rbxts/services";
```
incorrectly compiles to
```ts
exports.foo = TS.import(script, TS.getModule(script, "services"))
exports.foo = foo
```