### PR TITLE
Create .npmignore

### DIFF
--- a/templates/package/.npmignore
+++ b/templates/package/.npmignore
@@ -1,0 +1,3 @@
+src/
+include/
+tsconfig.json


### PR DESCRIPTION
By default, creating a package with `rbxtsc init package` will create a package w/o an `.npmignore`. This makes the published tarball include a bunch of extra stuff such as `src/`, `include/`, as well as `tsconfig.json`. 

The inclusion of `src/` has broken builds for me before, so I just want to make sure this is already addressed out of the box.