### PR TITLE
Add project.json files to package template

### DIFF
--- a/src/CLI/commands/init.ts
+++ b/src/CLI/commands/init.ts
@@ -210,7 +210,7 @@ async function init(argv: yargs.Arguments<InitOptions>, initMode: InitMode) {
 			pkgJson.name = RBXTS_SCOPE + "/" + pkgJson.name;
 			pkgJson.main = "out/init.lua";
 			pkgJson.types = "out/index.d.ts";
-			pkgJson.files = ["out", "!**/*.tsbuildinfo"];
+			pkgJson.files = ["out", "default.project.json", "!**/*.tsbuildinfo"];
 			pkgJson.publishConfig = { access: "public" };
 			pkgJson.scripts.prepublishOnly = selectedPackageManager.build;
 		}

--- a/templates/package/default.project.json
+++ b/templates/package/default.project.json
@@ -1,0 +1,18 @@
+{
+	"name": "roblox-ts-package",
+	"globIgnorePaths": [
+		"**/package.json",
+		"**/tsconfig.json"
+	],
+	"tree": {
+		"$path": "out",
+		"node_modules": {
+			"$className": "Folder",
+			"@rbxts": {
+				"$path": {
+					"optional": "node_modules/@rbxts"
+				}
+			}
+		}
+	}
+}

--- a/templates/package/serve.project.json
+++ b/templates/package/serve.project.json
@@ -1,0 +1,16 @@
+{
+	"name": "roblox-ts-package-serve",
+	"globIgnorePaths": [
+		"**/package.json",
+		"**/tsconfig.json"
+	],
+	"tree": {
+		"$className": "DataModel",
+		"ServerScriptService": {
+			"$className": "ServerScriptService",
+			"Package": {
+				"$path": "out"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds a `default.project.json` and `serve.project.json`.

The `default.project.json` will allow for packages to be put into Studio without the need for an intermediary `out` folder. It also gives a good starting point for more advanced configurations.

The `serve.project.json` allows you to use `rojo serve` or `rojo build` to create a place file from your project. This is useful for experimenting, running unit tests, or testing UI with stories.

TODO: Need to automatically set `default.project.json` "name" field to the package's name without scope. Otherwise, it ends up with the wrong name in Studio. We _could_ allow this by statically mapping to the in-Studio name, but this invites issues like possible name collisions with other packages..