### PR TITLE
Support alternative npm scopes

### DIFF
--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -61,7 +61,7 @@ local function isPlugin(object)
 end
 
 -- module resolution
-function TS.getModule(object, moduleName)
+function TS.getModule(object, moduleName, scope)
 	if RunService:IsRunning() and object:IsDescendantOf(ReplicatedFirst) then
 		warn("roblox-ts packages should not be used from ReplicatedFirst!")
 	end
@@ -90,7 +90,8 @@ function TS.getModule(object, moduleName)
 		object = object.Parent
 	until object == nil or object == globalModules
 
-	return globalModules:FindFirstChild(moduleName) or error("Could not find module: " .. moduleName, 2)
+	local scopedModules = globalModules:FindFirstChild(scope or "@rbxts");
+	return (scopedModules or globalModules):FindFirstChild(moduleName) or error("Could not find module: " .. moduleName, 2)
 end
 
 -- This is a hash which TS.import uses as a kind of linked-list-like history of [Script who Loaded] -> Library

--- a/lib/RuntimeLib.lua
+++ b/lib/RuntimeLib.lua
@@ -61,7 +61,12 @@ local function isPlugin(object)
 end
 
 -- module resolution
-function TS.getModule(object, moduleName, scope)
+function TS.getModule(object, scope, moduleName)
+	if moduleName == nil then
+		moduleName = scope
+		scope = "@rbxts"
+	end
+
 	if RunService:IsRunning() and object:IsDescendantOf(ReplicatedFirst) then
 		warn("roblox-ts packages should not be used from ReplicatedFirst!")
 	end

--- a/src/Project/functions/compileFiles.ts
+++ b/src/Project/functions/compileFiles.ts
@@ -13,7 +13,7 @@ import { hasErrors } from "Project/util/hasErrors";
 import { LogService } from "Shared/classes/LogService";
 import { PathTranslator } from "Shared/classes/PathTranslator";
 import { NetworkType, RbxPath, RojoResolver } from "Shared/classes/RojoResolver";
-import { ProjectType } from "Shared/constants";
+import { ProjectType, RBXTS_SCOPE } from "Shared/constants";
 import { ProjectData } from "Shared/types";
 import { assert } from "Shared/util/assert";
 import { benchmarkIfVerbose } from "Shared/util/benchmark";
@@ -104,8 +104,11 @@ export function compileFiles(
 		}
 	}
 
-	if (projectType !== ProjectType.Package && !rojoResolver.getRbxPathFromFilePath(data.nodeModulesPath)) {
-		return emitResultFailure("Rojo project contained no data for node_modules folder!");
+	if (
+		projectType !== ProjectType.Package &&
+		!rojoResolver.getRbxPathFromFilePath(path.join(data.nodeModulesPath, RBXTS_SCOPE))
+	) {
+		return emitResultFailure("Rojo project contained no data for node_modules/@rbxts folder!");
 	}
 
 	LogService.writeLineIfVerbose(`compiling as ${projectType}..`);

--- a/src/Project/functions/createNodeModulesPathMapping.ts
+++ b/src/Project/functions/createNodeModulesPathMapping.ts
@@ -8,7 +8,7 @@ export function createNodeModulesPathMapping(nodeModulesPath: string) {
 		// go through each org
 		for (const scope of fs.readdirSync(nodeModulesPath, { withFileTypes: true })) {
 			const scopePath = path.join(nodeModulesPath, scope.name);
-			if (scope.isDirectory()) {
+			if (scope.isDirectory() && scope.name.startsWith("@")) {
 				// map module paths
 				for (const pkgName of fs.readdirSync(scopePath)) {
 					const pkgPath = path.join(scopePath, pkgName);

--- a/src/Project/functions/createNodeModulesPathMapping.ts
+++ b/src/Project/functions/createNodeModulesPathMapping.ts
@@ -5,20 +5,29 @@ import { realPathExistsSync } from "Shared/util/realPathExistsSync";
 export function createNodeModulesPathMapping(nodeModulesPath: string) {
 	const nodeModulesPathMapping = new Map<string, string>();
 	if (fs.pathExistsSync(nodeModulesPath)) {
-		// map module paths
-		for (const pkgName of fs.readdirSync(nodeModulesPath)) {
-			const pkgPath = path.join(nodeModulesPath, pkgName);
-			const pkgJsonPath = realPathExistsSync(path.join(pkgPath, "package.json"));
-			if (pkgJsonPath !== undefined) {
-				const pkgJson = fs.readJsonSync(pkgJsonPath) as {
-					main?: string;
-					typings?: string;
-					types?: string;
-				};
-				// both "types" and "typings" are valid
-				const typesPath = pkgJson.types ?? pkgJson.typings ?? "index.d.ts";
-				if (pkgJson.main) {
-					nodeModulesPathMapping.set(path.resolve(pkgPath, typesPath), path.resolve(pkgPath, pkgJson.main));
+		// go through each org
+		for (const org of fs.readdirSync(nodeModulesPath, { withFileTypes: true })) {
+			const orgPath = path.join(nodeModulesPath, org.name);
+			if (org.isDirectory()) {
+				// map module paths
+				for (const pkgName of fs.readdirSync(orgPath)) {
+					const pkgPath = path.join(orgPath, pkgName);
+					const pkgJsonPath = realPathExistsSync(path.join(pkgPath, "package.json"));
+					if (pkgJsonPath !== undefined) {
+						const pkgJson = fs.readJsonSync(pkgJsonPath) as {
+							main?: string;
+							typings?: string;
+							types?: string;
+						};
+						// both "types" and "typings" are valid
+						const typesPath = pkgJson.types ?? pkgJson.typings ?? "index.d.ts";
+						if (pkgJson.main) {
+							nodeModulesPathMapping.set(
+								path.resolve(pkgPath, typesPath),
+								path.resolve(pkgPath, pkgJson.main),
+							);
+						}
+					}
 				}
 			}
 		}

--- a/src/Project/functions/createNodeModulesPathMapping.ts
+++ b/src/Project/functions/createNodeModulesPathMapping.ts
@@ -6,12 +6,12 @@ export function createNodeModulesPathMapping(nodeModulesPath: string) {
 	const nodeModulesPathMapping = new Map<string, string>();
 	if (fs.pathExistsSync(nodeModulesPath)) {
 		// go through each org
-		for (const org of fs.readdirSync(nodeModulesPath, { withFileTypes: true })) {
-			const orgPath = path.join(nodeModulesPath, org.name);
-			if (org.isDirectory()) {
+		for (const scope of fs.readdirSync(nodeModulesPath, { withFileTypes: true })) {
+			const scopePath = path.join(nodeModulesPath, scope.name);
+			if (scope.isDirectory()) {
 				// map module paths
-				for (const pkgName of fs.readdirSync(orgPath)) {
-					const pkgPath = path.join(orgPath, pkgName);
+				for (const pkgName of fs.readdirSync(scopePath)) {
+					const pkgPath = path.join(scopePath, pkgName);
 					const pkgJsonPath = realPathExistsSync(path.join(pkgPath, "package.json"));
 					if (pkgJsonPath !== undefined) {
 						const pkgJson = fs.readJsonSync(pkgJsonPath) as {

--- a/src/Project/functions/createProjectData.ts
+++ b/src/Project/functions/createProjectData.ts
@@ -3,10 +3,11 @@ import fs from "fs-extra";
 import path from "path";
 import { createNodeModulesPathMapping } from "Project/functions/createNodeModulesPathMapping";
 import { RojoResolver } from "Shared/classes/RojoResolver";
-import { NODE_MODULES, RBXTS_SCOPE } from "Shared/constants";
+import { NODE_MODULES } from "Shared/constants";
 import { ProjectError } from "Shared/errors/ProjectError";
 import { ProjectData, ProjectFlags, ProjectOptions } from "Shared/types";
 
+const PACKAGE_REGEX = /^@[a-z0-9-]*\//;
 const DEFAULT_PROJECT_OPTIONS: ProjectOptions = {
 	includePath: "",
 	rojo: undefined,
@@ -30,7 +31,7 @@ export function createProjectData(
 	let pkgVersion = "";
 	try {
 		const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath).toString());
-		isPackage = (pkgJson.name ?? "").startsWith(RBXTS_SCOPE + "/");
+		isPackage = PACKAGE_REGEX.test(pkgJson.name ?? "");
 		pkgVersion = pkgJson.version;
 	} catch (e) {}
 
@@ -40,7 +41,7 @@ export function createProjectData(
 	// intentionally use || here for empty string case
 	const includePath = path.resolve(projectOptions.includePath || path.join(projectPath, "include"));
 
-	const nodeModulesPath = path.join(path.dirname(pkgJsonPath), NODE_MODULES, RBXTS_SCOPE);
+	const nodeModulesPath = path.join(path.dirname(pkgJsonPath), NODE_MODULES);
 	const nodeModulesPathMapping = createNodeModulesPathMapping(nodeModulesPath);
 
 	let rojoConfigPath: string | undefined;

--- a/src/Project/functions/validateCompilerOptions.ts
+++ b/src/Project/functions/validateCompilerOptions.ts
@@ -1,6 +1,7 @@
 import ts from "byots";
 import kleur from "kleur";
 import path from "path";
+import { RBXTS_SCOPE } from "Shared/constants";
 import { ProjectError } from "Shared/errors/ProjectError";
 
 const ENFORCED_OPTIONS = {
@@ -55,8 +56,9 @@ export function validateCompilerOptions(opts: ts.CompilerOptions, nodeModulesPat
 		errors.push(`${y(`"allowSyntheticDefaultImports"`)} must be ${y(`true`)}`);
 	}
 
-	if (opts.typeRoots === undefined || !validateTypeRoots(nodeModulesPath, opts.typeRoots)) {
-		errors.push(`${y(`"typeRoots"`)} must contain ${y(nodeModulesPath)}`);
+	const rbxtsModules = path.join(nodeModulesPath, RBXTS_SCOPE);
+	if (opts.typeRoots === undefined || !validateTypeRoots(rbxtsModules, opts.typeRoots)) {
+		errors.push(`${y(`"typeRoots"`)} must contain ${y(rbxtsModules)}`);
 	}
 
 	// configurable compiler options

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -177,6 +177,8 @@ export const errors = {
 		issue(1043),
 	),
 	noModuleSpecifierFile: error("Could not find file for import. Did you forget to `npm install`?"),
+	noInvalidModule: error("You can only use npm scopes that are listed in your typeRoots."),
+	noUnscopedModule: error("You cannot use modules directly under node_modules."),
 	noRojoData: errorWithContext((path: string) => [
 		`Could not find Rojo data. There is no $path in your Rojo config that covers ${path}`,
 	]),

--- a/src/TSTransformer/classes/RoactSymbolManager.ts
+++ b/src/TSTransformer/classes/RoactSymbolManager.ts
@@ -1,6 +1,7 @@
 import ts from "byots";
 import fs from "fs-extra";
 import path from "path";
+import { RBXTS_SCOPE } from "Shared/constants";
 import { ProjectData } from "Shared/types";
 import { assert } from "Shared/util/assert";
 import { realPathExistsSync } from "Shared/util/realPathExistsSync";
@@ -43,7 +44,7 @@ export class RoactSymbolManager {
 		program: ts.Program,
 		typeChecker: ts.TypeChecker,
 	): RoactSymbolManager | undefined {
-		const pkgPath = path.join(data.nodeModulesPath, "roact");
+		const pkgPath = path.join(data.nodeModulesPath, RBXTS_SCOPE, "roact");
 		const pkgJsonPath = realPathExistsSync(path.join(pkgPath, "package.json"));
 		if (pkgJsonPath !== undefined) {
 			const pkgJson = fs.readJsonSync(pkgJsonPath) as { typings?: string; types?: string };
@@ -57,7 +58,7 @@ export class RoactSymbolManager {
 		}
 
 		// playground fallback
-		const roactIndexSourceFilePath = path.join(data.nodeModulesPath, "roact", "src", "index.d.ts");
+		const roactIndexSourceFilePath = path.join(data.nodeModulesPath, RBXTS_SCOPE, "roact", "src", "index.d.ts");
 		const roactIndexSourceFile = program.getSourceFile(roactIndexSourceFilePath);
 		if (roactIndexSourceFile) {
 			return new RoactSymbolManager(typeChecker, roactIndexSourceFile);

--- a/src/TSTransformer/util/createImportExpression.ts
+++ b/src/TSTransformer/util/createImportExpression.ts
@@ -90,8 +90,8 @@ function getNodeModulesImport(state: TransformState, moduleSpecifier: ts.Express
 	return propertyAccessExpressionChain(
 		luau.call(state.TS(moduleSpecifier.parent, "getModule"), [
 			luau.globals.script,
-			luau.string(moduleName),
 			luau.string(moduleScope),
+			luau.string(moduleName),
 		]),
 		relativeRbxPath.slice(2),
 	);


### PR DESCRIPTION
supports custom npm scopes as long as:

1. under typeRoots (node_modules/@scope)
2. the scope's path is under the node_modules using the scope's name in Rojo
e.g 
```json
"node_modules": {
	"$path": "node_modules/@rbxts",
	"@globglogabgalab": {
		"$path": "node_modules/@globglogabgalab"
	}
}
```