### PR TITLE
Custom Math Prototype

### DIFF
--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -117,16 +117,31 @@ export class MacroManager {
 		}
 
 		for (const [className, methods] of Object.entries(PROPERTY_CALL_MACROS)) {
-			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, className, ts.SymbolFlags.Interface);
+			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, className, ts.SymbolFlags.All);
 
 			const methodMap = new Map<string, ts.Symbol>();
 			for (const declaration of symbol.declarations ?? []) {
 				if (ts.isInterfaceDeclaration(declaration)) {
 					for (const member of declaration.members) {
 						if (ts.isMethodSignature(member) && ts.isIdentifier(member.name)) {
-							const symbol = getType(typeChecker, member).symbol;
-							assert(symbol);
-							methodMap.set(member.name.text, symbol);
+							const memberSymbol = getType(typeChecker, member).symbol;
+							assert(memberSymbol);
+							methodMap.set(member.name.text, memberSymbol);
+						}
+					}
+				} else if (
+					ts.isTypeAliasDeclaration(declaration) &&
+					declaration.typeParameters &&
+					declaration.typeParameters.length === 1
+				) {
+					const type = declaration.type;
+					if (ts.isObjectTypeDeclaration(type)) {
+						for (const member of type.members) {
+							if (ts.isPropertySignature(member) && ts.isIdentifier(member.name)) {
+								const memberSymbol = typeChecker.getSymbolAtLocation(member.name);
+								assert(memberSymbol);
+								methodMap.set(member.name.text, memberSymbol);
+							}
 						}
 					}
 				}

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -1,5 +1,4 @@
 import luau from "@roblox-ts/luau-ast";
-import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { MacroList, PropertyCallMacro } from "TSTransformer/macros/types";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
@@ -17,24 +16,6 @@ function makeMathMethod(operator: luau.BinaryOperator): PropertyCallMacro {
 		}
 		return luau.binary(expression, operator, rhs);
 	};
-}
-
-const OPERATOR_TO_NAME_MAP = new Map<luau.BinaryOperator, "add" | "sub" | "mul" | "div" | "concat">([
-	["+", "add"],
-	["-", "sub"],
-	["*", "mul"],
-	["/", "div"],
-	["..", "concat"],
-]);
-
-function makeMathSet(...operators: Array<luau.BinaryOperator>) {
-	const result: { [index: string]: PropertyCallMacro } = {};
-	for (const operator of operators) {
-		const methodName = OPERATOR_TO_NAME_MAP.get(operator);
-		assert(methodName);
-		result[methodName] = makeMathMethod(operator);
-	}
-	return result;
 }
 
 function makeStringCallback(strCallback: luau.PropertyAccessExpression): PropertyCallMacro {
@@ -926,11 +907,11 @@ const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 };
 
 export const PROPERTY_CALL_MACROS: { [className: string]: MacroList<PropertyCallMacro> } = {
-	Add: makeMathSet("+"),
-	Sub: makeMathSet("-"),
-	Mul: makeMathSet("*"),
-	Div: makeMathSet("/"),
-	Concat: makeMathSet(".."),
+	Add: { add: makeMathMethod("+") },
+	Sub: { sub: makeMathMethod("-") },
+	Mul: { mul: makeMathMethod("*") },
+	Div: { div: makeMathMethod("/") },
+	Concat: { concat: makeMathMethod("..") },
 
 	String: STRING_CALLBACKS,
 	ArrayLike: ARRAY_LIKE_METHODS,

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -8,7 +8,7 @@ import { isDefinitelyType, isNumberType, isStringType } from "TSTransformer/util
 import { valueToIdStr } from "TSTransformer/util/valueToIdStr";
 import ts from "typescript";
 
-function makeMathMethod(operator: luau.BinaryOperator): PropertyCallMacro {
+function makeBinaryMacroMethod(operator: luau.BinaryOperator): PropertyCallMacro {
 	return (state, node, expression, args) => {
 		let rhs = args[0];
 		if (!luau.isSimple(rhs)) {
@@ -907,11 +907,11 @@ const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 };
 
 export const PROPERTY_CALL_MACROS: { [className: string]: MacroList<PropertyCallMacro> } = {
-	Add: { add: makeMathMethod("+") },
-	Sub: { sub: makeMathMethod("-") },
-	Mul: { mul: makeMathMethod("*") },
-	Div: { div: makeMathMethod("/") },
-	Concat: { concat: makeMathMethod("..") },
+	Add: { add: makeBinaryMacroMethod("+") },
+	Sub: { sub: makeBinaryMacroMethod("-") },
+	Mul: { mul: makeBinaryMacroMethod("*") },
+	Div: { div: makeBinaryMacroMethod("/") },
+	Concat: { concat: makeBinaryMacroMethod("..") },
 
 	String: STRING_CALLBACKS,
 	ArrayLike: ARRAY_LIKE_METHODS,

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -926,15 +926,6 @@ const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 };
 
 export const PROPERTY_CALL_MACROS: { [className: string]: MacroList<PropertyCallMacro> } = {
-	// math classes
-	// CFrame: makeMathSet("+", "-", "*"),
-	// UDim: makeMathSet("+", "-"),
-	// UDim2: makeMathSet("+", "-"),
-	// Vector2: makeMathSet("+", "-", "*", "/"),
-	// Vector2int16: makeMathSet("+", "-", "*", "/"),
-	// Vector3: makeMathSet("+", "-", "*", "/"),
-	// Vector3int16: makeMathSet("+", "-", "*", "/"),
-
 	Add: makeMathSet("+"),
 	Sub: makeMathSet("-"),
 	Mul: makeMathSet("*"),

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -19,11 +19,12 @@ function makeMathMethod(operator: luau.BinaryOperator): PropertyCallMacro {
 	};
 }
 
-const OPERATOR_TO_NAME_MAP = new Map<luau.BinaryOperator, "add" | "sub" | "mul" | "div">([
+const OPERATOR_TO_NAME_MAP = new Map<luau.BinaryOperator, "add" | "sub" | "mul" | "div" | "concat">([
 	["+", "add"],
 	["-", "sub"],
 	["*", "mul"],
 	["/", "div"],
+	["..", "concat"],
 ]);
 
 function makeMathSet(...operators: Array<luau.BinaryOperator>) {
@@ -926,13 +927,19 @@ const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 
 export const PROPERTY_CALL_MACROS: { [className: string]: MacroList<PropertyCallMacro> } = {
 	// math classes
-	CFrame: makeMathSet("+", "-", "*"),
-	UDim: makeMathSet("+", "-"),
-	UDim2: makeMathSet("+", "-"),
-	Vector2: makeMathSet("+", "-", "*", "/"),
-	Vector2int16: makeMathSet("+", "-", "*", "/"),
-	Vector3: makeMathSet("+", "-", "*", "/"),
-	Vector3int16: makeMathSet("+", "-", "*", "/"),
+	// CFrame: makeMathSet("+", "-", "*"),
+	// UDim: makeMathSet("+", "-"),
+	// UDim2: makeMathSet("+", "-"),
+	// Vector2: makeMathSet("+", "-", "*", "/"),
+	// Vector2int16: makeMathSet("+", "-", "*", "/"),
+	// Vector3: makeMathSet("+", "-", "*", "/"),
+	// Vector3int16: makeMathSet("+", "-", "*", "/"),
+
+	Add: makeMathSet("+"),
+	Sub: makeMathSet("-"),
+	Mul: makeMathSet("*"),
+	Div: makeMathSet("/"),
+	Concat: makeMathSet(".."),
 
 	String: STRING_CALLBACKS,
 	ArrayLike: ARRAY_LIKE_METHODS,

--- a/src/TSTransformer/nodes/expressions/transformCallExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformCallExpression.ts
@@ -198,6 +198,14 @@ export function transformPropertyCallExpressionInner(
 		}
 	}
 
+	const expSymbol = state.typeChecker.getSymbolAtLocation(node.expression)?.valueDeclaration?.symbol;
+	if (expSymbol) {
+		const macro = state.services.macroManager.getPropertyCallMacro(expSymbol);
+		if (macro) {
+			return runCallMacro(macro, state, node, baseExpression, nodeArguments);
+		}
+	}
+
 	const [args, prereqs] = state.capture(() => ensureTransformOrder(state, nodeArguments));
 	fixVoidArgumentsForRobloxFunctions(state, symbol, args, nodeArguments);
 


### PR DESCRIPTION
Added these types to `@rbxts/compiler-types` 
```TS
type Add<T> = { add: T };
type Sub<T> = { sub: T };
type Mul<T> = { mul: T };
type Div<T> = { div: T };
type Concat<T> = { concat: T };
```

Then defined `CFrame` in `@rbxts/types` as:
```TS
interface CFrame extends
	Add<{
		(this: CFrame, v3: Vector3): CFrame;
	}>,
	Sub<{
		(this: CFrame, v3: Vector3): CFrame;
	}>,
	Mul<{
		(this: CFrame, cframe: CFrame): CFrame;
		(this: CFrame, v3: Vector3): CFrame;
		(this: CFrame, other: CFrame | Vector3): CFrame | Vector3;
	}>
{
    // definition here
}
```

Examples:
```TS
interface MyType
	extends Concat<{
		(this: MyType, other: number): string;
	}> {}

declare const a: CFrame;
declare const b: Vector3;
const c = a.add(b); // a + b

declare const foo: MyType;
const x = foo.concat(123); // foo .. 123
```