### PR TITLE
Activate eslint on tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 node_modules
-tests

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"prepublishOnly": "npm run build",
 		"build": "ttsc -b",
 		"build-watch": "ttsc -b -w",
-		"eslint": "eslint \"src/**/*.ts\" --max-warnings 0",
+		"eslint": "eslint src/**/*.ts tests/**/*.ts --max-warnings 0",
 		"devlink": "cd devlink && npm link",
 		"test": "npm run build && npm run test-setup && npm run test-compile && npm run test-rojo && npm run test-run",
 		"test-setup": "cd tests && npm install @rbxts/types@latest @rbxts/compiler-types@latest",

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,17 @@
+{
+	"parserOptions": {
+		"project": "./tests/tsconfig.json"
+	},
+	"rules": {
+		"@typescript-eslint/ban-types": "off",
+		"@typescript-eslint/no-any": "off",
+		"@typescript-eslint/no-explicit-any": "off",
+		"@typescript-eslint/no-extra-non-null-assertion": "off",
+		"@typescript-eslint/no-unused-expressions": "off",
+		"@typescript-eslint/no-unused-vars": "off",
+		"no-constant-condition": "off",
+		"no-empty": "off",
+		"no-empty-pattern": "off",
+		"no-unused-labels": "off"
+	}
+}

--- a/tests/src/diagnostics/expectedFunctionGotMethod.1.ts
+++ b/tests/src/diagnostics/expectedFunctionGotMethod.1.ts
@@ -6,4 +6,4 @@ interface HasCallback {
 
 const obj: HasCallback = {
 	callback() {},
-}
+};

--- a/tests/src/diagnostics/expectedFunctionGotMethod.2.ts
+++ b/tests/src/diagnostics/expectedFunctionGotMethod.2.ts
@@ -5,5 +5,5 @@ interface HasCallback {
 }
 
 const obj: HasCallback = {
-	callback: function() {},
-}
+	callback: function () {},
+};

--- a/tests/src/diagnostics/expectedMethodGotFunction.1.ts
+++ b/tests/src/diagnostics/expectedMethodGotFunction.1.ts
@@ -6,4 +6,4 @@ interface HasMethod {
 
 const obj: HasMethod = {
 	method: () => {},
-}
+};

--- a/tests/src/diagnostics/expectedMethodGotFunction.2.ts
+++ b/tests/src/diagnostics/expectedMethodGotFunction.2.ts
@@ -6,4 +6,4 @@ interface HasMethod {
 
 const obj: HasMethod = {
 	method: () => {},
-}
+};

--- a/tests/src/diagnostics/expectedMethodGotFunction.3.ts
+++ b/tests/src/diagnostics/expectedMethodGotFunction.3.ts
@@ -8,4 +8,4 @@ function method() {}
 
 const obj: HasMethod = {
 	method,
-}
+};

--- a/tests/src/diagnostics/expectedMethodGotFunction.4.ts
+++ b/tests/src/diagnostics/expectedMethodGotFunction.4.ts
@@ -6,4 +6,4 @@ interface HasMethod {
 
 const obj: HasMethod = {
 	method(this: void) {},
-}
+};

--- a/tests/src/diagnostics/noAny.1.ts
+++ b/tests/src/diagnostics/noAny.1.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare const x: any;
+const [a, b] = x;

--- a/tests/src/diagnostics/noAny.10.ts
+++ b/tests/src/diagnostics/noAny.10.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare const A: any;
+new A();

--- a/tests/src/diagnostics/noAny.11.ts
+++ b/tests/src/diagnostics/noAny.11.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare const a: any;
+a.b;

--- a/tests/src/diagnostics/noAny.12.ts
+++ b/tests/src/diagnostics/noAny.12.ts
@@ -1,4 +1,4 @@
 export {};
 
-declare let a: any;
+declare const a: any;
 [...a];

--- a/tests/src/diagnostics/noAny.12.ts
+++ b/tests/src/diagnostics/noAny.12.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare let a: any;
+[...a];

--- a/tests/src/diagnostics/noAny.13.ts
+++ b/tests/src/diagnostics/noAny.13.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare let a: any;
+++a;

--- a/tests/src/diagnostics/noAny.14.ts
+++ b/tests/src/diagnostics/noAny.14.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare let a: any;
+a++;

--- a/tests/src/diagnostics/noAny.2.ts
+++ b/tests/src/diagnostics/noAny.2.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare const x: any;
+const { a, b } = x;

--- a/tests/src/diagnostics/noAny.3.ts
+++ b/tests/src/diagnostics/noAny.3.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare const a: any;
+declare const b: number;
+a + b;

--- a/tests/src/diagnostics/noAny.4.ts
+++ b/tests/src/diagnostics/noAny.4.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare const a: number;
+declare const b: any;
+a + b;

--- a/tests/src/diagnostics/noAny.5.ts
+++ b/tests/src/diagnostics/noAny.5.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare const a: any;
+a();

--- a/tests/src/diagnostics/noAny.6.ts
+++ b/tests/src/diagnostics/noAny.6.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare const a: any;
+a.b();

--- a/tests/src/diagnostics/noAny.7.ts
+++ b/tests/src/diagnostics/noAny.7.ts
@@ -1,0 +1,4 @@
+export {};
+
+declare const a: any;
+a["b"]();

--- a/tests/src/diagnostics/noAny.8.ts
+++ b/tests/src/diagnostics/noAny.8.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare const a: Record<string, number>;
+declare const b: any;
+a[b];

--- a/tests/src/diagnostics/noAny.9.ts
+++ b/tests/src/diagnostics/noAny.9.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare const a: any;
+declare const b: string;
+a[b];

--- a/tests/src/diagnostics/noAny.ts
+++ b/tests/src/diagnostics/noAny.ts
@@ -1,5 +1,0 @@
-export {};
-
-function foo(x: any) {
-	print(x.y);
-}

--- a/tests/src/diagnostics/noArguments.ts
+++ b/tests/src/diagnostics/noArguments.ts
@@ -1,5 +1,6 @@
 export {};
 
 function foo() {
+	// eslint-disable-next-line prefer-rest-params
 	print(arguments);
 }

--- a/tests/src/diagnostics/noAwaitForOf.ts
+++ b/tests/src/diagnostics/noAwaitForOf.ts
@@ -1,5 +1,6 @@
 export {};
 
 async function foo() {
-	for await (const x of [1, 2, 3]) {}
+	for await (const x of [1, 2, 3]) {
+	}
 }

--- a/tests/src/diagnostics/noDestructureAssignmentExpression.ts
+++ b/tests/src/diagnostics/noDestructureAssignmentExpression.ts
@@ -3,4 +3,4 @@ export {};
 let a: boolean;
 let b: string | void;
 
-print([a, b] = pcall(() => {}));
+print(([a, b] = pcall(() => {})));

--- a/tests/src/diagnostics/noExportAssignmentLet.ts
+++ b/tests/src/diagnostics/noExportAssignmentLet.ts
@@ -1,2 +1,3 @@
+// eslint-disable-next-line no-autofix/prefer-const
 let x = 1;
 export = x;

--- a/tests/src/diagnostics/noFunctionExpressionName.ts
+++ b/tests/src/diagnostics/noFunctionExpressionName.ts
@@ -1,3 +1,3 @@
 export {};
 
-print(function foo() {})
+print(function foo() {});

--- a/tests/src/diagnostics/noLabeledStatement.1.ts
+++ b/tests/src/diagnostics/noLabeledStatement.1.ts
@@ -1,4 +1,4 @@
 export {};
 
-label:
-for (const x of [1, 2, 3]) {}
+label: for (const x of [1, 2, 3]) {
+}

--- a/tests/src/diagnostics/noLabeledStatement.2.ts
+++ b/tests/src/diagnostics/noLabeledStatement.2.ts
@@ -1,6 +1,6 @@
 export {};
 
 for (const x of [1, 2, 3]) {
-	// @ts-ignore
+	// @ts-expect-error non-existent label
 	break label;
 }

--- a/tests/src/diagnostics/noLabeledStatement.3.ts
+++ b/tests/src/diagnostics/noLabeledStatement.3.ts
@@ -1,6 +1,6 @@
 export {};
 
 for (const x of [1, 2, 3]) {
-	// @ts-ignore
+	// @ts-expect-error non-existent label
 	continue label;
 }

--- a/tests/src/diagnostics/noLuaTupleInTemplateExpression.ts
+++ b/tests/src/diagnostics/noLuaTupleInTemplateExpression.ts
@@ -1,7 +1,7 @@
 export {};
 
 function a() {
-	return [1, 2] as LuaTuple<[number, number]>
+	return [1, 2] as LuaTuple<[number, number]>;
 }
 
-`${a()}`
+`${a()}`;

--- a/tests/src/diagnostics/noMacroUnion.1.ts
+++ b/tests/src/diagnostics/noMacroUnion.1.ts
@@ -1,5 +1,6 @@
 export {};
 
 function foo(x: ReadonlyArray<number> | ReadonlyMap<number, string>) {
-	for (const v of x) {}
+	for (const v of x) {
+	}
 }

--- a/tests/src/diagnostics/noModuleSpecifierFile.ts
+++ b/tests/src/diagnostics/noModuleSpecifierFile.ts
@@ -1,3 +1,3 @@
-// @ts-expect-error
+// @ts-expect-error non-existent package
 import { x } from "packageThatDoesNotExist";
 print(x);

--- a/tests/src/diagnostics/noNonNumberStringRelationOperator.ts
+++ b/tests/src/diagnostics/noNonNumberStringRelationOperator.ts
@@ -1,5 +1,5 @@
 export {};
 
-let a = new Vector3();
-let b = new Vector3();
+const a = new Vector3();
+const b = new Vector3();
 print(a < b);

--- a/tests/src/diagnostics/noSpreadDestructuring.2.ts
+++ b/tests/src/diagnostics/noSpreadDestructuring.2.ts
@@ -1,3 +1,3 @@
 export {};
 
-const {X, ...etc} = new Vector3();
+const { X, ...etc } = new Vector3();

--- a/tests/src/diagnostics/noVar.ts
+++ b/tests/src/diagnostics/noVar.ts
@@ -1,3 +1,4 @@
 export {};
 
+// eslint-disable-next-line no-var
 var x = 1;

--- a/tests/src/main.server.ts
+++ b/tests/src/main.server.ts
@@ -1,7 +1,7 @@
 import { ServerScriptService } from "@rbxts/services";
 import TestEZ from "@rbxts/testez";
 
-const results = TestEZ.TestBootstrap.run([ ServerScriptService.tests ]);
+const results = TestEZ.TestBootstrap.run([ServerScriptService.tests]);
 if (results.errors.size() > 0 || results.failureCount > 0) {
 	error("Tests failed!");
 }

--- a/tests/src/tests/array.spec.ts
+++ b/tests/src/tests/array.spec.ts
@@ -18,6 +18,7 @@ export = () => {
 		expect(foo()[1]).to.equal(2);
 		expect(foo()[2]).to.equal(3);
 
+		// eslint-disable-next-line no-autofix/prefer-const
 		let i = 2;
 		let a = arr[i];
 		let b = arr[2];
@@ -40,7 +41,7 @@ export = () => {
 		expect(d).to.equal(3);
 
 		function f<T extends 0 | 1 | 2 | number>(v: T) {
-			let a = [];
+			const a = [];
 			a[v] = 3; // shouldn't make a compiler error
 		}
 
@@ -86,7 +87,7 @@ export = () => {
 		expect(noodle.strings[2]).to.equal("Lasagna");
 		expect(noodle.strings[3]).to.equal("Penne");
 
-		let arr = [0];
+		const arr = [0];
 		arr.push(1, 2, arr[1]);
 
 		expect(arr[0]).to.equal(0);
@@ -117,14 +118,14 @@ export = () => {
 
 	it("should support move", () => {
 		const a = [1, 2, 3];
-		let b = [0];
+		const b = [0];
 		a.move(1, 2, 0);
 		expect(a.join(", ")).to.equal("2, 3, 3");
 		a.move(0, 2, 1, b);
 		expect(b.join(", ")).to.equal("0, 2, 3, 3");
 		b.move(0, 1, 2);
 		expect(b.join(", ")).to.equal("0, 2, 0, 2");
-	})
+	});
 
 	it("should support shift", () => {
 		const a = [1, 2, 3];
@@ -313,15 +314,15 @@ export = () => {
 	});
 
 	it("should allow spread 3", () => {
-		const oldArr = [2]
-		let counter = 0
-		const newArr = [++counter, ...oldArr]
+		const oldArr = [2];
+		let counter = 0;
+		const newArr = [++counter, ...oldArr];
 		expect(newArr[0]).to.equal(1);
 		expect(newArr[1]).to.equal(2);
 	});
 
 	it("should allow spread 4", () => {
-		let counter = 0
+		let counter = 0;
 		const newArr = [++counter, ..."abc"];
 		expect(newArr[0]).to.equal(1);
 		expect(newArr[1]).to.equal("a");
@@ -330,14 +331,14 @@ export = () => {
 	});
 
 	it("should allow spread 5", () => {
-		let counter = 0
+		let counter = 0;
 		const newArr = [++counter, ...new Set([2])];
 		expect(newArr[0]).to.equal(1);
 		expect(newArr[1]).to.equal(2);
 	});
 
 	it("should allow spread 6", () => {
-		let counter = 0
+		let counter = 0;
 		const newArr = [["a", ++counter], ...new Map([["b", 2]])];
 		expect(newArr[0][0]).to.equal("a");
 		expect(newArr[0][1]).to.equal(1);
@@ -350,7 +351,7 @@ export = () => {
 			yield 2;
 		}
 
-		let counter = 0
+		let counter = 0;
 		const newArr = [++counter, ...foo()];
 		expect(newArr[0]).to.equal(1);
 		expect(newArr[1]).to.equal(2);
@@ -471,7 +472,7 @@ export = () => {
 	});
 
 	it("should support Array constructor", () => {
-		expect(new Array(10, undefined).isEmpty()).to.equal(true);
+		expect([10, undefined].isEmpty()).to.equal(true);
 	});
 
 	it("should support Array.mapFiltered", () => {

--- a/tests/src/tests/assignment.spec.ts
+++ b/tests/src/tests/assignment.spec.ts
@@ -3,6 +3,7 @@
 export = () => {
 	it("should support logical null coalescing assignment statement", () => {
 		let x: boolean | undefined;
+		// eslint-disable-next-line no-autofix/prefer-const
 		x ??= true;
 		expect(x).to.equal(true);
 	});
@@ -21,19 +22,19 @@ export = () => {
 
 	it("should support logical null coalescing assignment expression", () => {
 		let x: boolean | undefined;
-		expect(x ??= true).to.equal(true);
+		expect((x ??= true)).to.equal(true);
 		expect(x).to.equal(true);
 	});
 
 	it("should support logical or assignment expression", () => {
 		let x = false;
-		expect(x ||= true).to.equal(true);
+		expect((x ||= true)).to.equal(true);
 		expect(x).to.equal(true);
 	});
 
 	it("should support logical and assignment expression", () => {
 		let x = true;
-		expect(x &&= false).to.equal(false);
+		expect((x &&= false)).to.equal(false);
 		expect(x).to.equal(false);
 	});
 };

--- a/tests/src/tests/binary.spec.ts
+++ b/tests/src/tests/binary.spec.ts
@@ -56,7 +56,7 @@ export = () => {
 									this.b++;
 								},
 
-								no: function() {
+								no: function () {
 									return (this[5] *= 7);
 								},
 
@@ -124,7 +124,7 @@ export = () => {
 		(x) *= 9;
 		expect(x).to.equal(45);
 
-		let o = { x: 3 };
+		const o = { x: 3 };
 		// prettier-ignore
 		(o.x) = 5;
 		expect(o.x).to.equal(5);

--- a/tests/src/tests/delete.spec.ts
+++ b/tests/src/tests/delete.spec.ts
@@ -16,6 +16,7 @@ export = () => {
 			};
 
 			delete myTrolly.apples;
+			// prettier-ignore
 			delete (myTrolly.pears);
 
 			expect(myTrolly.apples).to.equal(undefined);
@@ -30,6 +31,7 @@ export = () => {
 			};
 
 			delete myTrolly?.apples;
+			// prettier-ignore
 			delete (myTrolly?.pears);
 
 			expect(myTrolly.apples).to.equal(undefined);
@@ -44,6 +46,7 @@ export = () => {
 			};
 
 			delete myTrolly["apples"];
+			// prettier-ignore
 			delete (myTrolly["pears"]);
 
 			expect(myTrolly.apples).to.equal(undefined);
@@ -58,6 +61,7 @@ export = () => {
 			};
 
 			delete myTrolly?.["apples"];
+			// prettier-ignore
 			delete (myTrolly?.["pears"]);
 
 			expect(myTrolly.apples).to.equal(undefined);
@@ -106,6 +110,7 @@ export = () => {
 			};
 
 			expect(delete myTrolly.apples).to.equal(true);
+			// prettier-ignore
 			expect(delete (myTrolly.pears)).to.equal(true);
 		});
 
@@ -113,6 +118,7 @@ export = () => {
 			const myTrolly = getFruitsOrUndefined();
 
 			expect(delete myTrolly?.apples).to.equal(true);
+			// prettier-ignore
 			expect(delete (myTrolly?.pears)).to.equal(true);
 		});
 
@@ -124,6 +130,7 @@ export = () => {
 			};
 
 			expect(delete myTrolly["apples"]).to.equal(true);
+			// prettier-ignore
 			expect(delete (myTrolly["apples"])).to.equal(true);
 		});
 
@@ -131,6 +138,7 @@ export = () => {
 			const myTrolly = getFruitsOrUndefined();
 
 			expect(delete myTrolly?.["apples"]).to.equal(true);
+			// prettier-ignore
 			expect(delete (myTrolly?.["pears"])).to.equal(true);
 		});
 	});

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -138,6 +138,7 @@ export = () => {
 		let x: number;
 		let y: number;
 		let z: number;
+		// eslint-disable-next-line no-autofix/prefer-const
 		[x, y, [z]] = [1, 2, [3]];
 		expect(x).to.equal(1);
 		expect(y).to.equal(2);
@@ -145,9 +146,9 @@ export = () => {
 	});
 
 	it("should support destructure assignment with identifier", () => {
-		let x: number;
-		let y: number;
-		let z: number;
+		let x = 0;
+		let y = 0;
+		let z = 0;
 		const obj: [number, number, [number]] = [1, 2, [3]];
 		[x, y, [z]] = obj;
 		expect(x).to.equal(1);
@@ -204,13 +205,13 @@ export = () => {
 	});
 
 	it("should destructure properly into already declared variables", () => {
-		let a: number;
+		let a = 0;
 		[a] = new Set([4]);
 		expect(a).to.equal(4);
 
-		let len: number;
-		({ [2]: len } = [1, 2, 3]);
-		expect(len).to.equal(3);
+		let third = 0;
+		({ [2]: third } = [1, 2, 3]);
+		expect(third).to.equal(3);
 
 		let y = 0;
 		({ x: y } = { x: 1 });
@@ -218,11 +219,10 @@ export = () => {
 	});
 
 	it("should destructure computed property types as well (number-only)", () => {
-		const array = new Array<number>();
-		array.push(1, 2, 3, 4);
+		const array = [1, 2, 3, 4];
 
 		function f(i: number) {
-			let num: number;
+			let num = 0 / 0;
 			({ [i]: num } = array);
 			return num;
 		}
@@ -346,8 +346,8 @@ export = () => {
 
 	it("should properly destruct with var element access", () => {
 		const array = [1, 2];
-		let a = 0;
-		let b = 1;
+		const a = 0;
+		const b = 1;
 		[array[a], array[b]] = [array[b], array[a]];
 		expect(array[a]).to.equal(2);
 		expect(array[b]).to.equal(1);
@@ -377,8 +377,8 @@ export = () => {
 
 	it("should support arrays with object destructure", () => {
 		const array = [3, 4];
-		let a = 0;
-		let b = 1;
+		const a = 0;
+		const b = 1;
 		({ [a]: array[b], [b]: array[a] } = array);
 		expect(array[a]).to.equal(3);
 		expect(array[b]).to.equal(3);
@@ -392,19 +392,19 @@ export = () => {
 	});
 
 	it("should support object destructing from object with shorthand syntax", () => {
-		let x = 123;
+		const x = 123;
 		const { x: y } = { x };
 		expect(y).to.equal(123);
 	});
 
 	it("should support object destructing from object with numeric literal key", () => {
-		let x = 456;
+		const x = 456;
 		const { 1: y } = { 1: x };
 		expect(y).to.equal(456);
 	});
 
 	it("should support object destructing from object with string literal key", () => {
-		let x = 789;
+		const x = 789;
 		// prettier-ignore
 		const { "str": y } = { "str": x };
 		expect(y).to.equal(789);
@@ -539,6 +539,7 @@ export = () => {
 			x: new Map([["heck", 123]]),
 		};
 		({
+			// eslint-disable-next-line no-autofix/prefer-const
 			x: [a],
 		} = obj);
 		expect(a[0]).to.equal("heck");
@@ -552,6 +553,7 @@ export = () => {
 			x: new Map([["heck", 123]]),
 		};
 		({
+			// eslint-disable-next-line no-autofix/prefer-const
 			x: [[a, b]],
 		} = obj);
 		expect(a).to.equal("heck");
@@ -565,6 +567,7 @@ export = () => {
 			x: [new Map([["heck", 123]])],
 		};
 		({
+			// eslint-disable-next-line no-autofix/prefer-const
 			x: [[[a, b]]],
 		} = obj);
 		expect(a).to.equal("heck");
@@ -577,6 +580,7 @@ export = () => {
 			x: [new Set(["heck"])],
 		};
 		({
+			// eslint-disable-next-line no-autofix/prefer-const
 			x: [[a]],
 		} = obj);
 		expect(a).to.equal("heck");
@@ -588,6 +592,7 @@ export = () => {
 			x: [new Set(["heck"])],
 		};
 		({
+			// eslint-disable-next-line no-autofix/prefer-const
 			x: [[[a]]],
 		} = obj);
 		expect(a).to.equal("h");
@@ -688,13 +693,13 @@ export = () => {
 
 	it("should support empty destructure", () => {
 		let x = 0;
-		const [] = pcall(() => x = 123);
+		const [] = pcall(() => (x = 123));
 		expect(x).to.equal(123);
 	});
 
 	it("should support empty destructure assignment", () => {
 		let x = 0;
-		[] = pcall(() => x = 123);
+		[] = pcall(() => (x = 123));
 		expect(x).to.equal(123);
 	});
 };

--- a/tests/src/tests/enum.spec.ts
+++ b/tests/src/tests/enum.spec.ts
@@ -26,10 +26,20 @@ enum Soups {
 
 enum EnumWithEscapedQuote {
 	// prettier-ignore
-	Quote = "\"",
+	Quote = '\'',
 }
 
 const enum EnumWithEscapedQuoteConst {
+	// prettier-ignore
+	Quote = '\'',
+}
+
+enum EnumWithEscapedDoubleQuote {
+	// prettier-ignore
+	Quote = "\"",
+}
+
+const enum EnumWithEscapedDoubleQuoteConst {
 	// prettier-ignore
 	Quote = "\"",
 }
@@ -111,10 +121,12 @@ export = () => {
 	}
 
 	it("should support enums with escaped quotes", () => {
-		expect(EnumWithEscapedQuote.Quote).to.equal('"');
+		expect(EnumWithEscapedQuote.Quote).to.equal("'");
+		expect(EnumWithEscapedDoubleQuote.Quote).to.equal('"');
 	});
 
 	it("should support const enums with escaped quotes", () => {
-		expect(EnumWithEscapedQuoteConst.Quote).to.equal('"');
+		expect(EnumWithEscapedQuoteConst.Quote).to.equal("'");
+		expect(EnumWithEscapedDoubleQuoteConst.Quote).to.equal('"');
 	});
 };

--- a/tests/src/tests/exportLet.spec.ts
+++ b/tests/src/tests/exportLet.spec.ts
@@ -2,6 +2,7 @@
 
 let y = 0;
 namespace Foo {
+	// eslint-disable-next-line no-autofix/prefer-const
 	export let x = 1;
 	y = x;
 }
@@ -14,12 +15,14 @@ namespace Bar {
 
 	export const { ClassName: a } = plr;
 
+	// eslint-disable-next-line no-autofix/prefer-const
 	export let { ClassName: b, Name: c } = plr;
+	// eslint-disable-next-line no-autofix/prefer-const
 	export let { ClassName, Name } = plr;
 }
 
 export = () => {
-	it("should allow mutatable exports", () => {
+	it("should allow mutable exports", () => {
 		expect(Foo.x).to.equal(1);
 		Foo.x = 2;
 		expect(Foo.x).to.equal(2);

--- a/tests/src/tests/function.spec.ts
+++ b/tests/src/tests/function.spec.ts
@@ -1,13 +1,13 @@
 /// <reference types="@rbxts/testez/globals" />
 
 namespace N {
-	export const a = function(this: typeof N, n: 5) {
+	export const a = function (this: typeof N, n: 5) {
 		return n;
 	};
-	export const b = function(this: void, n: 5) {
+	export const b = function (this: void, n: 5) {
 		return n;
 	};
-	export const c = function(n: 5) {
+	export const c = function (n: 5) {
 		return n;
 	};
 	export const d = (n: 5) => {
@@ -88,7 +88,7 @@ export = () => {
 
 	it("should support function expressions", () => {
 		expect(
-			(function() {
+			(function () {
 				return 123;
 			})(),
 		).to.equal(123);
@@ -138,10 +138,10 @@ export = () => {
 				expect(this).to.equal(undefined);
 				expect(n).to.equal(5);
 			}
-			public e = function(n: 5) {
+			public e = function (n: 5) {
 				expect(n).to.equal(5);
 			};
-			public f = function(this: A, n: 5) {
+			public f = function (this: A, n: 5) {
 				expect(this instanceof A).to.equal(true);
 				expect(n).to.equal(5);
 			};
@@ -163,11 +163,11 @@ export = () => {
 				expect(this).to.equal(o);
 				expect(n).to.equal(5);
 			},
-			c: function(this: void, n: 5) {
+			c: function (this: void, n: 5) {
 				expect(this).to.equal(undefined);
 				expect(n).to.equal(5);
 			},
-			d: function(n: 5) {
+			d: function (n: 5) {
 				expect(this).to.equal(o);
 				expect(n).to.equal(5);
 			},
@@ -178,7 +178,7 @@ export = () => {
 				expect(this).to.equal(o);
 				expect(n).to.equal(5);
 			},
-			g: function(this: {}, n: 5) {
+			g: function (this: {}, n: 5) {
 				expect(this).to.equal(o);
 				expect(n).to.equal(5);
 			},
@@ -189,7 +189,7 @@ export = () => {
 			expect(n).to.equal(5);
 		}
 
-		const g = function(this: void, n: 5) {
+		const g = function (this: void, n: 5) {
 			// expect(this).to.equal(undefined);
 			expect(n).to.equal(5);
 		};
@@ -223,23 +223,23 @@ export = () => {
 		f(5);
 		g(5);
 
-		(function(this: void, n: 5) {
+		(function (this: void, n: 5) {
 			expect(n).to.equal(5);
 		})(5);
 		({
-			x: function(n: 5) {
+			x: function (n: 5) {
 				expect(n).to.equal(5);
 			},
 		}.x(5));
 
 		({
-			x: function(this: void, n: 5) {
+			x: function (this: void, n: 5) {
 				expect(n).to.equal(5);
 			},
 		}.x(5));
 
 		({
-			x: function(this: {}, n: 5) {
+			x: function (this: {}, n: 5) {
 				expect(n).to.equal(5);
 			},
 		}.x(5));
@@ -249,7 +249,7 @@ export = () => {
 		})(5);
 
 		const obj = {
-			saferNum: function(this: void, n: number): number {
+			saferNum: function (this: void, n: number): number {
 				return n === n && n > 0 ? n : 0;
 			}, // wouldn't compile previously because it is a named function
 		};
@@ -273,7 +273,7 @@ export = () => {
 	});
 
 	it("should not wrap argument spread expressions in parentheses", () => {
-		const args: unknown[] = ["123", "456"];
+		const args: Array<unknown> = ["123", "456"];
 		expect(select(1, ...args)[1]).to.equal("456");
 	});
 };

--- a/tests/src/tests/if.spec.ts
+++ b/tests/src/tests/if.spec.ts
@@ -16,10 +16,11 @@ export = () => {
 		expect(foo(11)).to.equal("baz");
 	});
 
-	it("should support prereqs in elseif", () => {
+	it("should handle conditional execution of prereqs in elseif", () => {
 		const array = [1];
 		if (true) {
-		} else if (array.pop() === 1) {}
+		} else if (array.pop() === 1) {
+		}
 		expect(array.size()).to.equal(1);
 	});
 };

--- a/tests/src/tests/literal.spec.ts
+++ b/tests/src/tests/literal.spec.ts
@@ -33,7 +33,9 @@ export = () => {
 		expect('foo'.size()).to.equal(3);
 		expect(`foo`.size()).to.equal(3);
 		expect("\"").to.equal("\"");
+		// eslint-disable-next-line no-useless-escape
 		expect(`\"`).to.equal("\"");
+		// eslint-disable-next-line no-useless-escape
 		expect('\"').to.equal("\"");
 		expect(`"`).to.equal("\"");
 		expect('"').to.equal("\"");

--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -119,6 +119,7 @@ export = () => {
 		const hit = new Set<number>();
 		const limit = 1;
 		let n = 0;
+		// eslint-disable-next-line for-direction
 		for (let i = 3; i <= limit; i -= 1) {
 			hit.add(i);
 			n++;
@@ -369,10 +370,10 @@ export = () => {
 
 	it("should support indexing tuple as array", () => {
 		const obj = {
-			a:1,
-			b:2,
-			c:3,
-		}
+			a: 1,
+			b: 2,
+			c: 3,
+		};
 
 		for (const tuple of pairs(obj)) {
 			expect(tuple[1]).to.equal(obj[tuple[0]]);
@@ -386,14 +387,16 @@ export = () => {
 			expect(tuple.size()).to.equal(1);
 			break;
 		}
-	})
+	});
 
 	it("should support iterator function with multiple returns when indexing tuple as array", () => {
-		const longIterator: IterableFunction<LuaTuple<[boolean, boolean, boolean, boolean, boolean, boolean]>> =
-		(() => [true, true, true, true, true, true] as LuaTuple<[boolean, boolean, boolean, boolean, boolean, boolean]>) as never;
+		const longIterator: IterableFunction<LuaTuple<[boolean, boolean, boolean, boolean, boolean, boolean]>> = (() =>
+			[true, true, true, true, true, true] as LuaTuple<
+				[boolean, boolean, boolean, boolean, boolean, boolean]
+			>) as never;
 		for (const tuple of longIterator) {
 			expect(tuple.size()).to.equal(6);
 			break;
 		}
-	})
+	});
 };

--- a/tests/src/tests/map.spec.ts
+++ b/tests/src/tests/map.spec.ts
@@ -20,10 +20,7 @@ export = () => {
 	});
 
 	it("should support get and set", () => {
-		const map = new Map<string, number>()
-			.set("a", 1)
-			.set("b", 2)
-			.set("c", 3);
+		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
 		map.get("a");
 		expect(map.get("a")).to.equal(1);
 		expect(map.get("b")).to.equal(2);
@@ -34,10 +31,7 @@ export = () => {
 	});
 
 	it("should support has", () => {
-		const map = new Map<string, number>()
-			.set("a", 1)
-			.set("b", 2)
-			.set("c", 3);
+		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
 		map.has("a");
 		expect(map.has("a")).to.equal(true);
 		expect(map.has("b")).to.equal(true);
@@ -46,30 +40,21 @@ export = () => {
 	});
 
 	it("should support delete", () => {
-		const map = new Map<string, number>()
-			.set("a", 1)
-			.set("b", 2)
-			.set("c", 3);
+		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
 		const hadA = map.delete("a");
 		expect(hadA).to.equal(true);
 		expect(map.get("a")).never.to.be.ok();
 	});
 
 	it("should support size", () => {
-		const map = new Map<string, number>()
-			.set("a", 1)
-			.set("b", 2)
-			.set("c", 3);
+		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
 		expect(map.size()).to.equal(3);
 		map.delete("b");
 		expect(map.size()).to.equal(2);
 	});
 
 	it("should support clear", () => {
-		const map = new Map<string, number>()
-			.set("a", 1)
-			.set("b", 2)
-			.set("c", 3);
+		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
 		map.clear();
 		expect(map.has("a")).to.equal(false);
 		expect(map.has("b")).to.equal(false);
@@ -85,10 +70,7 @@ export = () => {
 		let hitB = 0;
 		let hitC = 0;
 
-		const map = new Map<string, number>()
-			.set("a", 1)
-			.set("b", 2)
-			.set("c", 3);
+		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
 
 		map.forEach((value, key, obj) => {
 			if (key === "a" && value === 1) {
@@ -171,7 +153,7 @@ export = () => {
 	it("should support the non-null assertion operator on maps", () => {
 		const a = new Map<number, number>();
 		let c: Map<number, number> | undefined;
-		(c!!! = a!!!).set(1, 2);
+		(c! = a!).set(1, 2);
 		expect(a!.get(1)).to.equal(2);
 
 		const b = new Map<string, Array<number>>([["a", [123]]]);

--- a/tests/src/tests/object.spec.ts
+++ b/tests/src/tests/object.spec.ts
@@ -3,6 +3,7 @@
 declare const self: undefined;
 
 namespace N {
+	// eslint-disable-next-line no-autofix/prefer-const
 	export let x = 5;
 	export const p = { a: { x } };
 }
@@ -26,6 +27,7 @@ export = () => {
 			2: 1,
 		};
 
+		// eslint-disable-next-line no-autofix/prefer-const
 		let i = 2;
 		let a = obj[i];
 		let b = obj[2];
@@ -173,9 +175,8 @@ export = () => {
 		}
 
 		{
-			const k = { o: 1, b: 2 };
+			const k: Record<string, any> = { o: 1, b: 2 };
 			const o = {
-				// @ts-ignore
 				o: 3,
 				...k,
 				b: k.o++,
@@ -186,11 +187,9 @@ export = () => {
 		}
 
 		{
-			const k = { o: 1, b: 2 };
+			const k: Record<string, any> = { o: 1, b: 2 };
 			const o = {
-				// @ts-ignore
 				o: 3,
-				// @ts-ignore
 				b: k.o++,
 				...k,
 			};
@@ -212,6 +211,7 @@ export = () => {
 
 	it("should support computedMethodNames", () => {
 		{
+			// eslint-disable-next-line no-inner-declarations
 			function g(n: 5) {
 				expect(self).to.equal(undefined);
 				return o.f(n);
@@ -317,7 +317,7 @@ export = () => {
 			return (this.n += n);
 		}
 
-		const mul = function<T extends Numerable>(this: T, n: number) {
+		const mul = function <T extends Numerable>(this: T, n: number) {
 			this.n *= n;
 			return this;
 		};
@@ -338,7 +338,7 @@ export = () => {
 		const o = {
 			count: 1,
 
-			getCount: function() {
+			getCount: function () {
 				return this.count;
 			},
 		};

--- a/tests/src/tests/object.spec.ts
+++ b/tests/src/tests/object.spec.ts
@@ -175,7 +175,7 @@ export = () => {
 		}
 
 		{
-			const k: Record<string, any> = { o: 1, b: 2 };
+			const k: Record<string, number> = { o: 1, b: 2 };
 			const o = {
 				o: 3,
 				...k,
@@ -187,7 +187,7 @@ export = () => {
 		}
 
 		{
-			const k: Record<string, any> = { o: 1, b: 2 };
+			const k: Record<string, number> = { o: 1, b: 2 };
 			const o = {
 				o: 3,
 				b: k.o++,

--- a/tests/src/tests/promise.spec.ts
+++ b/tests/src/tests/promise.spec.ts
@@ -16,13 +16,13 @@ export = () => {
 	});
 
 	it("should allow async function expressions", () => {
-		const foo = async function() {
+		const foo = async function () {
 			return "foo";
-		}
+		};
 
-		const bar = async function() {
+		const bar = async function () {
 			return (await foo()) + "bar";
-		}
+		};
 
 		const [success, value] = bar().await();
 		expect(success).to.equal(true);

--- a/tests/src/tests/set.spec.ts
+++ b/tests/src/tests/set.spec.ts
@@ -89,7 +89,7 @@ export = () => {
 		expect(set.has(f)).to.equal(true);
 		let i = 0;
 
-		let k = { x: i++ };
+		const k = { x: i++ };
 
 		new WeakSet();
 		new WeakSet([]);
@@ -128,10 +128,7 @@ export = () => {
 	});
 
 	it("should support has", () => {
-		const set = new Set<string>()
-			.add("a")
-			.add("b")
-			.add("c");
+		const set = new Set<string>().add("a").add("b").add("c");
 		set.has("a");
 		expect(set.has("a")).to.equal(true);
 		expect(set.has("b")).to.equal(true);
@@ -140,10 +137,7 @@ export = () => {
 	});
 
 	it("should support clear", () => {
-		const set = new Set<string>()
-			.add("a")
-			.add("b")
-			.add("c");
+		const set = new Set<string>().add("a").add("b").add("c");
 		set.clear();
 		expect(set.size()).to.equal(0);
 		expect(set.has("a")).to.equal(false);
@@ -152,10 +146,7 @@ export = () => {
 	});
 
 	it("should support delete", () => {
-		const set = new Set<string>()
-			.add("a")
-			.add("b")
-			.add("c");
+		const set = new Set<string>().add("a").add("b").add("c");
 		expect(set.size()).to.equal(3);
 		expect(set.has("b")).to.equal(true);
 		const hadB = set.delete("b");
@@ -174,10 +165,7 @@ export = () => {
 		let hitB = 0;
 		let hitC = 0;
 
-		const set = new Set<string>()
-			.add("a")
-			.add("b")
-			.add("c");
+		const set = new Set<string>().add("a").add("b").add("c");
 		set.forEach((value, value2, obj) => {
 			expect(value).to.equal(value2);
 			expect(obj).to.equal(set);
@@ -195,10 +183,7 @@ export = () => {
 	});
 
 	it("should support size", () => {
-		const set = new Set<string>()
-			.add("a")
-			.add("b")
-			.add("c");
+		const set = new Set<string>().add("a").add("b").add("c");
 		expect(set.size()).to.equal(3);
 		set.add("d");
 		expect(set.size()).to.equal(4);

--- a/tests/src/tests/string.spec.ts
+++ b/tests/src/tests/string.spec.ts
@@ -75,8 +75,8 @@ export = () => {
 	});
 
 	it("should support variable string indices", () => {
-		let i = 1;
-		let j = 3;
+		const i = 1;
+		const j = 3;
 		expect("foobar".sub(i, j)).to.equal("foo");
 	});
 
@@ -103,7 +103,7 @@ export = () => {
 		}
 
 		let j = 0;
-		let myStr = "யாமறிந்த";
+		const myStr = "யாமறிந்த";
 		for (const substr of myStr) {
 			expect(substr).to.equal(["ய", "ா", "ம", "ற", "ி", "ந", "்", "த"][j++]);
 		}
@@ -115,18 +115,28 @@ export = () => {
 
 		const obj = {
 			[`str
-			ing`]: "foo"
+			ing`]: "foo",
 		};
 
-		expect(obj[`str
-			ing`]).to.equal("foo");
+		expect(
+			obj[
+				`str
+			ing`
+			],
+		).to.equal("foo");
 		expect(obj[key]).to.equal("foo");
 
-		obj[`str
-			ing`] = "bar";
+		obj[
+			`str
+			ing`
+		] = "bar";
 
-		expect(obj[`str
-			ing`]).to.equal("bar");
+		expect(
+			obj[
+				`str
+			ing`
+			],
+		).to.equal("bar");
 		expect(obj[key]).to.equal("bar");
 	});
 

--- a/tests/src/tests/switch.spec.ts
+++ b/tests/src/tests/switch.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-duplicate-case */
 /// <reference types="@rbxts/testez/globals" />
 
 export = () => {
@@ -13,6 +14,7 @@ export = () => {
 					if (true) {
 						break;
 					}
+				// eslint-disable-next-line no-fallthrough
 				case "e": {
 					return 4;
 				}

--- a/tests/src/tests/ternary.spec.ts
+++ b/tests/src/tests/ternary.spec.ts
@@ -9,30 +9,30 @@ export = () => {
 	});
 
 	it("should support JS truthiness", () => {
-		let value = 123;
-		let zero = 0;
-		let emptyStr = "";
-		let NaN = 0/0;
+		const value = 123;
+		const zero = 0;
+		const emptyStr = "";
+		const nan = 0 / 0;
 
 		expect(value ? "PASS" : "FAIL").to.equal("PASS");
 		expect(zero ? "PASS" : "FAIL").to.equal("FAIL");
 		expect(emptyStr ? "PASS" : "FAIL").to.equal("FAIL");
-		expect(NaN ? "PASS" : "FAIL").to.equal("FAIL");
+		expect(nan ? "PASS" : "FAIL").to.equal("FAIL");
 	});
 
 	it("should support JS truthiness with prereqs", () => {
-		let value = 123;
-		let zero = 0;
-		let emptyStr = "";
-		let NaN = 0/0;
+		const value = 123;
+		const zero = 0;
+		const emptyStr = "";
+		const nan = 0 / 0;
 
 		let strA = "A";
 		let strB = "";
 
-		expect(value ? strA += "B" : "FAIL").to.equal("AB");
-		expect(zero ? "FAIL" : strB += "X").to.equal("X");
-		expect(emptyStr ? "FAIL" : strB += "Y").to.equal("XY");
-		expect(NaN ? "FAIL" : strB += "Z").to.equal("XYZ");
+		expect(value ? (strA += "B") : "FAIL").to.equal("AB");
+		expect(zero ? "FAIL" : (strB += "X")).to.equal("X");
+		expect(emptyStr ? "FAIL" : (strB += "Y")).to.equal("XY");
+		expect(nan ? "FAIL" : (strB += "Z")).to.equal("XYZ");
 	});
 
 	it("should correctly wrap if-expressions in parentheses where needed", () => {

--- a/tests/src/tests/try.spec.ts
+++ b/tests/src/tests/try.spec.ts
@@ -2,7 +2,7 @@
 
 export = () => {
 	it("should support try/catch", () => {
-		let x: number = 123;
+		let x = 123;
 		try {
 			x = 456;
 		} catch (e) {}

--- a/tests/src/tests/tuple.spec.ts
+++ b/tests/src/tests/tuple.spec.ts
@@ -121,6 +121,7 @@ export = () => {
 		}
 
 		function bar(): LuaTuple<[[number, string], boolean]> {
+			// prettier-ignore
 			return ([foo(), true] as unknown) as LuaTuple<[[number, string], boolean]>;
 		}
 
@@ -162,6 +163,7 @@ export = () => {
 
 	it("should allow LuaTuples to have Array<> inside", () => {
 		function foo(): LuaTuple<[number, number, ...Array<string>] | []> {
+			// prettier-ignore
 			return ([1, 2, "3"] as unknown) as LuaTuple<[number, number, ...Array<string>] | []>;
 		}
 


### PR DESCRIPTION
- Enables eslint on tests
- Fixes various formatting issues in tests
- Fixes `let` usage over `const` in tests where it does not change any inferred types
  - eslint-ignore comments added instead for the latter cases
- Removes and adds some parentheses where they do not affect tested behaviour
  - prettier-ignore comments added for the latter cases
- Changes ts-ignore to ts-expect-error with explanation in cases where illegal behaviour is tested anyways
- Adds a bunch of no-any tests for every case where `validateNoAny` is called
- Adds test cases for enums single quote escaping