### PR TITLE
Remove ajv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@roblox-ts/luau-ast": "^1.0.8",
 				"@roblox-ts/rojo-resolver": "^1.0.4",
-				"ajv": "^8.12.0",
 				"chokidar": "^3.5.3",
 				"fs-extra": "^11.1.0",
 				"kleur": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 	"dependencies": {
 		"@roblox-ts/luau-ast": "^1.0.8",
 		"@roblox-ts/rojo-resolver": "^1.0.4",
-		"ajv": "^8.12.0",
 		"chokidar": "^3.5.3",
 		"fs-extra": "^11.1.0",
 		"kleur": "^4.1.5",


### PR DESCRIPTION
It was only used by rojo-resolver, but I forgot to remove it when splitting that out.