### PR TITLE
Fix errors detected by luau.Node type change

### DIFF
--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -72,7 +72,7 @@ function makeEveryOrSomeMethod(
 		expression = state.pushToVarIfComplex(expression, "exp");
 
 		const resultId = state.pushToVar(luau.bool(initialState), "result");
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
@@ -245,7 +245,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	forEach: (state, node, expression, args) => {
 		expression = state.pushToVarIfComplex(expression, "exp");
 
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
 		state.prereq(
@@ -269,7 +269,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 			luau.call(luau.globals.table.create, [luau.unary("#", expression)]),
 			"newValue",
 		);
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
 		state.prereq(
@@ -296,7 +296,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		expression = state.pushToVarIfComplex(expression, "exp");
 
 		const newValueId = state.pushToVar(luau.array(), "newValue");
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const lengthId = state.pushToVar(luau.number(0), "length");
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
@@ -410,7 +410,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		expression = state.pushToVarIfComplex(expression, "exp");
 
 		const newValueId = state.pushToVar(luau.array(), "newValue");
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const lengthId = state.pushToVar(luau.number(0), "length");
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
@@ -520,7 +520,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	find: (state, node, expression, args) => {
 		expression = state.pushToVarIfComplex(expression, "exp");
 
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const loopId = luau.tempId("i");
 		const valueId = luau.tempId("v");
 		const resultId = state.pushToVar(undefined, "result");
@@ -556,7 +556,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	findIndex: (state, node, expression, args) => {
 		expression = state.pushToVarIfComplex(expression, "exp");
 
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const loopId = luau.tempId("i");
 		const valueId = luau.tempId("v");
 		const resultId = state.pushToVar(luau.number(-1), "result");
@@ -821,7 +821,7 @@ const READONLY_SET_METHODS: MacroList<PropertyCallMacro> = {
 	forEach: (state, node, expression, args) => {
 		expression = state.pushToVarIfComplex(expression, "exp");
 
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const valueId = luau.tempId("v");
 		state.prereq(
 			luau.create(luau.SyntaxKind.ForStatement, {
@@ -867,7 +867,7 @@ const READONLY_MAP_METHODS: MacroList<PropertyCallMacro> = {
 	forEach: (state, node, expression, args) => {
 		expression = state.pushToVarIfComplex(expression, "exp");
 
-		const callbackId = state.pushToVarIfComplex(args[0], "callback");
+		const callbackId = state.pushToVarIfNonId(args[0], "callback");
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
 		state.prereq(

--- a/src/TSTransformer/nodes/transformWritable.ts
+++ b/src/TSTransformer/nodes/transformWritable.ts
@@ -21,7 +21,7 @@ export function transformWritableExpression(
 	if (ts.isPropertyAccessExpression(node)) {
 		const expression = transformExpression(state, node.expression);
 		return luau.property(
-			readAfterWrite ? state.pushToVarIfComplex(expression, "exp") : convertToIndexableExpression(expression),
+			readAfterWrite ? state.pushToVarIfNonId(expression, "exp") : convertToIndexableExpression(expression),
 			node.name.text,
 		);
 	} else if (ts.isElementAccessExpression(node)) {
@@ -29,7 +29,7 @@ export function transformWritableExpression(
 		const indexExp = addOneIfArrayType(state, state.getType(node.expression), index);
 		return luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 			expression: readAfterWrite
-				? state.pushToVarIfComplex(expression, "exp")
+				? state.pushToVarIfNonId(expression, "exp")
 				: convertToIndexableExpression(expression),
 			index: readAfterWrite ? state.pushToVarIfComplex(indexExp, "index") : indexExp,
 		});


### PR DESCRIPTION
Adapting to the changes from roblox-ts/luau-ast#69

These are all cases where `pushToVarIfComplex` is used, but this does not push `false` and other literals, which are not indexable. These values are then used in cases that only accept indexable expressions, syntax-wise.
Also in all cases, the literals never appear without @ts-ignore comments, which will cause assertion fail while rendering. The only other simple node kinds are Identifier and TemporaryIdentifier. Therefore, switching to `pushToVarIfNonId` is not a change in behaviour.