### PR TITLE
Do not compare non-functions in method assignment validation

### DIFF
--- a/src/TSTransformer/util/validateMethodAssignment.ts
+++ b/src/TSTransformer/util/validateMethodAssignment.ts
@@ -8,7 +8,7 @@ import ts from "typescript";
 function hasCallSignatures(type: ts.Type) {
 	let hasCallSignatures = false;
 	walkTypes(type, t => {
-		hasCallSignatures = hasCallSignatures || t.getCallSignatures().length > 0;
+		hasCallSignatures ||= t.getCallSignatures().length > 0;
 	});
 	return hasCallSignatures;
 }


### PR DESCRIPTION
Method assign validation would incorrectly compare non-functions with functions

https://roblox-ts.com/playground/#code/GYVwdgxgLglg9mABDMAHAFFAhgawKYBciA3ogM4wBee6AlEQG5wwAmiAvogD4nlWGIwIALYAjPACcOtEuwBQclBlIVqRAIwBWaUA