### PR TITLE
Fix #1877

### DIFF
--- a/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
@@ -24,11 +24,6 @@ export function transformElementAccessExpressionInner(
 	const expType = state.typeChecker.getNonOptionalType(state.getType(node.expression));
 	addIndexDiagnostics(state, node, expType);
 
-	const constantValue = getConstantValueLiteral(state, node);
-	if (constantValue) {
-		return constantValue;
-	}
-
 	const [index, prereqs] = state.capture(() => transformExpression(state, argumentExpression));
 
 	if (!luau.list.isEmpty(prereqs)) {
@@ -72,5 +67,10 @@ export function transformElementAccessExpressionInner(
 }
 
 export function transformElementAccessExpression(state: TransformState, node: ts.ElementAccessExpression) {
+	const constantValue = getConstantValueLiteral(state, node);
+	if (constantValue) {
+		return constantValue;
+	}
+
 	return transformOptionalChain(state, node);
 }

--- a/src/TSTransformer/nodes/expressions/transformIdentifier.ts
+++ b/src/TSTransformer/nodes/expressions/transformIdentifier.ts
@@ -4,7 +4,7 @@ import { assert } from "Shared/util/assert";
 import { getOrSetDefault } from "Shared/util/getOrSetDefault";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
-import { isBlockLike, isNonNamespaceModuleDeclaration } from "TSTransformer/typeGuards";
+import { isBlockLike, isNamespace } from "TSTransformer/typeGuards";
 import { isDefinedAsLet } from "TSTransformer/util/isDefinedAsLet";
 import { getAncestor, isAncestorOf, skipDownwards, skipUpwards } from "TSTransformer/util/traversal";
 import { getFirstConstructSymbol } from "TSTransformer/util/types";
@@ -147,7 +147,7 @@ export function transformIdentifier(state: TransformState, node: ts.Identifier) 
 	if (
 		symbol.valueDeclaration &&
 		symbol.valueDeclaration.getSourceFile() === node.getSourceFile() &&
-		getAncestor(symbol.valueDeclaration, isNonNamespaceModuleDeclaration) === undefined
+		getAncestor(symbol.valueDeclaration, node => ts.isModuleDeclaration(node) && !isNamespace(node)) === undefined
 	) {
 		const exportAccess = state.getModuleIdPropertyAccess(symbol);
 		if (exportAccess && isDefinedAsLet(state, symbol)) {

--- a/src/TSTransformer/nodes/expressions/transformIdentifier.ts
+++ b/src/TSTransformer/nodes/expressions/transformIdentifier.ts
@@ -4,7 +4,7 @@ import { assert } from "Shared/util/assert";
 import { getOrSetDefault } from "Shared/util/getOrSetDefault";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
-import { isBlockLike } from "TSTransformer/typeGuards";
+import { isBlockLike, isNonNamespaceModuleDeclaration } from "TSTransformer/typeGuards";
 import { isDefinedAsLet } from "TSTransformer/util/isDefinedAsLet";
 import { getAncestor, isAncestorOf, skipDownwards, skipUpwards } from "TSTransformer/util/traversal";
 import { getFirstConstructSymbol } from "TSTransformer/util/types";
@@ -147,7 +147,7 @@ export function transformIdentifier(state: TransformState, node: ts.Identifier) 
 	if (
 		symbol.valueDeclaration &&
 		symbol.valueDeclaration.getSourceFile() === node.getSourceFile() &&
-		getAncestor(symbol.valueDeclaration, ts.isModuleDeclaration) === undefined
+		getAncestor(symbol.valueDeclaration, isNonNamespaceModuleDeclaration) === undefined
 	) {
 		const exportAccess = state.getModuleIdPropertyAccess(symbol);
 		if (exportAccess && isDefinedAsLet(state, symbol)) {

--- a/src/TSTransformer/nodes/expressions/transformIdentifier.ts
+++ b/src/TSTransformer/nodes/expressions/transformIdentifier.ts
@@ -144,7 +144,11 @@ export function transformIdentifier(state: TransformState, node: ts.Identifier) 
 	}
 
 	// exit here for export let so we don't check hoist later
-	if (symbol.valueDeclaration && symbol.valueDeclaration.getSourceFile() === node.getSourceFile()) {
+	if (
+		symbol.valueDeclaration &&
+		symbol.valueDeclaration.getSourceFile() === node.getSourceFile() &&
+		getAncestor(symbol.valueDeclaration, ts.isModuleDeclaration) === undefined
+	) {
 		const exportAccess = state.getModuleIdPropertyAccess(symbol);
 		if (exportAccess && isDefinedAsLet(state, symbol)) {
 			return exportAccess;

--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -19,11 +19,6 @@ export function transformPropertyAccessExpressionInner(
 	validateNotAnyType(state, node.expression);
 	addIndexDiagnostics(state, node, state.typeChecker.getNonOptionalType(state.getType(node)));
 
-	const constantValue = getConstantValueLiteral(state, node);
-	if (constantValue) {
-		return constantValue;
-	}
-
 	if (ts.isDeleteExpression(skipUpwards(node).parent)) {
 		state.prereq(
 			luau.create(luau.SyntaxKind.Assignment, {
@@ -41,6 +36,11 @@ export function transformPropertyAccessExpressionInner(
 export function transformPropertyAccessExpression(state: TransformState, node: ts.PropertyAccessExpression) {
 	if (ts.isSuperProperty(node)) {
 		DiagnosticService.addDiagnostic(errors.noSuperProperty(node));
+	}
+
+	const constantValue = getConstantValueLiteral(state, node);
+	if (constantValue) {
+		return constantValue;
 	}
 
 	return transformOptionalChain(state, node);

--- a/src/TSTransformer/typeGuards.ts
+++ b/src/TSTransformer/typeGuards.ts
@@ -19,3 +19,9 @@ export function isUnaryAssignmentOperator(
 export function isTemplateLiteralType(type: ts.Type): type is ts.TemplateLiteralType {
 	return "texts" in type && "types" in type && !!(type.flags & ts.TypeFlags.TemplateLiteral);
 }
+
+export function isNonNamespaceModuleDeclaration(node: ts.Node): node is ts.ModuleDeclaration {
+	return (
+		ts.isModuleDeclaration(node) && (ts.isGlobalScopeAugmentation(node) || ts.isExternalModuleAugmentation(node))
+	);
+}

--- a/src/TSTransformer/typeGuards.ts
+++ b/src/TSTransformer/typeGuards.ts
@@ -20,8 +20,6 @@ export function isTemplateLiteralType(type: ts.Type): type is ts.TemplateLiteral
 	return "texts" in type && "types" in type && !!(type.flags & ts.TypeFlags.TemplateLiteral);
 }
 
-export function isNonNamespaceModuleDeclaration(node: ts.Node): node is ts.ModuleDeclaration {
-	return (
-		ts.isModuleDeclaration(node) && (ts.isGlobalScopeAugmentation(node) || ts.isExternalModuleAugmentation(node))
-	);
+export function isNamespace(node: ts.Node): node is ts.ModuleDeclaration {
+	return ts.isModuleDeclaration(node) && !!(node.flags & ts.NodeFlags.Namespace);
 }


### PR DESCRIPTION
Crash here happens due to trying to compile the enum identifier itself as part of the optional chaining logic, because that compiles from left -> right. Instead, we should just early out ASAP for const enum values.

Moves the `getConstantValueLiteral()` logic outside of the optional chaining logic. There shouldn't be any overlap here, and this will ensure that we don't try to compile the other parts of the expression.