### PR TITLE
Add eslint-plugin-deprecation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,13 +12,10 @@
 		"@typescript-eslint/eslint-plugin",
 		"prettier",
 		"simple-import-sort",
-		"no-autofix"
+		"no-autofix",
+		"deprecation"
 	],
-	"extends": [
-		"eslint:recommended",
-		"plugin:@typescript-eslint/recommended",
-		"plugin:prettier/recommended"
-	],
+	"extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
 	"rules": {
 		"prettier/prettier": "warn",
 		"@typescript-eslint/array-type": [
@@ -28,10 +25,7 @@
 				"readonly": "generic"
 			}
 		],
-		"@typescript-eslint/no-floating-promises": [
-			"error",
-			{ "ignoreVoid": true }
-		],
+		"@typescript-eslint/no-floating-promises": ["error", { "ignoreVoid": true }],
 		"@typescript-eslint/no-unused-vars": "warn",
 		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/interface-name-prefix": "off",
@@ -52,6 +46,7 @@
 		"no-undef-init": "error",
 		"prefer-const": "off",
 		"simple-import-sort/exports": "warn",
-		"simple-import-sort/imports": "warn"
+		"simple-import-sort/imports": "warn",
+		"deprecation/deprecation": "warn"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
 				"@typescript-eslint/parser": "^5.36.2",
 				"eslint": "^8.23.0",
 				"eslint-config-prettier": "^8.5.0",
-				"eslint-plugin-deprecation": "^1.3.3",
 				"eslint-plugin-no-autofix": "^1.2.3",
 				"eslint-plugin-prettier": "^4.2.1",
 				"eslint-plugin-simple-import-sort": "^8.0.0",
@@ -797,66 +796,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@typescript-eslint/experimental-utils": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.49.0.tgz",
-			"integrity": "sha512-veLpCJLYn44Fru7mSvi2doxQMzMCOFSDYdMUQhAzaH1vFYq2RVNpecZ8d18Wh6UMv07yahXkiv/aShWE48iE9Q==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/utils": "5.49.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/utils": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
-			"integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.49.0",
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/typescript-estree": "5.49.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0",
-				"semver": "^7.3.7"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
@@ -982,23 +921,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
-			"integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/type-utils": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
@@ -1093,61 +1015,6 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@typescript-eslint/types": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
-			"integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
-			"integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
 			"version": "7.3.8",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
 			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
@@ -1284,32 +1151,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
-			"integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "5.49.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/acorn": {
@@ -1784,27 +1625,6 @@
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
 			}
-		},
-		"node_modules/eslint-plugin-deprecation": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
-			"integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/experimental-utils": "^5.0.0",
-				"tslib": "^2.3.1",
-				"tsutils": "^3.21.0"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
-				"typescript": "^3.7.5 || ^4.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-deprecation/node_modules/tslib": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-			"dev": true
 		},
 		"node_modules/eslint-plugin-no-autofix": {
 			"version": "1.2.3",
@@ -4989,42 +4809,6 @@
 				}
 			}
 		},
-		"@typescript-eslint/experimental-utils": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.49.0.tgz",
-			"integrity": "sha512-veLpCJLYn44Fru7mSvi2doxQMzMCOFSDYdMUQhAzaH1vFYq2RVNpecZ8d18Wh6UMv07yahXkiv/aShWE48iE9Q==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/utils": "5.49.0"
-			},
-			"dependencies": {
-				"@typescript-eslint/utils": {
-					"version": "5.49.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
-					"integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.9",
-						"@types/semver": "^7.3.12",
-						"@typescript-eslint/scope-manager": "5.49.0",
-						"@typescript-eslint/types": "5.49.0",
-						"@typescript-eslint/typescript-estree": "5.49.0",
-						"eslint-scope": "^5.1.1",
-						"eslint-utils": "^3.0.0",
-						"semver": "^7.3.7"
-					}
-				},
-				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
-			}
-		},
 		"@typescript-eslint/parser": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
@@ -5095,16 +4879,6 @@
 				}
 			}
 		},
-		"@typescript-eslint/scope-manager": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
-			"integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0"
-			}
-		},
 		"@typescript-eslint/type-utils": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
@@ -5154,38 +4928,6 @@
 					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
 					"dev": true
 				},
-				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
-			}
-		},
-		"@typescript-eslint/types": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
-			"integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
-			"dev": true
-		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
-			"integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/types": "5.49.0",
-				"@typescript-eslint/visitor-keys": "5.49.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
 				"semver": {
 					"version": "7.3.8",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -5268,24 +5010,6 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
-				}
-			}
-		},
-		"@typescript-eslint/visitor-keys": {
-			"version": "5.49.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
-			"integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/types": "5.49.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-					"dev": true
 				}
 			}
 		},
@@ -5768,25 +5492,6 @@
 			"integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
 			"dev": true,
 			"requires": {}
-		},
-		"eslint-plugin-deprecation": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
-			"integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/experimental-utils": "^5.0.0",
-				"tslib": "^2.3.1",
-				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-					"dev": true
-				}
-			}
 		},
 		"eslint-plugin-no-autofix": {
 			"version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
 				"@typescript-eslint/parser": "^5.36.2",
 				"eslint": "^8.23.0",
 				"eslint-config-prettier": "^8.5.0",
+				"eslint-plugin-deprecation": "^1.3.3",
 				"eslint-plugin-no-autofix": "^1.2.3",
 				"eslint-plugin-prettier": "^4.2.1",
 				"eslint-plugin-simple-import-sort": "^9.0.0",
@@ -740,6 +741,25 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@typescript-eslint/experimental-utils": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.49.0.tgz",
+			"integrity": "sha512-veLpCJLYn44Fru7mSvi2doxQMzMCOFSDYdMUQhAzaH1vFYq2RVNpecZ8d18Wh6UMv07yahXkiv/aShWE48iE9Q==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/utils": "5.49.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "5.49.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
@@ -1405,6 +1425,27 @@
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
 			}
+		},
+		"node_modules/eslint-plugin-deprecation": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
+			"integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/experimental-utils": "^5.0.0",
+				"tslib": "^2.3.1",
+				"tsutils": "^3.21.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"typescript": "^3.7.5 || ^4.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-deprecation/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+			"dev": true
 		},
 		"node_modules/eslint-plugin-no-autofix": {
 			"version": "1.2.3",
@@ -4557,6 +4598,15 @@
 				}
 			}
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.49.0.tgz",
+			"integrity": "sha512-veLpCJLYn44Fru7mSvi2doxQMzMCOFSDYdMUQhAzaH1vFYq2RVNpecZ8d18Wh6UMv07yahXkiv/aShWE48iE9Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/utils": "5.49.0"
+			}
+		},
 		"@typescript-eslint/parser": {
 			"version": "5.49.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
@@ -5147,6 +5197,25 @@
 			"integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
 			"dev": true,
 			"requires": {}
+		},
+		"eslint-plugin-deprecation": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
+			"integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^5.0.0",
+				"tslib": "^2.3.1",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
+			}
 		},
 		"eslint-plugin-no-autofix": {
 			"version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
 				"@typescript-eslint/parser": "^5.36.2",
 				"eslint": "^8.23.0",
 				"eslint-config-prettier": "^8.5.0",
+				"eslint-plugin-deprecation": "^1.3.3",
 				"eslint-plugin-no-autofix": "^1.2.3",
 				"eslint-plugin-prettier": "^4.2.1",
 				"eslint-plugin-simple-import-sort": "^8.0.0",
@@ -796,6 +797,66 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@typescript-eslint/experimental-utils": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.49.0.tgz",
+			"integrity": "sha512-veLpCJLYn44Fru7mSvi2doxQMzMCOFSDYdMUQhAzaH1vFYq2RVNpecZ8d18Wh6UMv07yahXkiv/aShWE48iE9Q==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/utils": "5.49.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/utils": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
+			"integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.49.0",
+				"@typescript-eslint/types": "5.49.0",
+				"@typescript-eslint/typescript-estree": "5.49.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0",
+				"semver": "^7.3.7"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/experimental-utils/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
@@ -921,6 +982,23 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+			"integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.49.0",
+				"@typescript-eslint/visitor-keys": "5.49.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/type-utils": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
@@ -1015,6 +1093,61 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+			"integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+			"integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.49.0",
+				"@typescript-eslint/visitor-keys": "5.49.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
 			"version": "7.3.8",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
 			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
@@ -1151,6 +1284,32 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+			"integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.49.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/acorn": {
@@ -1625,6 +1784,27 @@
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
 			}
+		},
+		"node_modules/eslint-plugin-deprecation": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
+			"integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/experimental-utils": "^5.0.0",
+				"tslib": "^2.3.1",
+				"tsutils": "^3.21.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"typescript": "^3.7.5 || ^4.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-deprecation/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+			"dev": true
 		},
 		"node_modules/eslint-plugin-no-autofix": {
 			"version": "1.2.3",
@@ -4809,6 +4989,42 @@
 				}
 			}
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.49.0.tgz",
+			"integrity": "sha512-veLpCJLYn44Fru7mSvi2doxQMzMCOFSDYdMUQhAzaH1vFYq2RVNpecZ8d18Wh6UMv07yahXkiv/aShWE48iE9Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/utils": "5.49.0"
+			},
+			"dependencies": {
+				"@typescript-eslint/utils": {
+					"version": "5.49.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
+					"integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.9",
+						"@types/semver": "^7.3.12",
+						"@typescript-eslint/scope-manager": "5.49.0",
+						"@typescript-eslint/types": "5.49.0",
+						"@typescript-eslint/typescript-estree": "5.49.0",
+						"eslint-scope": "^5.1.1",
+						"eslint-utils": "^3.0.0",
+						"semver": "^7.3.7"
+					}
+				},
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
 		"@typescript-eslint/parser": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
@@ -4879,6 +5095,16 @@
 				}
 			}
 		},
+		"@typescript-eslint/scope-manager": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+			"integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "5.49.0",
+				"@typescript-eslint/visitor-keys": "5.49.0"
+			}
+		},
 		"@typescript-eslint/type-utils": {
 			"version": "5.48.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz",
@@ -4928,6 +5154,38 @@
 					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
 					"dev": true
 				},
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+			"integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
+			"dev": true
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+			"integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "5.49.0",
+				"@typescript-eslint/visitor-keys": "5.49.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
 				"semver": {
 					"version": "7.3.8",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -5010,6 +5268,24 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
+				}
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+			"integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "5.49.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+					"dev": true
 				}
 			}
 		},
@@ -5492,6 +5768,25 @@
 			"integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
 			"dev": true,
 			"requires": {}
+		},
+		"eslint-plugin-deprecation": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
+			"integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^5.0.0",
+				"tslib": "^2.3.1",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
+			}
 		},
 		"eslint-plugin-no-autofix": {
 			"version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"@typescript-eslint/parser": "^5.36.2",
 		"eslint": "^8.23.0",
 		"eslint-config-prettier": "^8.5.0",
+		"eslint-plugin-deprecation": "^1.3.3",
 		"eslint-plugin-no-autofix": "^1.2.3",
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-simple-import-sort": "^8.0.0",


### PR DESCRIPTION
Guards against using deprecated properties/methods/functions, like `node.decorators` since TS 4.8.