### PR TITLE
Add contextual info to the 'noRojoData' diagnostic

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -49,10 +49,10 @@ function diagnosticWithContext<T>(
 		}
 
 		if (contextFormatter) {
-			messages.concat(contextFormatter(context));
+			messages = messages.concat(contextFormatter(context));
 		}
 
-		return createDiagnosticWithLocation(result.id, messages.filter(x => x.length > 0).join("\n"), category, node);
+		return createDiagnosticWithLocation(result.id, messages.join("\n"), category, node);
 	};
 	result.id = id++;
 	return result;

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -49,7 +49,7 @@ function diagnosticWithContext<T>(
 		}
 
 		if (contextFormatter) {
-			messages = messages.concat(contextFormatter(context));
+			messages.push(...contextFormatter(context));
 		}
 
 		return createDiagnosticWithLocation(result.id, messages.join("\n"), category, node);

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -3,10 +3,12 @@ import kleur from "kleur";
 import { createDiagnosticWithLocation } from "Shared/util/createDiagnosticWithLocation";
 import { createTextDiagnostic } from "Shared/util/createTextDiagnostic";
 
-export type DiagnosticFactory = {
-	(node: ts.Node): ts.DiagnosticWithLocation;
+export type DiagnosticFactory<T = void> = {
+	(node: ts.Node, context: T): ts.DiagnosticWithLocation;
 	id: number;
 };
+
+type DiagnosticContextFormatter<T> = (ctx: T) => Array<string>;
 
 const REPO_URL = "https://github.com/roblox-ts/roblox-ts";
 
@@ -19,16 +21,38 @@ function issue(id: number) {
 }
 
 let id = 0;
+
 /**
  * Returns a `DiagnosticFactory` that includes a function used to generate a readable message for the diagnostic.
  * @param messages The list of messages to include in the error report.
  */
-function diagnostic(category: ts.DiagnosticCategory, ...messages: Array<string>) {
-	const result = (node: ts.Node) => {
+function diagnostic(category: ts.DiagnosticCategory, ...messages: Array<string>): DiagnosticFactory {
+	return diagnosticWithContext<void>(category, undefined, ...messages);
+}
+
+/**
+ * Returns a `DiagnosticFactory` that includes a function used to generate a readable message for the diagnostic.
+ * The context is additonal data from the location where the diagnostic occurred that is used to generate dynamic
+ * messages.
+ * @param contextFormatter An optional function to format the context parameter for this diagnostic. The returned
+ * formatted messages are displayed last in the diagnostic report.
+ * @param messages The list of messages to include in the diagnostic report.
+ */
+function diagnosticWithContext<T>(
+	category: ts.DiagnosticCategory,
+	contextFormatter?: DiagnosticContextFormatter<T>,
+	...messages: Array<string>
+): DiagnosticFactory<T> {
+	const result = (node: ts.Node, context: T) => {
 		if (category === ts.DiagnosticCategory.Error) {
 			debugger;
 		}
-		return createDiagnosticWithLocation(result.id, messages.join("\n"), category, node);
+
+		if (contextFormatter) {
+			messages.concat(contextFormatter(context));
+		}
+
+		return createDiagnosticWithLocation(result.id, messages.filter(x => x.length > 0).join("\n"), category, node);
 	};
 	result.id = id++;
 	return result;
@@ -40,6 +64,13 @@ function diagnosticText(category: ts.DiagnosticCategory, ...messages: Array<stri
 
 function error(...messages: Array<string>): DiagnosticFactory {
 	return diagnostic(ts.DiagnosticCategory.Error, ...messages);
+}
+
+function errorWithContext<T>(
+	contextFormatter: DiagnosticContextFormatter<T>,
+	...messages: Array<string>
+): DiagnosticFactory<T> {
+	return diagnosticWithContext(ts.DiagnosticCategory.Error, contextFormatter, ...messages);
 }
 
 function warning(...messages: Array<string>): DiagnosticFactory {
@@ -143,7 +174,9 @@ export const errors = {
 		issue(1043),
 	),
 	noModuleSpecifierFile: error("Could not find file for import. Did you forget to `npm install`?"),
-	noRojoData: error("Could not find Rojo data"),
+	noRojoData: errorWithContext((path: string) => [
+		`Could not find Rojo data. There is no $path in your Rojo config that covers ${path}`,
+	]),
 	noNonModuleImport: error("Cannot import a non-ModuleScript!"),
 	noIsolatedImport: error("Attempted to import a file inside of an isolated container from outside!"),
 

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -234,7 +234,9 @@ export class TransformState {
 				const sourceOutPath = this.pathTranslator.getOutputPath(sourceFile.fileName);
 				const rbxPath = this.rojoResolver.getRbxPathFromFilePath(sourceOutPath);
 				if (!rbxPath) {
-					DiagnosticService.addDiagnostic(errors.noRojoData(sourceFile));
+					DiagnosticService.addDiagnostic(
+						errors.noRojoData(sourceFile, path.relative(this.data.projectPath, sourceOutPath)),
+					);
 					return luau.create(luau.SyntaxKind.VariableDeclaration, {
 						left: RUNTIME_LIB_ID,
 						right: luau.nil(),

--- a/src/TSTransformer/util/createImportExpression.ts
+++ b/src/TSTransformer/util/createImportExpression.ts
@@ -52,7 +52,9 @@ function getNodeModulesImport(state: TransformState, moduleSpecifier: ts.Express
 	);
 	const relativeRbxPath = state.pkgRojoResolver.getRbxPathFromFilePath(moduleOutPath);
 	if (!relativeRbxPath) {
-		DiagnosticService.addDiagnostic(errors.noRojoData(moduleSpecifier));
+		DiagnosticService.addDiagnostic(
+			errors.noRojoData(moduleSpecifier, path.relative(state.data.projectPath, moduleOutPath)),
+		);
 		return luau.emptyId();
 	}
 
@@ -86,7 +88,9 @@ export function createImportExpression(
 		const moduleOutPath = state.pathTranslator.getImportPath(virtualPath);
 		const moduleRbxPath = state.rojoResolver.getRbxPathFromFilePath(moduleOutPath);
 		if (!moduleRbxPath) {
-			DiagnosticService.addDiagnostic(errors.noRojoData(moduleSpecifier));
+			DiagnosticService.addDiagnostic(
+				errors.noRojoData(moduleSpecifier, path.relative(state.data.projectPath, moduleOutPath)),
+			);
 			return luau.emptyId();
 		}
 
@@ -99,7 +103,9 @@ export function createImportExpression(
 		const sourceOutPath = state.pathTranslator.getOutputPath(sourceFile.fileName);
 		const sourceRbxPath = state.rojoResolver.getRbxPathFromFilePath(sourceOutPath);
 		if (!sourceRbxPath) {
-			DiagnosticService.addDiagnostic(errors.noRojoData(sourceFile));
+			DiagnosticService.addDiagnostic(
+				errors.noRojoData(sourceFile, path.relative(state.data.projectPath, sourceOutPath)),
+			);
 			return luau.emptyId();
 		}
 


### PR DESCRIPTION
An attempt to solve part of #1293. Changes the 'noRojoData' diagnostic message to include the path of the expected output file that could be not be found in the Rojo project.

**Before**
![image](https://user-images.githubusercontent.com/2184244/115131218-37d71a80-9fab-11eb-8b81-4023500a111f.png)

**After**
![image](https://user-images.githubusercontent.com/2184244/115131192-0fe7b700-9fab-11eb-9b4d-5949c268921b.png)

In order to achieve this, I refactored part of the diagnostic system to support passing additional "context" values to DiagnosticFactory functions.