### PR TITLE
Add support for decorators

### DIFF
--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -391,6 +391,7 @@ export class TransformState {
 
 	public symbolToIdMap = new Map<ts.Symbol, luau.TemporaryIdentifier>();
 
+	// stores a mapping of `key` in `obj[key] = value` for classes so that the `key` can be referred to later
 	private classElementToObjectKeyMap = new Map<ts.ClassElement, luau.AnyIdentifier>();
 
 	public setClassElementObjectKey(classElement: ts.ClassElement, identifier: luau.AnyIdentifier) {

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -390,4 +390,15 @@ export class TransformState {
 	}
 
 	public symbolToIdMap = new Map<ts.Symbol, luau.TemporaryIdentifier>();
+
+	private classElementToObjectKeyMap = new Map<ts.ClassElement, luau.AnyIdentifier>();
+
+	public setClassElementObjectKey(classElement: ts.ClassElement, identifier: luau.AnyIdentifier) {
+		assert(!this.classElementToObjectKeyMap.has(classElement));
+		this.classElementToObjectKeyMap.set(classElement, identifier);
+	}
+
+	public getClassElementObjectKey(classElement: ts.ClassElement) {
+		return this.classElementToObjectKeyMap.get(classElement);
+	}
 }

--- a/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
+++ b/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
@@ -4,6 +4,7 @@ import { assert } from "Shared/util/assert";
 import { SYMBOL_NAMES, TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { transformClassConstructor } from "TSTransformer/nodes/class/transformClassConstructor";
+import { transformDecorators } from "TSTransformer/nodes/class/transformDecorators";
 import { transformPropertyDeclaration } from "TSTransformer/nodes/class/transformPropertyDeclaration";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
@@ -441,6 +442,8 @@ export function transformClassLikeDeclaration(state: TransformState, node: ts.Cl
 			}),
 		);
 	}
+
+	luau.list.pushList(statementsInner, transformDecorators(state, node, returnVar));
 
 	luau.list.push(
 		statements,

--- a/src/TSTransformer/nodes/class/transformDecorators.ts
+++ b/src/TSTransformer/nodes/class/transformDecorators.ts
@@ -5,206 +5,18 @@ import { transformExpression } from "TSTransformer/nodes/expressions/transformEx
 import { transformObjectKey } from "TSTransformer/nodes/transformObjectKey";
 import ts from "typescript";
 
-function transformMethodDecorators(
+function transformMemberDecorators(
 	state: TransformState,
-	member: ts.MethodDeclaration,
-	classId: luau.AnyIdentifier,
-): luau.List<luau.Statement> {
-	const result = luau.list.make<luau.Statement>();
-	const finalizers = luau.list.make<luau.Statement>();
-
-	const multipleDecorators = member.decorators !== undefined && member.decorators.length > 1;
-
-	const name = member.name;
-	if (name && !ts.isPrivateIdentifier(name)) {
-		for (const decorator of member.decorators ?? []) {
-			// eslint-disable-next-line no-autofix/prefer-const
-			let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
-
-			luau.list.pushList(result, prereqs);
-
-			if (multipleDecorators && !luau.isSimple(expression)) {
-				const tempId = luau.tempId("decorator");
-				luau.list.push(
-					result,
-					luau.create(luau.SyntaxKind.VariableDeclaration, {
-						left: tempId,
-						right: expression,
-					}),
-				);
-				expression = tempId;
-			}
-
-			assert(luau.isIndexableExpression(expression));
-
-			let key: luau.Expression | undefined = state.getClassElementObjectKey(member);
-			if (key === undefined) {
-				let keyPrereqs: luau.List<luau.Statement>;
-				[key, keyPrereqs] = state.capture(() => transformObjectKey(state, name));
-				luau.list.pushList(result, keyPrereqs);
-			}
-
-			const decoratorStatements = luau.list.make<luau.Statement>();
-
-			// local _descriptor = decorator(Class, "name", { value = Class.name })
-			// if _descriptor then
-			// 	Class.name = _descriptor.value
-			// end
-			const descriptorId = luau.tempId("descriptor");
-
-			luau.list.push(
-				decoratorStatements,
-				luau.create(luau.SyntaxKind.VariableDeclaration, {
-					left: descriptorId,
-					right: luau.call(expression, [
-						classId,
-						key,
-						luau.map([
-							[
-								luau.string("value"),
-								luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-									expression: classId,
-									index: key,
-								}),
-							],
-						]),
-					]),
-				}),
-			);
-
-			luau.list.push(
-				decoratorStatements,
-				luau.create(luau.SyntaxKind.IfStatement, {
-					condition: descriptorId,
-					statements: luau.list.make(
-						luau.create(luau.SyntaxKind.Assignment, {
-							left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-								expression: classId,
-								index: key,
-							}),
-							operator: "=",
-							right: luau.property(descriptorId, "value"),
-						}),
-					),
-					elseBody: luau.list.make(),
-				}),
-			);
-
-			luau.list.unshiftList(finalizers, decoratorStatements);
-		}
-	}
-
-	luau.list.pushList(result, finalizers);
-
-	return result;
-}
-
-function transformPropertyDecorators(
-	state: TransformState,
-	member: ts.PropertyDeclaration,
-	classId: luau.AnyIdentifier,
-): luau.List<luau.Statement> {
-	const result = luau.list.make<luau.Statement>();
-	const finalizers = luau.list.make<luau.Statement>();
-
-	const multipleDecorators = member.decorators !== undefined && member.decorators.length > 1;
-
-	const name = member.name;
-	if (name && !ts.isPrivateIdentifier(name)) {
-		for (const decorator of member.decorators ?? []) {
-			// eslint-disable-next-line no-autofix/prefer-const
-			let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
-
-			luau.list.pushList(result, prereqs);
-
-			if (multipleDecorators && !luau.isSimple(expression)) {
-				const tempId = luau.tempId("decorator");
-				luau.list.push(
-					result,
-					luau.create(luau.SyntaxKind.VariableDeclaration, {
-						left: tempId,
-						right: expression,
-					}),
-				);
-				expression = tempId;
-			}
-
-			assert(luau.isIndexableExpression(expression));
-
-			const [key, keyPrereqs] = state.capture(() => transformObjectKey(state, name));
-			luau.list.pushList(result, keyPrereqs);
-
-			// decorator(Class, "name")
-			luau.list.unshift(
-				finalizers,
-				luau.create(luau.SyntaxKind.CallStatement, {
-					expression: luau.call(expression, [classId, key]),
-				}),
-			);
-		}
-	}
-
-	luau.list.pushList(result, finalizers);
-
-	return result;
-}
-
-function transformParameterDecorators(
-	state: TransformState,
-	member: ts.MethodDeclaration | ts.ConstructorDeclaration,
-	classId: luau.AnyIdentifier,
-): luau.List<luau.Statement> {
-	const result = luau.list.make<luau.Statement>();
-
-	for (let i = 0; i < member.parameters.length; i++) {
-		const parameter = member.parameters[i];
-		if (ts.isIdentifier(parameter.name)) {
-			const finalizers = luau.list.make<luau.Statement>();
-			const multipleDecorators = member.decorators !== undefined && member.decorators.length > 1;
-			for (const decorator of parameter.decorators ?? []) {
-				// eslint-disable-next-line no-autofix/prefer-const
-				let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
-
-				luau.list.pushList(result, prereqs);
-
-				if (multipleDecorators && !luau.isSimple(expression)) {
-					const tempId = luau.tempId("decorator");
-					luau.list.push(
-						result,
-						luau.create(luau.SyntaxKind.VariableDeclaration, {
-							left: tempId,
-							right: expression,
-						}),
-					);
-					expression = tempId;
-				}
-
-				assert(luau.isIndexableExpression(expression));
-
-				// decorator(Class, "name", 0)
-				luau.list.unshift(
-					finalizers,
-					luau.create(luau.SyntaxKind.CallStatement, {
-						expression: luau.call(expression, [classId, luau.string(parameter.name.text), luau.number(i)]),
-					}),
-				);
-			}
-			luau.list.pushList(result, finalizers);
-		}
-	}
-
-	return result;
-}
-
-function transformClassDecorators(
-	state: TransformState,
-	node: ts.ClassLikeDeclaration,
-	classId: luau.AnyIdentifier,
+	node: ts.ClassLikeDeclaration | ts.MethodDeclaration | ts.PropertyDeclaration | ts.ParameterDeclaration,
+	callback: (expression: luau.IndexableExpression, key?: luau.Expression) => luau.List<luau.Statement>,
 ): luau.List<luau.Statement> {
 	const result = luau.list.make<luau.Statement>();
 	const finalizers = luau.list.make<luau.Statement>();
 
 	const multipleDecorators = node.decorators !== undefined && node.decorators.length > 1;
+
+	const name = node.name;
+	if (!name || ts.isPrivateIdentifier(name)) return result;
 
 	for (const decorator of node.decorators ?? []) {
 		// eslint-disable-next-line no-autofix/prefer-const
@@ -224,22 +36,141 @@ function transformClassDecorators(
 			expression = tempId;
 		}
 
-		assert(luau.isIndexableExpression(expression));
+		let key: luau.Expression | undefined;
+		if (ts.isMethodDeclaration(node) || ts.isPropertyDeclaration(node)) {
+			key = state.getClassElementObjectKey(node);
+			if (!key) {
+				let keyPrereqs: luau.List<luau.Statement>;
+				assert(!ts.isBindingPattern(name));
+				[key, keyPrereqs] = state.capture(() => transformObjectKey(state, name));
+				luau.list.pushList(result, keyPrereqs);
+			}
+		}
 
-		// Class = decorator(Class) or Class
-		luau.list.unshift(
-			finalizers,
-			luau.create(luau.SyntaxKind.Assignment, {
-				left: classId,
-				operator: "=",
-				right: luau.binary(luau.call(expression, [classId]), "or", classId),
-			}),
-		);
+		assert(luau.isIndexableExpression(expression));
+		luau.list.unshiftList(finalizers, callback(expression, key));
 	}
 
 	luau.list.pushList(result, finalizers);
 
 	return result;
+}
+
+function transformMethodDecorators(
+	state: TransformState,
+	member: ts.MethodDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	return transformMemberDecorators(state, member, (expression, key) => {
+		const result = luau.list.make<luau.Statement>();
+
+		// local _descriptor = decorator(Class, "name", { value = Class.name })
+		// if _descriptor then
+		// 	Class.name = _descriptor.value
+		// end
+
+		const descriptorId = luau.tempId("descriptor");
+
+		luau.list.push(
+			result,
+			luau.create(luau.SyntaxKind.VariableDeclaration, {
+				left: descriptorId,
+				right: luau.call(expression, [
+					classId,
+					key!,
+					luau.map([
+						[
+							luau.string("value"),
+							luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+								expression: classId,
+								index: key!,
+							}),
+						],
+					]),
+				]),
+			}),
+		);
+
+		luau.list.push(
+			result,
+			luau.create(luau.SyntaxKind.IfStatement, {
+				condition: descriptorId,
+				statements: luau.list.make(
+					luau.create(luau.SyntaxKind.Assignment, {
+						left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+							expression: classId,
+							index: key!,
+						}),
+						operator: "=",
+						right: luau.property(descriptorId, "value"),
+					}),
+				),
+				elseBody: luau.list.make(),
+			}),
+		);
+
+		return result;
+	});
+}
+
+function transformPropertyDecorators(
+	state: TransformState,
+	member: ts.PropertyDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	return transformMemberDecorators(state, member, (expression, key) =>
+		// decorator(Class, "name")
+		luau.list.make(
+			luau.create(luau.SyntaxKind.CallStatement, {
+				expression: luau.call(expression, [classId, key!]),
+			}),
+		),
+	);
+}
+
+function transformParameterDecorators(
+	state: TransformState,
+	member: ts.MethodDeclaration | ts.ConstructorDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	const result = luau.list.make<luau.Statement>();
+
+	for (let i = 0; i < member.parameters.length; i++) {
+		const parameter = member.parameters[i];
+		const name = parameter.name;
+		if (ts.isIdentifier(name)) {
+			luau.list.pushList(
+				result,
+				transformMemberDecorators(state, parameter, expression =>
+					// decorator(Class, "name", 0)
+					luau.list.make(
+						luau.create(luau.SyntaxKind.CallStatement, {
+							expression: luau.call(expression, [classId, luau.string(name.text), luau.number(i)]),
+						}),
+					),
+				),
+			);
+		}
+	}
+
+	return result;
+}
+
+function transformClassDecorators(
+	state: TransformState,
+	node: ts.ClassLikeDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	return transformMemberDecorators(state, node, expression =>
+		// Class = decorator(Class) or Class
+		luau.list.make(
+			luau.create(luau.SyntaxKind.Assignment, {
+				left: classId,
+				operator: "=",
+				right: luau.binary(luau.call(expression, [classId]), "or", classId),
+			}),
+		),
+	);
 }
 
 export function transformDecorators(

--- a/src/TSTransformer/nodes/class/transformDecorators.ts
+++ b/src/TSTransformer/nodes/class/transformDecorators.ts
@@ -1,0 +1,289 @@
+import luau from "@roblox-ts/luau-ast";
+import { assert } from "Shared/util/assert";
+import { TransformState } from "TSTransformer";
+import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
+import { transformObjectKey } from "TSTransformer/nodes/transformObjectKey";
+import ts from "typescript";
+
+function transformMethodDecorators(
+	state: TransformState,
+	member: ts.MethodDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	const result = luau.list.make<luau.Statement>();
+	const finalizers = luau.list.make<luau.Statement>();
+
+	const multipleDecorators = member.decorators !== undefined && member.decorators.length > 1;
+
+	const name = member.name;
+	if (name && !ts.isPrivateIdentifier(name)) {
+		for (const decorator of member.decorators ?? []) {
+			// eslint-disable-next-line no-autofix/prefer-const
+			let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
+
+			luau.list.pushList(result, prereqs);
+
+			if (multipleDecorators) {
+				const tempId = luau.tempId("decorator");
+				luau.list.push(
+					result,
+					luau.create(luau.SyntaxKind.VariableDeclaration, {
+						left: tempId,
+						right: expression,
+					}),
+				);
+				expression = tempId;
+			}
+
+			assert(luau.isIndexableExpression(expression));
+
+			let key: luau.Expression | undefined = state.getClassElementObjectKey(member);
+			if (key === undefined) {
+				let keyPrereqs: luau.List<luau.Statement>;
+				[key, keyPrereqs] = state.capture(() => transformObjectKey(state, name));
+				luau.list.pushList(result, keyPrereqs);
+			}
+
+			const decoratorStatements = luau.list.make<luau.Statement>();
+
+			// local _descriptor = decorator(Class, "name", { value = Class.name })
+			// if _descriptor then
+			// 	Class.name = _descriptor.value
+			// end
+			const descriptorId = luau.tempId("descriptor");
+
+			luau.list.push(
+				decoratorStatements,
+				luau.create(luau.SyntaxKind.VariableDeclaration, {
+					left: descriptorId,
+					right: luau.call(expression, [
+						classId,
+						key,
+						luau.map([
+							[
+								luau.string("value"),
+								luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+									expression: classId,
+									index: key,
+								}),
+							],
+						]),
+					]),
+				}),
+			);
+
+			luau.list.push(
+				decoratorStatements,
+				luau.create(luau.SyntaxKind.IfStatement, {
+					condition: descriptorId,
+					statements: luau.list.make(
+						luau.create(luau.SyntaxKind.Assignment, {
+							left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+								expression: classId,
+								index: key,
+							}),
+							operator: "=",
+							right: luau.property(descriptorId, "value"),
+						}),
+					),
+					elseBody: luau.list.make(),
+				}),
+			);
+
+			luau.list.unshiftList(finalizers, decoratorStatements);
+		}
+	}
+
+	luau.list.pushList(result, finalizers);
+
+	return result;
+}
+
+function transformPropertyDecorators(
+	state: TransformState,
+	member: ts.PropertyDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	const result = luau.list.make<luau.Statement>();
+	const finalizers = luau.list.make<luau.Statement>();
+
+	const multipleDecorators = member.decorators !== undefined && member.decorators.length > 1;
+
+	const name = member.name;
+	if (name && !ts.isPrivateIdentifier(name)) {
+		for (const decorator of member.decorators ?? []) {
+			// eslint-disable-next-line no-autofix/prefer-const
+			let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
+
+			luau.list.pushList(result, prereqs);
+
+			if (multipleDecorators) {
+				const tempId = luau.tempId("decorator");
+				luau.list.push(
+					result,
+					luau.create(luau.SyntaxKind.VariableDeclaration, {
+						left: tempId,
+						right: expression,
+					}),
+				);
+				expression = tempId;
+			}
+
+			assert(luau.isIndexableExpression(expression));
+
+			const [key, keyPrereqs] = state.capture(() => transformObjectKey(state, name));
+			luau.list.pushList(result, keyPrereqs);
+
+			// decorator(Class, "name")
+			luau.list.unshift(
+				finalizers,
+				luau.create(luau.SyntaxKind.CallStatement, {
+					expression: luau.call(expression, [classId, key]),
+				}),
+			);
+		}
+	}
+
+	luau.list.pushList(result, finalizers);
+
+	return result;
+}
+
+function transformParameterDecorators(
+	state: TransformState,
+	member: ts.MethodDeclaration | ts.ConstructorDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	const result = luau.list.make<luau.Statement>();
+
+	for (let i = 0; i < member.parameters.length; i++) {
+		const parameter = member.parameters[i];
+		if (ts.isIdentifier(parameter.name)) {
+			const finalizers = luau.list.make<luau.Statement>();
+			const multipleDecorators = member.decorators !== undefined && member.decorators.length > 1;
+			for (const decorator of parameter.decorators ?? []) {
+				// eslint-disable-next-line no-autofix/prefer-const
+				let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
+
+				luau.list.pushList(result, prereqs);
+
+				if (multipleDecorators) {
+					const tempId = luau.tempId("decorator");
+					luau.list.push(
+						result,
+						luau.create(luau.SyntaxKind.VariableDeclaration, {
+							left: tempId,
+							right: expression,
+						}),
+					);
+					expression = tempId;
+				}
+
+				assert(luau.isIndexableExpression(expression));
+
+				// decorator(Class, "name", 0)
+				luau.list.unshift(
+					finalizers,
+					luau.create(luau.SyntaxKind.CallStatement, {
+						expression: luau.call(expression, [classId, luau.string(parameter.name.text), luau.number(i)]),
+					}),
+				);
+			}
+			luau.list.pushList(result, finalizers);
+		}
+	}
+
+	return result;
+}
+
+function transformClassDecorators(
+	state: TransformState,
+	node: ts.ClassLikeDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	const result = luau.list.make<luau.Statement>();
+	const finalizers = luau.list.make<luau.Statement>();
+
+	const multipleDecorators = node.decorators !== undefined && node.decorators.length > 1;
+
+	for (const decorator of node.decorators ?? []) {
+		// eslint-disable-next-line no-autofix/prefer-const
+		let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
+
+		luau.list.pushList(result, prereqs);
+
+		if (multipleDecorators) {
+			const tempId = luau.tempId("decorator");
+			luau.list.push(
+				result,
+				luau.create(luau.SyntaxKind.VariableDeclaration, {
+					left: tempId,
+					right: expression,
+				}),
+			);
+			expression = tempId;
+		}
+
+		assert(luau.isIndexableExpression(expression));
+
+		// Class = decorator(Class) or Class
+		luau.list.unshift(
+			finalizers,
+			luau.create(luau.SyntaxKind.Assignment, {
+				left: classId,
+				operator: "=",
+				right: luau.binary(luau.call(expression, [classId]), "or", classId),
+			}),
+		);
+	}
+
+	luau.list.pushList(result, finalizers);
+
+	return result;
+}
+
+export function transformDecorators(
+	state: TransformState,
+	node: ts.ClassLikeDeclaration,
+	classId: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	const result = luau.list.make<luau.Statement>();
+
+	// https://www.typescriptlang.org/docs/handbook/decorators.html#decorator-evaluation
+
+	// Instance Decorators
+	for (const member of node.members) {
+		if (!ts.getSelectedSyntacticModifierFlags(member, ts.ModifierFlags.Static)) {
+			if (ts.isMethodDeclaration(member)) {
+				luau.list.pushList(result, transformMethodDecorators(state, member, classId));
+				luau.list.pushList(result, transformParameterDecorators(state, member, classId));
+			} else if (ts.isPropertyDeclaration(member)) {
+				luau.list.pushList(result, transformPropertyDecorators(state, member, classId));
+			}
+		}
+	}
+
+	// Static Decorators
+	for (const member of node.members) {
+		if (!!ts.getSelectedSyntacticModifierFlags(member, ts.ModifierFlags.Static)) {
+			if (ts.isMethodDeclaration(member)) {
+				luau.list.pushList(result, transformMethodDecorators(state, member, classId));
+				luau.list.pushList(result, transformParameterDecorators(state, member, classId));
+			} else if (ts.isPropertyDeclaration(member)) {
+				luau.list.pushList(result, transformPropertyDecorators(state, member, classId));
+			}
+		}
+	}
+
+	// Constructor Parameter Decorators
+	for (const member of node.members) {
+		if (ts.isConstructorDeclaration(member)) {
+			luau.list.pushList(result, transformParameterDecorators(state, member, classId));
+		}
+	}
+
+	// Class Decorators
+	luau.list.pushList(result, transformClassDecorators(state, node, classId));
+
+	return result;
+}

--- a/src/TSTransformer/nodes/class/transformDecorators.ts
+++ b/src/TSTransformer/nodes/class/transformDecorators.ts
@@ -62,6 +62,8 @@ function transformMethodDecorators(
 	classId: luau.AnyIdentifier,
 ): luau.List<luau.Statement> {
 	return transformMemberDecorators(state, member, (expression, key) => {
+		assert(key);
+
 		const result = luau.list.make<luau.Statement>();
 
 		// local _descriptor = decorator(Class, "name", { value = Class.name })
@@ -77,13 +79,13 @@ function transformMethodDecorators(
 				left: descriptorId,
 				right: luau.call(expression, [
 					classId,
-					key!,
+					key,
 					luau.map([
 						[
 							luau.string("value"),
 							luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 								expression: classId,
-								index: key!,
+								index: key,
 							}),
 						],
 					]),
@@ -99,7 +101,7 @@ function transformMethodDecorators(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 							expression: classId,
-							index: key!,
+							index: key,
 						}),
 						operator: "=",
 						right: luau.property(descriptorId, "value"),
@@ -118,14 +120,15 @@ function transformPropertyDecorators(
 	member: ts.PropertyDeclaration,
 	classId: luau.AnyIdentifier,
 ): luau.List<luau.Statement> {
-	return transformMemberDecorators(state, member, (expression, key) =>
+	return transformMemberDecorators(state, member, (expression, key) => {
+		assert(key);
 		// decorator(Class, "name")
-		luau.list.make(
+		return luau.list.make(
 			luau.create(luau.SyntaxKind.CallStatement, {
-				expression: luau.call(expression, [classId, key!]),
+				expression: luau.call(expression, [classId, key]),
 			}),
-		),
-	);
+		);
+	});
 }
 
 function transformParameterDecorators(

--- a/src/TSTransformer/nodes/class/transformDecorators.ts
+++ b/src/TSTransformer/nodes/class/transformDecorators.ts
@@ -23,7 +23,7 @@ function transformMethodDecorators(
 
 			luau.list.pushList(result, prereqs);
 
-			if (multipleDecorators) {
+			if (multipleDecorators && !luau.isSimple(expression)) {
 				const tempId = luau.tempId("decorator");
 				luau.list.push(
 					result,
@@ -117,7 +117,7 @@ function transformPropertyDecorators(
 
 			luau.list.pushList(result, prereqs);
 
-			if (multipleDecorators) {
+			if (multipleDecorators && !luau.isSimple(expression)) {
 				const tempId = luau.tempId("decorator");
 				luau.list.push(
 					result,
@@ -167,7 +167,7 @@ function transformParameterDecorators(
 
 				luau.list.pushList(result, prereqs);
 
-				if (multipleDecorators) {
+				if (multipleDecorators && !luau.isSimple(expression)) {
 					const tempId = luau.tempId("decorator");
 					luau.list.push(
 						result,
@@ -212,7 +212,7 @@ function transformClassDecorators(
 
 		luau.list.pushList(result, prereqs);
 
-		if (multipleDecorators) {
+		if (multipleDecorators && !luau.isSimple(expression)) {
 			const tempId = luau.tempId("decorator");
 			luau.list.push(
 				result,

--- a/src/TSTransformer/nodes/transformMethodDeclaration.ts
+++ b/src/TSTransformer/nodes/transformMethodDeclaration.ts
@@ -19,13 +19,13 @@ export function transformMethodDeclaration(
 	const result = luau.list.make<luau.Statement>();
 
 	if (!node.body) {
-		return result;
+		return luau.list.make<luau.Statement>();
 	}
 
 	assert(node.name);
 	if (ts.isPrivateIdentifier(node.name)) {
 		DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(node.name));
-		return result;
+		return luau.list.make<luau.Statement>();
 	}
 
 	// eslint-disable-next-line no-autofix/prefer-const

--- a/src/TSTransformer/nodes/transformMethodDeclaration.ts
+++ b/src/TSTransformer/nodes/transformMethodDeclaration.ts
@@ -35,11 +35,13 @@ export function transformMethodDeclaration(
 	let name = transformObjectKey(state, node.name);
 	if (node.decorators !== undefined && !luau.isSimple(name)) {
 		const tempId = luau.tempId("key");
-		const statement = luau.create(luau.SyntaxKind.VariableDeclaration, {
-			left: tempId,
-			right: name,
-		});
-		luau.list.push(result, statement);
+		luau.list.push(
+			result,
+			luau.create(luau.SyntaxKind.VariableDeclaration, {
+				left: tempId,
+				right: name,
+			}),
+		);
 		name = tempId;
 		state.setClassElementObjectKey(node, tempId);
 	}

--- a/src/TSTransformer/nodes/transformMethodDeclaration.ts
+++ b/src/TSTransformer/nodes/transformMethodDeclaration.ts
@@ -16,21 +16,33 @@ export function transformMethodDeclaration(
 	node: ts.MethodDeclaration,
 	ptr: Pointer<luau.Map | luau.AnyIdentifier>,
 ) {
+	const result = luau.list.make<luau.Statement>();
+
 	if (!node.body) {
-		return luau.list.make<luau.Statement>();
+		return result;
 	}
 
 	assert(node.name);
 	if (ts.isPrivateIdentifier(node.name)) {
 		DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(node.name));
-		return luau.list.make<luau.Statement>();
+		return result;
 	}
 
 	// eslint-disable-next-line no-autofix/prefer-const
 	let { statements, parameters, hasDotDotDot } = transformParameters(state, node);
 	luau.list.pushList(statements, transformStatementList(state, node.body.statements));
 
-	const name = transformObjectKey(state, node.name);
+	let name = transformObjectKey(state, node.name);
+	if (node.decorators !== undefined && !luau.isSimple(name)) {
+		const tempId = luau.tempId("key");
+		const statement = luau.create(luau.SyntaxKind.VariableDeclaration, {
+			left: tempId,
+			right: name,
+		});
+		luau.list.push(result, statement);
+		name = tempId;
+		state.setClassElementObjectKey(node, tempId);
+	}
 
 	const isAsync = !!ts.getSelectedSyntacticModifierFlags(node, ts.ModifierFlags.Async);
 
@@ -45,7 +57,8 @@ export function transformMethodDeclaration(
 	if (!isAsync && luau.isStringLiteral(name) && !luau.isMap(ptr.value) && luau.isValidIdentifier(name.value)) {
 		if (isMethod(state, node)) {
 			luau.list.shift(parameters); // remove `self`
-			return luau.list.make(
+			luau.list.push(
+				result,
 				luau.create(luau.SyntaxKind.MethodDeclaration, {
 					expression: ptr.value,
 					name: name.value,
@@ -55,7 +68,8 @@ export function transformMethodDeclaration(
 				}),
 			);
 		} else {
-			return luau.list.make(
+			luau.list.push(
+				result,
 				luau.create(luau.SyntaxKind.FunctionDeclaration, {
 					name: luau.property(ptr.value, name.value),
 					localize: false,
@@ -65,6 +79,7 @@ export function transformMethodDeclaration(
 				}),
 			);
 		}
+		return result;
 	}
 
 	let expression: luau.Expression = luau.create(luau.SyntaxKind.FunctionExpression, {
@@ -78,5 +93,10 @@ export function transformMethodDeclaration(
 	}
 
 	// we have to use `class[name] = function()`
-	return state.capturePrereqs(() => assignToMapPointer(state, ptr, name, expression));
+	luau.list.pushList(
+		result,
+		state.capturePrereqs(() => assignToMapPointer(state, ptr, name, expression)),
+	);
+
+	return result;
 }

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -78,14 +78,8 @@ export function isDefinedType(type: ts.Type) {
 	);
 }
 
-export function isAnyType(type: ts.Type) {
-	return (
-		!!(type.flags & ts.TypeFlags.Any) &&
-		!(
-			ts.getObjectFlags(type) &
-			(ts.ObjectFlags.CouldContainTypeVariables | ts.ObjectFlags.CouldContainTypeVariablesComputed)
-		)
-	);
+export function isAnyType(state: TransformState): TypeCheck {
+	return type => type === state.typeChecker.getAnyType();
 }
 
 export function isBooleanType(type: ts.Type) {

--- a/src/TSTransformer/util/validateNotAny.ts
+++ b/src/TSTransformer/util/validateNotAny.ts
@@ -20,7 +20,7 @@ export function validateNotAnyType(state: TransformState, node: ts.Node) {
 		}
 	}
 
-	if (isDefinitelyType(type, isAnyType)) {
+	if (isDefinitelyType(type, isAnyType(state))) {
 		const symbol = state.getOriginalSymbol(node);
 		if (symbol && !state.multiTransformState.isReportedByNoAnyCache.has(symbol)) {
 			state.multiTransformState.isReportedByNoAnyCache.add(symbol);

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -12,7 +12,7 @@
 				"@rbxts/roact": "^1.3.0-ts.7",
 				"@rbxts/services": "^1.1.2",
 				"@rbxts/testez": "^0.3.1-ts.6",
-				"@rbxts/types": "^1.0.569"
+				"@rbxts/types": "^1.0.571"
 			}
 		},
 		"node_modules/@rbxts/compiler-types": {
@@ -36,9 +36,9 @@
 			"integrity": "sha512-WiiRmYF1bvq4rgiXpzAgvgajZ+Iq49b+d0ki+WrqflUMuDTpUfBduqEWg1bS5t1KAZ22OHfH2pjeqwXwlaif8w=="
 		},
 		"node_modules/@rbxts/types": {
-			"version": "1.0.569",
-			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.569.tgz",
-			"integrity": "sha512-gPvf4usjp4sHDZeexfKbWa4xB/Q181lI4NsI5LaR7V5mx3ZUVKM+PSQ5TmOx+9hs25TWyCPffTOfO7a/7XPYZQ=="
+			"version": "1.0.571",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.571.tgz",
+			"integrity": "sha512-VKBktp/GefC8uHzzRhZJE8EhQw6Zq2oMzc8dlWoaj2xe6rT2bWllYg4pl7tuw29LjaUuIqWm0GUhbSqMiKmmaQ=="
 		}
 	},
 	"dependencies": {
@@ -63,9 +63,9 @@
 			"integrity": "sha512-WiiRmYF1bvq4rgiXpzAgvgajZ+Iq49b+d0ki+WrqflUMuDTpUfBduqEWg1bS5t1KAZ22OHfH2pjeqwXwlaif8w=="
 		},
 		"@rbxts/types": {
-			"version": "1.0.569",
-			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.569.tgz",
-			"integrity": "sha512-gPvf4usjp4sHDZeexfKbWa4xB/Q181lI4NsI5LaR7V5mx3ZUVKM+PSQ5TmOx+9hs25TWyCPffTOfO7a/7XPYZQ=="
+			"version": "1.0.571",
+			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.571.tgz",
+			"integrity": "sha512-VKBktp/GefC8uHzzRhZJE8EhQw6Zq2oMzc8dlWoaj2xe6rT2bWllYg4pl7tuw29LjaUuIqWm0GUhbSqMiKmmaQ=="
 		}
 	}
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,6 +14,6 @@
 		"@rbxts/roact": "^1.3.0-ts.7",
 		"@rbxts/services": "^1.1.2",
 		"@rbxts/testez": "^0.3.1-ts.6",
-		"@rbxts/types": "^1.0.569"
+		"@rbxts/types": "^1.0.571"
 	}
 }


### PR DESCRIPTION
Fixes #1790

Until the types are added to `@rbxts/compiler-types`, you'll need a `types.d.ts` file with:

```TS
export {};

declare global {
	type InferThis<T> = T extends (this: infer U, ...parameters: Array<any>) => any ? U : never;

	type Parameters2<T> = T extends (...args: infer P) => any ? P : never;
	type ReturnType2<T> = T extends (...args: Array<any>) => infer R ? R : never;

	interface TypedPropertyDescriptor<T> {
		value: (self: InferThis<T>, ...parameters: Parameters2<T>) => ReturnType2<T>;
	}
}
```

`Parameters2` and `ReturnType2` just remove the `extends Callback` constraint.