### PR TITLE
Enable passing indexed functions in parameters

### DIFF
--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -2,6 +2,7 @@ import luau from "LuauAST";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { transformIndexWithoutCall } from "TSTransformer/nodes/transformIndexWithoutCall";
 import { transformOptionalChain } from "TSTransformer/nodes/transformOptionalChain";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { isMethod } from "TSTransformer/util/isMethod";
@@ -30,8 +31,7 @@ export function transformPropertyAccessExpressionInner(
 
 	const parent = skipUpwards(node).parent;
 	if (!isValidMethodIndexWithoutCall(parent) && isMethod(state, node)) {
-		DiagnosticService.addDiagnostic(errors.noIndexWithoutCall(node));
-		return luau.emptyId();
+		return transformIndexWithoutCall(state, node);
 	}
 
 	if (ts.isPrototypeAccess(node)) {

--- a/src/TSTransformer/nodes/transformIndexWithoutCall.ts
+++ b/src/TSTransformer/nodes/transformIndexWithoutCall.ts
@@ -1,0 +1,24 @@
+import luau from "LuauAST";
+import { TransformState } from "TSTransformer/classes/TransformState";
+import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
+import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
+import { PropertyAccessExpression } from "typescript";
+
+export function transformIndexWithoutCall(state: TransformState, node: PropertyAccessExpression) {
+	const statements = luau.list.make<luau.Statement>(
+		luau.create(luau.SyntaxKind.ReturnStatement, {
+			expression: luau.create(luau.SyntaxKind.MethodCallExpression, {
+				expression: convertToIndexableExpression(transformExpression(state, node.expression)),
+				name: node.name.escapedText.toString(),
+				args: luau.list.make<luau.Expression<keyof luau.ExpressionByKind>>(
+					luau.create(luau.SyntaxKind.VarArgsLiteral, {}),
+				),
+			}),
+		}),
+	);
+	return luau.create(luau.SyntaxKind.FunctionExpression, {
+		statements,
+		parameters: luau.list.make(),
+		hasDotDotDot: true,
+	});
+}

--- a/tests/src/diagnostics/noIndexWithoutCall.ts
+++ b/tests/src/diagnostics/noIndexWithoutCall.ts
@@ -1,3 +1,3 @@
 export {};
 
-game.ChildAdded.Connect(game.Destroy);
+game.ChildAdded.Connect(game["Destroy"]);


### PR DESCRIPTION
Instead of erroring with this
```typescript
function a(d: (f: string) => string) {
	return d;
}

const b = {
	c(f: string) {
		return f;
	},
};

a(b.c);
```
It will become 
```lua
local function a(d)
	return d
end
local b = {
	c = function(self, f)
		return f
	end,
}
a(function(...)
	b:c(...)
end)
```