### PR TITLE
Remove duplicate types to createTruthinessChecks

### DIFF
--- a/src/TSTransformer/macros/callMacros.ts
+++ b/src/TSTransformer/macros/callMacros.ts
@@ -17,7 +17,7 @@ const PRIMITIVE_LUAU_TYPES = new Set([
 
 export const CALL_MACROS: MacroList<CallMacro> = {
 	assert: (state, node, expression, args) => {
-		args[0] = createTruthinessChecks(state, args[0], node.arguments[0], state.getType(node.arguments[0]));
+		args[0] = createTruthinessChecks(state, args[0], node.arguments[0]);
 		return luau.call(luau.globals.assert, args);
 	},
 

--- a/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
@@ -10,7 +10,7 @@ export function transformConditionalExpression(state: TransformState, node: ts.C
 	const [whenFalse, whenFalsePrereqs] = state.capture(() => transformExpression(state, node.whenFalse));
 	if (luau.list.isEmpty(whenTruePrereqs) && luau.list.isEmpty(whenFalsePrereqs)) {
 		return luau.create(luau.SyntaxKind.IfExpression, {
-			condition: createTruthinessChecks(state, condition, node.condition, state.getType(node.condition)),
+			condition: createTruthinessChecks(state, condition, node.condition),
 			expression: whenTrue,
 			alternative: whenFalse,
 		});

--- a/src/TSTransformer/nodes/expressions/transformUnaryExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformUnaryExpression.ts
@@ -60,12 +60,7 @@ export function transformPrefixUnaryExpression(state: TransformState, node: ts.P
 		}
 		return luau.unary("-", transformExpression(state, node.operand));
 	} else if (node.operator === ts.SyntaxKind.ExclamationToken) {
-		const checks = createTruthinessChecks(
-			state,
-			transformExpression(state, node.operand),
-			node.operand,
-			state.getType(node.operand),
-		);
+		const checks = createTruthinessChecks(state, transformExpression(state, node.operand), node.operand);
 		return luau.unary("not", checks);
 	} else if (node.operator === ts.SyntaxKind.TildeToken) {
 		return luau.call(luau.property(luau.globals.bit32, "bnot"), [transformExpression(state, node.operand)]);

--- a/src/TSTransformer/nodes/statements/transformDoStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformDoStatement.ts
@@ -10,12 +10,7 @@ export function transformDoStatement(state: TransformState, node: ts.DoStatement
 	const statements = transformStatementList(state, getStatements(node.statement));
 
 	const [condition, conditionPrereqs] = state.capture(() =>
-		createTruthinessChecks(
-			state,
-			transformExpression(state, node.expression),
-			node.expression,
-			state.getType(node.expression),
-		),
+		createTruthinessChecks(state, transformExpression(state, node.expression), node.expression),
 	);
 
 	const repeatStatements = luau.list.make<luau.Statement>();

--- a/src/TSTransformer/nodes/statements/transformForStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForStatement.ts
@@ -247,12 +247,7 @@ export function transformForStatement(state: TransformState, node: ts.ForStateme
 	// eslint-disable-next-line prefer-const
 	let [conditionExp, conditionPrereqs] = state.capture(() => {
 		if (condition) {
-			return createTruthinessChecks(
-				state,
-				transformExpression(state, condition),
-				condition,
-				state.getType(condition),
-			);
+			return createTruthinessChecks(state, transformExpression(state, condition), condition);
 		} else {
 			return luau.bool(true);
 		}

--- a/src/TSTransformer/nodes/statements/transformIfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformIfStatement.ts
@@ -7,12 +7,7 @@ import { getStatements } from "TSTransformer/util/getStatements";
 import ts from "typescript";
 
 export function transformIfStatementInner(state: TransformState, node: ts.IfStatement): luau.IfStatement {
-	const condition = createTruthinessChecks(
-		state,
-		transformExpression(state, node.expression),
-		node.expression,
-		state.getType(node.expression),
-	);
+	const condition = createTruthinessChecks(state, transformExpression(state, node.expression), node.expression);
 
 	const statements = transformStatementList(state, getStatements(node.thenStatement));
 

--- a/src/TSTransformer/nodes/statements/transformWhileStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformWhileStatement.ts
@@ -11,12 +11,7 @@ export function transformWhileStatement(state: TransformState, node: ts.WhileSta
 
 	// eslint-disable-next-line prefer-const
 	let [conditionExp, conditionPrereqs] = state.capture(() =>
-		createTruthinessChecks(
-			state,
-			transformExpression(state, node.expression),
-			node.expression,
-			state.getType(node.expression),
-		),
+		createTruthinessChecks(state, transformExpression(state, node.expression), node.expression),
 	);
 
 	if (!luau.list.isEmpty(conditionPrereqs)) {

--- a/src/TSTransformer/nodes/transformLogicalOrCoalescingAssignmentExpression.ts
+++ b/src/TSTransformer/nodes/transformLogicalOrCoalescingAssignmentExpression.ts
@@ -59,7 +59,7 @@ function transformLogicalAndAssignmentExpression(
 
 	state.prereq(
 		luau.create(luau.SyntaxKind.IfStatement, {
-			condition: createTruthinessChecks(state, writable, left, writableType),
+			condition: createTruthinessChecks(state, writable, left),
 			statements: ifStatements,
 			elseBody: luau.list.make(),
 		}),
@@ -81,7 +81,6 @@ function transformLogicalOrAssignmentExpression(
 	left: ts.LeftHandSideExpression,
 	right: ts.Expression,
 ) {
-	const writableType = state.getType(left);
 	const writable = transformWritableExpression(state, left, true);
 	const [value, valuePreqreqs] = state.capture(() => transformExpression(state, right));
 
@@ -100,7 +99,7 @@ function transformLogicalOrAssignmentExpression(
 
 	state.prereq(
 		luau.create(luau.SyntaxKind.IfStatement, {
-			condition: luau.unary("not", createTruthinessChecks(state, writable, left, writableType)),
+			condition: luau.unary("not", createTruthinessChecks(state, writable, left)),
 			statements: ifStatements,
 			elseBody: luau.list.make(),
 		}),

--- a/src/TSTransformer/nodes/transformLogicalOrCoalescingAssignmentExpression.ts
+++ b/src/TSTransformer/nodes/transformLogicalOrCoalescingAssignmentExpression.ts
@@ -40,7 +40,6 @@ function transformLogicalAndAssignmentExpression(
 	left: ts.LeftHandSideExpression,
 	right: ts.Expression,
 ) {
-	const writableType = state.getType(left);
 	const writable = transformWritableExpression(state, left, true);
 	const [value, valuePreqreqs] = state.capture(() => transformExpression(state, right));
 

--- a/src/TSTransformer/util/createTruthinessChecks.ts
+++ b/src/TSTransformer/util/createTruthinessChecks.ts
@@ -14,12 +14,8 @@ export function willCreateTruthinessChecks(type: ts.Type) {
 	);
 }
 
-export function createTruthinessChecks(
-	state: TransformState,
-	exp: luau.Expression,
-	node: ts.Expression,
-	type: ts.Type,
-) {
+export function createTruthinessChecks(state: TransformState, exp: luau.Expression, node: ts.Expression) {
+	const type = state.getType(node);
 	const isAssignableToZero = isPossiblyType(type, isNumberLiteralType(0));
 	const isAssignableToNaN = isPossiblyType(type, isNaNType);
 	const isAssignableToEmptyString = isPossiblyType(type, isEmptyStringType);


### PR DESCRIPTION
This argument is only ever provided by `state.getType(node)`
Since this method caches results, there is no performance benefit
Instead, createTruthinessChecks can call `state.getType(node)` directly
Passing anything other than `node`'s type does not make sense, since `node` is used for reporting the truthiness check warning