### PR TITLE
Fix broken optimized loop cases where condition doesn't match incrementor

### DIFF
--- a/src/TSTransformer/nodes/statements/transformForStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForStatement.ts
@@ -430,7 +430,8 @@ function transformForStatementOptimized(state: TransformState, node: ts.ForState
 		condition.operatorToken.kind === ts.SyntaxKind.LessThanToken ||
 		condition.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken
 	) {
-		// for (let i = 0; i < 10; i++)
+		// do not optimize for cases which should never run like:
+		// for (let i = 10; i < 0; i--)
 		if (stepValue < 0) {
 			return undefined;
 		}
@@ -438,12 +439,13 @@ function transformForStatementOptimized(state: TransformState, node: ts.ForState
 		condition.operatorToken.kind === ts.SyntaxKind.GreaterThanToken ||
 		condition.operatorToken.kind === ts.SyntaxKind.GreaterThanEqualsToken
 	) {
-		// for (let i = 10; i >= 0; i--)
+		// do not optimize for cases which should never run like:
+		// for (let i = 0; i > 10; i++)
 		if (stepValue > 0) {
 			return undefined;
 		}
 	} else {
-		// other comparison operators like !==, ===
+		// do not optimize for other comparison operators like !==, ===
 		return undefined;
 	}
 

--- a/src/TSTransformer/nodes/statements/transformForStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForStatement.ts
@@ -393,7 +393,9 @@ function isProbablyInteger(state: TransformState, expression: ts.Expression): bo
 function transformForStatementOptimized(state: TransformState, node: ts.ForStatement) {
 	const { initializer, condition, incrementor, statement } = node;
 
-	// validate initializer
+	// this function is difficult to break up because it uses several type guard functions..
+
+	// validate initializer exists and is a single identifier `x` with a value that is _probably_ an integer
 
 	if (!initializer || !ts.isVariableDeclarationList(initializer) || initializer.declarations.length !== 1) {
 		return undefined;
@@ -409,7 +411,11 @@ function transformForStatementOptimized(state: TransformState, node: ts.ForState
 		return undefined;
 	}
 
-	// validate incrementor
+	if (!isProbablyInteger(state, decInit)) {
+		return undefined;
+	}
+
+	// validate incrementor exists and is _probably_ an integer change in `x`
 
 	if (!incrementor) {
 		return undefined;
@@ -420,7 +426,7 @@ function transformForStatementOptimized(state: TransformState, node: ts.ForState
 		return undefined;
 	}
 
-	// validate condition
+	// validate condition exists and is a BinaryExpression with an operator that matches the incrementor
 
 	if (!condition || !ts.isBinaryExpression(condition)) {
 		return undefined;
@@ -449,7 +455,7 @@ function transformForStatementOptimized(state: TransformState, node: ts.ForState
 		return undefined;
 	}
 
-	if (!isProbablyInteger(state, decInit) || !isProbablyInteger(state, condition.right)) {
+	if (!isProbablyInteger(state, condition.right)) {
 		return undefined;
 	}
 


### PR DESCRIPTION
Fixes two broken unit tests by reverting their emit to the unoptimized case.

## Problem

The previous check allowed `<`, `<=`, `>`, or `>=`.

However, this caused broken behavior with invalid loops that shouldn't actually run:
```ts
for (let i = 3; i <= 1; i -= 1) {
	print(i);
}
```

would compile into:
```lua
for i = 3, 1, -1 do
	print(i)
end
```

## Solution

The new check allows:
- `<`, `<=` with `i++`
- `>` and `>=` with `i--`
(or similar incrementors like `i += 5`, etc.)