### PR TITLE
Ban `@ts-ignore` and add --allowCommentDirectives

### DIFF
--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -103,6 +103,10 @@ export = ts.identity<yargs.CommandModule<{}, BuildFlags & Partial<ProjectOptions
 			.option("rojo", {
 				string: true,
 				describe: "manually select Rojo project file",
+			})
+			.option("allowCommentDirectives", {
+				boolean: true,
+				hidden: true,
 			}),
 
 	handler: async argv => {

--- a/src/CLI/test.ts
+++ b/src/CLI/test.ts
@@ -21,14 +21,9 @@ describe("should compile tests project", () => {
 	const data = createProjectData(
 		path.join(PACKAGE_ROOT, "tests", "tsconfig.json"),
 		Object.assign({}, DEFAULT_PROJECT_OPTIONS, {
-			logTruthyChanges: false,
-			noInclude: false,
 			project: "",
-			usePolling: false,
-			verbose: false,
-			watch: false,
-			writeOnlyChanged: false,
-			optimizedLoops: false,
+			allowCommentDirectives: true,
+			optimizedLoops: true,
 		}),
 	);
 	const program = createProjectProgram(data);

--- a/src/Project/classes/VirtualProject.ts
+++ b/src/Project/classes/VirtualProject.ts
@@ -119,7 +119,7 @@ export class VirtualProject {
 
 		const diagnostics = new Array<ts.Diagnostic>();
 		diagnostics.push(...ts.getPreEmitDiagnostics(this.program, sourceFile));
-		diagnostics.push(...getCustomPreEmitDiagnostics(sourceFile));
+		diagnostics.push(...getCustomPreEmitDiagnostics(this.data, sourceFile));
 		if (hasErrors(diagnostics)) throw new DiagnosticError(diagnostics);
 
 		const multiTransformState = new MultiTransformState();

--- a/src/Project/functions/compileFiles.ts
+++ b/src/Project/functions/compileFiles.ts
@@ -162,7 +162,7 @@ export function compileFiles(
 		const progress = `${i + 1}/${sourceFiles.length}`.padStart(progressMaxLength);
 		benchmarkIfVerbose(`${progress} compile ${path.relative(process.cwd(), sourceFile.fileName)}`, () => {
 			DiagnosticService.addDiagnostics(ts.getPreEmitDiagnostics(proxyProgram, sourceFile));
-			DiagnosticService.addDiagnostics(getCustomPreEmitDiagnostics(sourceFile));
+			DiagnosticService.addDiagnostics(getCustomPreEmitDiagnostics(data, sourceFile));
 			if (DiagnosticService.hasErrors()) return;
 
 			const transformState = new TransformState(

--- a/src/Project/preEmitDiagnostics/fileUsesCommentDirectives.ts
+++ b/src/Project/preEmitDiagnostics/fileUsesCommentDirectives.ts
@@ -1,0 +1,34 @@
+import { errors } from "Shared/diagnostics";
+import { ProjectData } from "Shared/types";
+import ts from "typescript";
+
+export function fileUsesCommentDirectives(data: ProjectData, sourceFile: ts.SourceFile) {
+	if (data.projectOptions.allowCommentDirectives) {
+		return [];
+	}
+
+	const diagnostics = new Array<ts.Diagnostic>();
+
+	for (const commentDirective of sourceFile.commentDirectives ?? []) {
+		diagnostics.push(
+			errors.noCommentDirectives({
+				sourceFile,
+				range: commentDirective.range,
+			}),
+		);
+	}
+
+	const tsNoCheckPragma = sourceFile.pragmas.get("ts-nocheck");
+	if (tsNoCheckPragma) {
+		for (const pragma of Array.isArray(tsNoCheckPragma) ? tsNoCheckPragma : [tsNoCheckPragma]) {
+			diagnostics.push(
+				errors.noCommentDirectives({
+					sourceFile,
+					range: pragma.range,
+				}),
+			);
+		}
+	}
+
+	return diagnostics;
+}

--- a/src/Project/util/getCustomPreEmitDiagnostics.ts
+++ b/src/Project/util/getCustomPreEmitDiagnostics.ts
@@ -1,12 +1,16 @@
+import { fileUsesCommentDirectives } from "Project/preEmitDiagnostics/fileUsesCommentDirectives";
+import { ProjectData } from "Shared/types";
 import ts from "typescript";
 
-export type PreEmitChecker = (sourceFile: ts.SourceFile) => Array<ts.Diagnostic>;
-const PRE_EMIT_DIAGNOSTICS: Array<PreEmitChecker> = [];
+export type PreEmitChecker = (data: ProjectData, sourceFile: ts.SourceFile) => Array<ts.Diagnostic>;
+const PRE_EMIT_DIAGNOSTICS: Array<PreEmitChecker> = [fileUsesCommentDirectives];
 
-export function getCustomPreEmitDiagnostics(sourceFile: ts.SourceFile) {
+export function getCustomPreEmitDiagnostics(data: ProjectData, sourceFile: ts.SourceFile) {
 	const diagnostics = new Array<ts.Diagnostic>();
-	for (const check of PRE_EMIT_DIAGNOSTICS) {
-		diagnostics.push(...check(sourceFile));
+	if (!data.projectOptions.allowCommentDirectives) {
+		for (const check of PRE_EMIT_DIAGNOSTICS) {
+			diagnostics.push(...check(data, sourceFile));
+		}
 	}
 	return diagnostics;
 }

--- a/src/Project/util/getCustomPreEmitDiagnostics.ts
+++ b/src/Project/util/getCustomPreEmitDiagnostics.ts
@@ -7,10 +7,8 @@ const PRE_EMIT_DIAGNOSTICS: Array<PreEmitChecker> = [fileUsesCommentDirectives];
 
 export function getCustomPreEmitDiagnostics(data: ProjectData, sourceFile: ts.SourceFile) {
 	const diagnostics = new Array<ts.Diagnostic>();
-	if (!data.projectOptions.allowCommentDirectives) {
-		for (const check of PRE_EMIT_DIAGNOSTICS) {
-			diagnostics.push(...check(data, sourceFile));
-		}
+	for (const check of PRE_EMIT_DIAGNOSTICS) {
+		diagnostics.push(...check(data, sourceFile));
 	}
 	return diagnostics;
 }

--- a/src/Shared/constants.ts
+++ b/src/Shared/constants.ts
@@ -51,4 +51,5 @@ export const DEFAULT_PROJECT_OPTIONS: ProjectOptions = {
 	logTruthyChanges: false,
 	writeOnlyChanged: false,
 	optimizedLoops: false,
+	allowCommentDirectives: false,
 };

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -1,12 +1,13 @@
 import { RbxPath } from "@roblox-ts/rojo-resolver";
 import kleur from "kleur";
+import { SourceFileWithTextRange } from "Shared/types";
 import { createDiagnosticWithLocation } from "Shared/util/createDiagnosticWithLocation";
 import { createTextDiagnostic } from "Shared/util/createTextDiagnostic";
 import ts from "typescript";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DiagnosticFactory<T extends Array<any> = []> = {
-	(node: ts.Node, ...context: T): ts.DiagnosticWithLocation;
+	(node: ts.Node | SourceFileWithTextRange, ...context: T): ts.DiagnosticWithLocation;
 	id: number;
 };
 
@@ -47,7 +48,7 @@ function diagnosticWithContext<T extends Array<any> = []>(
 	contextFormatter?: DiagnosticContextFormatter<T>,
 	...messages: Array<string | false>
 ): DiagnosticFactory<T> {
-	const result = (node: ts.Node, ...context: T) => {
+	const result = (node: ts.Node | SourceFileWithTextRange, ...context: T) => {
 		if (category === ts.DiagnosticCategory.Error) {
 			debugger;
 		}
@@ -163,6 +164,11 @@ export const errors = {
 	noIndexWithoutCall: error(
 		"Cannot index a method without calling it!",
 		suggestion("Use the form `() => a.b()` instead of `a.b`."),
+	),
+	noCommentDirectives: error(
+		"Usage of `@ts-ignore`, `@ts-expect-error`, and `@ts-nocheck` are not supported!",
+		"roblox-ts needs type and symbol info to compile correctly.",
+		suggestion("Consider using type assertions or `declare` statements."),
 	),
 
 	// macro methods

--- a/src/Shared/types.ts
+++ b/src/Shared/types.ts
@@ -12,6 +12,7 @@ export interface ProjectOptions {
 	watch: boolean;
 	writeOnlyChanged: boolean;
 	optimizedLoops: boolean;
+	allowCommentDirectives: boolean;
 }
 
 export interface ProjectData {
@@ -65,4 +66,9 @@ export interface TransformerPluginConfig {
 	 * any other properties provided to the transformer as config argument
 	 * */
 	[options: string]: unknown;
+}
+
+export interface SourceFileWithTextRange {
+	sourceFile: ts.SourceFile;
+	range: ts.ReadonlyTextRange;
 }

--- a/src/Shared/util/createDiagnosticWithLocation.ts
+++ b/src/Shared/util/createDiagnosticWithLocation.ts
@@ -1,19 +1,35 @@
+import { SourceFileWithTextRange } from "Shared/types";
 import ts from "typescript";
 
 export function createDiagnosticWithLocation(
 	id: number,
-	message: string,
+	messageText: string,
 	category: ts.DiagnosticCategory,
-	node: ts.Node,
+	node: ts.Node | SourceFileWithTextRange,
 ): ts.DiagnosticWithLocation {
-	return {
-		category,
-		code: " roblox-ts" as unknown as number,
-		file: node.getSourceFile(),
-		messageText: message,
-		start: node.getStart(),
-		length: node.getWidth(),
-		diagnosticType: 0,
-		id,
-	} as ts.DiagnosticWithLocation;
+	const code = " roblox-ts" as never;
+	const diagnosticType = 0;
+	if ("kind" in node) {
+		return {
+			category,
+			code,
+			messageText,
+			diagnosticType,
+			id,
+			file: node.getSourceFile(),
+			start: node.getStart(),
+			length: node.getWidth(),
+		} as ts.DiagnosticWithLocation;
+	} else {
+		return {
+			category,
+			code,
+			messageText,
+			diagnosticType,
+			id,
+			file: node.sourceFile,
+			start: node.range.pos,
+			length: node.range.end,
+		} as ts.DiagnosticWithLocation;
+	}
 }


### PR DESCRIPTION
Bans:
- `@ts-ignore`
- `@ts-expect-error`
- `@ts-nocheck`

Adds a project option / CLI flag: --allowCommentDirectives to skip these checks.

Reworked diagnostics a bit to allow for `ts.SourceFile` + `ts.ReadonlyTextRange` instead of a `ts.Node`