### PR TITLE
Cleanup diagnostics

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -141,7 +141,6 @@ export const errors = {
 	noUnaryPlus: error("Unary `+` is not supported!", suggestion("Use `tonumber(x)` instead.")),
 	noNonNumberUnaryMinus: error("Unary `-` is only supported for number types!"),
 	noAwaitForOf: error("`await` is not supported in for-of loops!"),
-	noComplexForOf: error("for-of loops do not support complex variable lists!", issue(1253)),
 	noAsyncGeneratorFunctions: error("Async generator functions are not supported!"),
 	noNonStringModuleSpecifier: error("Module specifiers must be a string literal."),
 	noIterableIteration: error("Iterating on Iterable<T> is not supported! You must use a more specific type."),
@@ -150,9 +149,6 @@ export const errors = {
 		"Can't use LuaTuple<T> in a template literal expression!",
 		suggestion("Did you mean to add `[0]`?"),
 	),
-
-	// macro methods
-	noOptionalMacroCall: error("Macro methods can not be optionally called!"),
 	noMixedTypeCall: error(
 		"Attempted to call a function with mixed types! All definitions must either be a method or a callback.",
 	),
@@ -160,11 +156,8 @@ export const errors = {
 		"Cannot index a method without calling it!",
 		suggestion("Use the form `() => a.b()` instead of `a.b`."),
 	),
-	noMacroWithoutCall: error(
-		"Cannot index a macro without calling it!",
-		suggestion("Use the form `() => a.b()` instead of `a.b`."),
-	),
-	noObjectWithoutMethod: error("Cannot access `Object` without calling a function on it!"),
+
+	// macro methods
 	noConstructorMacroWithoutNew: error("Cannot index a constructor macro without using the `new` operator!"),
 	noMacroExtends: error("Cannot extend from a macro class!"),
 	noMacroUnion: error("Macro cannot be applied to a union type!"),
@@ -183,9 +176,6 @@ export const errors = {
 	noModuleSpecifierFile: error("Could not find file for import. Did you forget to `npm install`?"),
 	noInvalidModule: error("You can only use npm scopes that are listed in your typeRoots."),
 	noUnscopedModule: error("You cannot use modules directly under node_modules."),
-	noRojoData: errorWithContext((path: string) => [
-		`Could not find Rojo data. There is no $path in your Rojo config that covers ${path}`,
-	]),
 	noNonModuleImport: error("Cannot import a non-ModuleScript!"),
 	noIsolatedImport: error("Attempted to import a file inside of an isolated container from outside!"),
 
@@ -195,12 +185,15 @@ export const errors = {
 		"More info: https://reactjs.org/docs/composition-vs-inheritance.html",
 	),
 	noSuperPropertyCallRoactComponent: error("`super` is not supported inside Roact components!"),
-	noSuperConstructorRoactComponent: error(
+	missingSuperConstructorRoactComponent: error(
 		"`super(props)` must be the first statement of the constructor in a Roact component!",
 	),
 	noJsxText: error("JSX text is not supported!"),
 
 	// files
+	noRojoData: errorWithContext((path: string) => [
+		`Could not find Rojo data. There is no $path in your Rojo config that covers ${path}`,
+	]),
 	incorrectFileName: (originalFileName: string, suggestedFileName: string, fullPath: string) =>
 		errorText(
 			`Incorrect file name: \`${originalFileName}\`!`,
@@ -215,7 +208,7 @@ export const errors = {
 };
 
 export const warnings = {
-	truthyChange: (checksStr: string) => warning(`value will be checked against ${checksStr}`),
+	truthyChange: (checksStr: string) => warning(`Value will be checked against ${checksStr}`),
 	stringOffsetChange: (text: string) => warning(`String macros no longer offset inputs: ${text}`),
 	runtimeLibUsedInReplicatedFirst: warning(
 		"This statement would generate a call to the runtime library. The runtime library should not be used from ReplicatedFirst.",

--- a/src/TSTransformer/nodes/expressions/transformCallExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformCallExpression.ts
@@ -138,7 +138,7 @@ export function transformCallExpressionInner(
 
 	if (ts.isSuperCall(node)) {
 		if (isInsideRoactComponent(state, node)) {
-			DiagnosticService.addDiagnostic(errors.noSuperConstructorRoactComponent(node));
+			DiagnosticService.addDiagnostic(errors.missingSuperConstructorRoactComponent(node));
 		}
 		return luau.call(luau.property(convertToIndexableExpression(expression), "constructor"), [
 			luau.globals.self,

--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -3,11 +3,9 @@ import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { transformOptionalChain } from "TSTransformer/nodes/transformOptionalChain";
+import { addIndexDiagnostics } from "TSTransformer/util/addIndexDiagnostics";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
-import { isMethod } from "TSTransformer/util/isMethod";
-import { isValidMethodIndexWithoutCall } from "TSTransformer/util/isValidMethodIndexWithoutCall";
 import { skipUpwards } from "TSTransformer/util/traversal";
-import { getFirstDefinedSymbol } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 import ts from "typescript";
 
@@ -18,32 +16,9 @@ export function transformPropertyAccessExpressionInner(
 	name: string,
 ) {
 	validateNotAnyType(state, node.expression);
+	addIndexDiagnostics(state, node, state.typeChecker.getNonOptionalType(state.getType(node)));
 
-	const expType = state.typeChecker.getNonOptionalType(state.getType(node));
-	const symbol = getFirstDefinedSymbol(state, expType);
-	if (symbol) {
-		if (state.services.macroManager.getPropertyCallMacro(symbol)) {
-			DiagnosticService.addDiagnostic(errors.noMacroWithoutCall(node));
-			return luau.emptyId();
-		}
-	}
-
-	const parent = skipUpwards(node).parent;
-	if (!isValidMethodIndexWithoutCall(parent) && isMethod(state, node)) {
-		DiagnosticService.addDiagnostic(errors.noIndexWithoutCall(node));
-		return luau.emptyId();
-	}
-
-	if (ts.isPrototypeAccess(node)) {
-		DiagnosticService.addDiagnostic(errors.noPrototype(node));
-	}
-
-	const constantValue = state.typeChecker.getConstantValue(node);
-	if (constantValue !== undefined) {
-		return typeof constantValue === "string" ? luau.string(constantValue) : luau.number(constantValue);
-	}
-
-	if (ts.isDeleteExpression(parent)) {
+	if (ts.isDeleteExpression(skipUpwards(node).parent)) {
 		state.prereq(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.property(convertToIndexableExpression(expression), name),
@@ -60,7 +35,6 @@ export function transformPropertyAccessExpressionInner(
 export function transformPropertyAccessExpression(state: TransformState, node: ts.PropertyAccessExpression) {
 	if (ts.isSuperProperty(node)) {
 		DiagnosticService.addDiagnostic(errors.noSuperProperty(node));
-		return luau.emptyId();
 	}
 
 	return transformOptionalChain(state, node);

--- a/src/TSTransformer/nodes/transformOptionalChain.ts
+++ b/src/TSTransformer/nodes/transformOptionalChain.ts
@@ -1,7 +1,5 @@
 import luau from "LuauAST";
-import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
-import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import {
 	transformCallExpressionInner,
 	transformElementCallExpressionInner,
@@ -15,7 +13,6 @@ import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { isMethod } from "TSTransformer/util/isMethod";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import { skipDownwards } from "TSTransformer/util/traversal";
-import { getFirstDefinedSymbol } from "TSTransformer/util/types";
 import { wrapReturnIfLuaTuple } from "TSTransformer/util/wrapReturnIfLuaTuple";
 import ts from "typescript";
 
@@ -273,16 +270,6 @@ function transformOptionalChainInner(
 			const [newValue, ifStatements] = state.capture(() => {
 				let newExpression: luau.Expression;
 				if (isCompoundCall(item) && item.callOptional) {
-					const expType = state.typeChecker.getNonOptionalType(state.getType(item.node.expression));
-					const symbol = getFirstDefinedSymbol(state, expType);
-					if (symbol) {
-						const macro = state.services.macroManager.getPropertyCallMacro(symbol);
-						if (macro) {
-							DiagnosticService.addDiagnostic(errors.noOptionalMacroCall(item.node));
-							return luau.emptyId();
-						}
-					}
-
 					const args = ensureTransformOrder(state, item.args);
 					if (isMethodCall) {
 						if (isSuperCall) {

--- a/src/TSTransformer/util/addIndexDiagnostics.ts
+++ b/src/TSTransformer/util/addIndexDiagnostics.ts
@@ -1,0 +1,30 @@
+import luau from "LuauAST";
+import { errors } from "Shared/diagnostics";
+import { TransformState } from "TSTransformer";
+import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { isMethod } from "TSTransformer/util/isMethod";
+import { isValidMethodIndexWithoutCall } from "TSTransformer/util/isValidMethodIndexWithoutCall";
+import { skipUpwards } from "TSTransformer/util/traversal";
+import { getFirstDefinedSymbol } from "TSTransformer/util/types";
+import ts from "typescript";
+
+export function addIndexDiagnostics(
+	state: TransformState,
+	node: ts.PropertyAccessExpression | ts.ElementAccessExpression | ts.SignatureDeclarationBase,
+	expType: ts.Type,
+) {
+	const symbol = getFirstDefinedSymbol(state, expType);
+	if (symbol && state.services.macroManager.getPropertyCallMacro(symbol)) {
+		DiagnosticService.addDiagnostic(errors.noIndexWithoutCall(node));
+		return luau.emptyId();
+	}
+
+	if (!isValidMethodIndexWithoutCall(skipUpwards(node).parent) && isMethod(state, node)) {
+		DiagnosticService.addDiagnostic(errors.noIndexWithoutCall(node));
+		return luau.emptyId();
+	}
+
+	if (ts.isPrototypeAccess(node)) {
+		DiagnosticService.addDiagnostic(errors.noPrototype(node));
+	}
+}

--- a/src/TSTransformer/util/getConstantValueLiteral.ts
+++ b/src/TSTransformer/util/getConstantValueLiteral.ts
@@ -1,0 +1,13 @@
+import luau from "LuauAST";
+import { TransformState } from "TSTransformer";
+import ts from "typescript";
+
+export function getConstantValueLiteral(
+	state: TransformState,
+	node: ts.EnumMember | ts.PropertyAccessExpression | ts.ElementAccessExpression,
+) {
+	const constantValue = state.typeChecker.getConstantValue(node);
+	if (constantValue !== undefined) {
+		return typeof constantValue === "string" ? luau.string(constantValue) : luau.number(constantValue);
+	}
+}


### PR DESCRIPTION
- Remove no longer used ones: noComplexForOf
- Remove ones that were previously necessary but have since been made redundant: noObjectWithoutMethod, noOptionalMacroCall
- Merge identical ones: noMacroWithoutCall & noIndexWithoutCall
- Categorise noRojoData as files, not import
- Clarify noSuperConstructorRoactComponent name