### PR TITLE
Use path.resolve on both parameters in validateTypeRoots

### DIFF
--- a/src/Project/functions/validateCompilerOptions.ts
+++ b/src/Project/functions/validateCompilerOptions.ts
@@ -21,7 +21,7 @@ function y(str: string) {
 function validateTypeRoots(nodeModulesPath: string, typeRoots: Array<string>) {
 	const typesPath = path.resolve(nodeModulesPath);
 	for (const typeRoot of typeRoots) {
-		if (path.normalize(typeRoot) === typesPath) {
+		if (path.resolve(typeRoot) === typesPath) {
 			return true;
 		}
 	}


### PR DESCRIPTION
The previous implementation of `validateTypeRoots` only `path.resolve`'d the `nodeModulesPath` which would cause an error when when using `VirtualProject`.

`VirtualProject` uses `/node_modules/@rbxts` which get normalized to `\node_modules\@rbxts` (within `validateTypeRoots`)
but the first parameter `nodeModulesPath` is already normalized from the caller
`\node_modules\@rbxts` and then gets resolved to `C:\node_modules\@rbxts`.

Which causes the compare to fail
`path.normalize(typeRoot) === typesPath`
`path.normalize('/node_modules/@rbxts') === 'C:\\node_modules\\@rbxts'`
`'\\node_modules\\@rbxts' === 'C:\\node_modules\\@rbxts'`

The solution is to `path.resolve` both variables.