### PR TITLE
Fix Luau if-expression precedence bug

### DIFF
--- a/src/LuauAST/impl/typeGuards.ts
+++ b/src/LuauAST/impl/typeGuards.ts
@@ -134,3 +134,9 @@ export const hasStatements = makeGuard(
 	luau.SyntaxKind.RepeatStatement,
 	luau.SyntaxKind.WhileStatement,
 );
+
+export const isExpressionWithPrecedence = makeGuard(
+	luau.SyntaxKind.IfExpression,
+	luau.SyntaxKind.UnaryExpression,
+	luau.SyntaxKind.BinaryExpression,
+);

--- a/src/LuauAST/types/nodes.ts
+++ b/src/LuauAST/types/nodes.ts
@@ -34,6 +34,8 @@ export type SimpleTypes =
 	| luau.NumberLiteral
 	| luau.StringLiteral;
 
+export type ExpressionWithPrecedence = luau.IfExpression | luau.UnaryExpression | luau.BinaryExpression;
+
 // expressions
 export interface NilLiteral extends luau.Expression<luau.SyntaxKind.NilLiteral> {}
 

--- a/src/LuauRenderer/nodes/expressions/renderIfExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderIfExpression.ts
@@ -1,5 +1,6 @@
 import luau from "LuauAST";
 import { render, RenderState } from "LuauRenderer";
+import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
 export function renderIfExpression(state: RenderState, node: luau.IfExpression) {
 	let result = `if ${render(state, node.condition)} then ${render(state, node.expression)} `;
@@ -13,6 +14,10 @@ export function renderIfExpression(state: RenderState, node: luau.IfExpression) 
 	}
 
 	result += `else ${render(state, currentAlternative)}`;
+
+	if (needsParentheses(node)) {
+		result = `(${result})`;
+	}
 
 	return result;
 }

--- a/src/LuauRenderer/util/needsParentheses.ts
+++ b/src/LuauRenderer/util/needsParentheses.ts
@@ -1,4 +1,5 @@
 import luau from "LuauAST";
+import { assert } from "Shared/util/assert";
 
 // https://www.lua.org/manual/5.1/manual.html#2.5.6
 /*
@@ -11,6 +12,8 @@ import luau from "LuauAST";
 	7. not   #     - (unary)
 	8. ^
 */
+
+const IF_EXPRESSION_PRECEDENCE = 1;
 
 const UNARY_OPERATOR_PRECEDENCE: { [K in luau.UnaryOperator]: number } = {
 	not: 7,
@@ -36,16 +39,20 @@ const BINARY_OPERATOR_PRECEDENCE: { [K in luau.BinaryOperator]: number } = {
 	"^": 8,
 };
 
-function getPrecedence(node: luau.BinaryExpression | luau.UnaryExpression) {
-	if (luau.isBinaryExpression(node)) {
+// are these all the expression types that need to be considered..?
+function getPrecedence(node: luau.ExpressionWithPrecedence) {
+	if (luau.isIfExpression(node)) {
+		return IF_EXPRESSION_PRECEDENCE;
+	} else if (luau.isBinaryExpression(node)) {
 		return BINARY_OPERATOR_PRECEDENCE[node.operator];
-	} else {
+	} else if (luau.isUnaryExpression(node)) {
 		return UNARY_OPERATOR_PRECEDENCE[node.operator];
 	}
+	assert(false);
 }
 
-export function needsParentheses(node: luau.BinaryExpression | luau.UnaryExpression) {
-	if (node.parent && (luau.isBinaryExpression(node.parent) || luau.isUnaryExpression(node.parent))) {
+export function needsParentheses(node: luau.ExpressionWithPrecedence) {
+	if (node.parent && luau.isExpressionWithPrecedence(node.parent)) {
 		const nodePrecedence = getPrecedence(node);
 		const parentPrecedence = getPrecedence(node.parent);
 		if (nodePrecedence < parentPrecedence) {

--- a/tests/src/tests/ternary.spec.ts
+++ b/tests/src/tests/ternary.spec.ts
@@ -34,4 +34,13 @@ export = () => {
 		expect(emptyStr ? "FAIL" : strB += "Y").to.equal("XY");
 		expect(NaN ? "FAIL" : strB += "Z").to.equal("XYZ");
 	});
+
+	it("should correctly wrap if-expressions in parentheses where needed", () => {
+		function getColorStr(on: boolean) {
+			return `${on ? "on" : "off"}Color`;
+		}
+
+		expect(getColorStr(true)).to.equal("onColor");
+		expect(getColorStr(false)).to.equal("offColor");
+	});
 };


### PR DESCRIPTION
The issue here is that we have an AST structure like:
```
luau.BinaryOperator
    luau.IfExpression
    luau.StringLiteral
```

this renders as
```lua
if condition then whenTrue else whenFalse .. "string"
```

We need to add parentheses around the if expression so it's properly treated as a "child" expression of the `luau.BinaryExpression`.

To do this, I've used the existing "operator precedence" system (via the function `needsParentheses()` in the renderer). This feels _more_ correct than just tossing parentheses around the expressions in `transformTemplateExpression()`, but I'm not 100% sure this covers all cases. Are there other expression types that also have this issue and we haven't considered them?

[playground link](https://roblox-ts.com/playground/#code/DYUwLgBA9gdhC8EwCcCuIDcAoLB6XEARqgOYBcEAzihAJaUQBEsjRqklAFlKsACZEQTWAGEowKMkZYAxrGpUaiAAYASAN6wIAfmExWFZgDMjjAL5iJyZdiA)