### PR TITLE
Remove test-setup script from main test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"eslint": "eslint \"src/**/*.ts\" --max-warnings 0",
 		"devlink": "npm run build && cd devlink && npm link",
 		"test": "npm run build && npm run test-compile && npm run test-rojo && npm run test-run",
+		"test-setup": "cd tests && npm install github:roblox-ts/compiler-types @rbxts/types@latest",
 		"test-compile": "nyc mocha --timeout 0 --recursive out/CLI/test.js",
 		"test-rojo": "rojo build tests -o ./tests/test.rbxlx",
 		"test-run": "run-in-roblox --place ./tests/test.rbxlx --script ./tests/out/main.server.lua"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
 		"build-watch": "ttsc -b -w",
 		"eslint": "eslint \"src/**/*.ts\" --max-warnings 0",
 		"devlink": "npm run build && cd devlink && npm link",
-		"test": "npm run build && npm run test-setup && npm run test-compile && npm run test-rojo && npm run test-run",
-		"test-setup": "cd tests && npm install github:roblox-ts/compiler-types @rbxts/types@latest",
+		"test": "npm run build && npm run test-compile && npm run test-rojo && npm run test-run",
 		"test-compile": "nyc mocha --timeout 0 --recursive out/CLI/test.js",
 		"test-rojo": "rojo build tests -o ./tests/test.rbxlx",
 		"test-run": "run-in-roblox --place ./tests/test.rbxlx --script ./tests/out/main.server.lua"


### PR DESCRIPTION
The `test-setup` script negatively affects testing because it always tries installing the most recent types. This makes `npm test` fail for older versions, which can be especially annoying while trying to `git bisect`. The behaviour of testing the current compiler with the newest types is retained in the github CI workflow, which calls the individual test steps separately, and continues to execute `test-setup`.