### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install NPM dependencies
-        run: npm install
+        run: npm ci
 
       - name: Compile and run tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Install NPM dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run ESLint
         run: npm run eslint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Install NPM dependencies
-        run: npm install
+        run: npm ci
 
       - name: Publish
         run: |


### PR DESCRIPTION
The workflows now use the faster `npm ci` instead of the `npm install` for installing packages.