### PR TITLE
Upgrade TypeScript to 5.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"lookpath": "^1.2.2",
 				"prompts": "^2.4.2",
 				"resolve": "^1.22.3",
-				"typescript": "=4.9.4",
+				"typescript": "=5.1.6",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -29,7 +29,7 @@
 				"@types/node": "^20.3.3",
 				"@types/prompts": "^2.4.4",
 				"@types/resolve": "^1.20.2",
-				"@types/ts-expose-internals": "npm:ts-expose-internals@=4.9.4",
+				"@types/ts-expose-internals": "npm:ts-expose-internals@=5.1.6",
 				"@types/yargs": "^17.0.24",
 				"@typescript-eslint/eslint-plugin": "^5.61.0",
 				"@typescript-eslint/parser": "^5.59.5",
@@ -42,7 +42,7 @@
 				"mocha": "^10.2.0",
 				"nyc": "^15.1.0",
 				"prettier": "^2.8.8",
-				"ttypescript": "^1.5.15",
+				"ts-patch": "^3.0.1",
 				"typescript-transform-paths": "^3.4.6"
 			}
 		},
@@ -469,30 +469,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -808,34 +784,6 @@
 				"fs-extra": "^11.1.0"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/fs-extra": {
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
@@ -906,9 +854,9 @@
 		},
 		"node_modules/@types/ts-expose-internals": {
 			"name": "ts-expose-internals",
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/ts-expose-internals/-/ts-expose-internals-4.9.4.tgz",
-			"integrity": "sha512-qHR+gMYDv45VSikUwg7CG8NXXXED2EspZ/WnZN1eQJEIlyzUHw3YIrzrKv47NQCaXKGvp01kZFlQ3y8BCGTahw==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/ts-expose-internals/-/ts-expose-internals-5.1.6.tgz",
+			"integrity": "sha512-BC/RMnO1TF9r6zjAfozKco9gUE8h0qppNc+S54Vp+uoHzxU+cqavcXYiew+fMoPKKZPI7rvcsiYSnJgbxAbeNw==",
 			"dev": true
 		},
 		"node_modules/@types/yargs": {
@@ -1313,16 +1261,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/aggregate-error": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -1411,13 +1349,6 @@
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
 			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
 			"dev": true
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -1649,13 +1580,6 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
 			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
 			"dev": true
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -2359,6 +2283,32 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/global-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+			"dev": true,
+			"dependencies": {
+				"ini": "^1.3.5",
+				"kind-of": "^6.0.2",
+				"which": "^1.3.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/global-prefix/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
 		"node_modules/globals": {
 			"version": "13.20.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -2398,12 +2348,6 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -2528,6 +2472,12 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
 		},
 		"node_modules/is-binary-path": {
@@ -2817,6 +2767,15 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2925,13 +2884,6 @@
 				"semver": "bin/semver.js"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2964,6 +2916,15 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/mocha": {
@@ -3999,58 +3960,22 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.9.1",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+		"node_modules/ts-patch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.0.1.tgz",
+			"integrity": "sha512-FH61Ywi3A9nBQmWU7GGA35TKoQzkkqkwpUzGixybWJ0KSeIVWUzFSX7JPCBEJcMLdXX/A3Jtdhp2tcVgMwaTtA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
+				"chalk": "^4.1.2",
+				"global-prefix": "^3.0.0",
+				"minimist": "^1.2.8",
+				"resolve": "^1.22.2",
+				"semver": "^7.3.8",
+				"strip-ansi": "^6.0.1"
 			},
 			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/ts-node/node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
+				"ts-patch": "bin/ts-patch.js",
+				"tspc": "bin/tspc.js"
 			}
 		},
 		"node_modules/tslib": {
@@ -4079,23 +4004,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
-		},
-		"node_modules/ttypescript": {
-			"version": "1.5.15",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
-			"integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
-			"dev": true,
-			"dependencies": {
-				"resolve": ">=1.9.0"
-			},
-			"bin": {
-				"ttsc": "bin/tsc",
-				"ttsserver": "bin/tsserver"
-			},
-			"peerDependencies": {
-				"ts-node": ">=8.0.2",
-				"typescript": ">=3.2.2"
-			}
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -4131,15 +4039,15 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/typescript-transform-paths": {
@@ -4204,13 +4112,6 @@
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
-		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -4358,16 +4259,6 @@
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 	},
 	"scripts": {
 		"prepublishOnly": "npm run build",
-		"build": "ttsc -b",
-		"build-watch": "ttsc -b -w",
+		"build": "tspc -b",
+		"build-watch": "tspc -b -w",
 		"eslint": "eslint \"src/**/*.ts\" --max-warnings 0",
 		"devlink": "npm run build && cd devlink && npm link",
 		"test": "npm run build && npm run test-compile && npm run test-rojo && npm run test-run",
@@ -57,7 +57,7 @@
 		"lookpath": "^1.2.2",
 		"prompts": "^2.4.2",
 		"resolve": "^1.22.3",
-		"typescript": "=4.9.4",
+		"typescript": "=5.1.6",
 		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
@@ -66,7 +66,7 @@
 		"@types/node": "^20.3.3",
 		"@types/prompts": "^2.4.4",
 		"@types/resolve": "^1.20.2",
-		"@types/ts-expose-internals": "npm:ts-expose-internals@=4.9.4",
+		"@types/ts-expose-internals": "npm:ts-expose-internals@=5.1.6",
 		"@types/yargs": "^17.0.24",
 		"@typescript-eslint/eslint-plugin": "^5.61.0",
 		"@typescript-eslint/parser": "^5.59.5",
@@ -79,7 +79,7 @@
 		"mocha": "^10.2.0",
 		"nyc": "^15.1.0",
 		"prettier": "^2.8.8",
-		"ttypescript": "^1.5.15",
+		"ts-patch": "^3.0.1",
 		"typescript-transform-paths": "^3.4.6"
 	},
 	"files": [

--- a/src/Project/classes/VirtualProject.ts
+++ b/src/Project/classes/VirtualProject.ts
@@ -57,7 +57,7 @@ export class VirtualProject {
 			strict: true,
 			target: ts.ScriptTarget.ESNext,
 			module: ts.ModuleKind.CommonJS,
-			moduleResolution: ts.ModuleResolutionKind.NodeJs,
+			moduleResolution: ts.ModuleResolutionKind.Node10,
 			moduleDetection: ts.ModuleDetectionKind.Force,
 			typeRoots: [RBXTS_SCOPE_PATH],
 			resolveJsonModule: true,

--- a/src/Project/functions/createProgramFactory.ts
+++ b/src/Project/functions/createProgramFactory.ts
@@ -9,7 +9,7 @@ function createCompilerHost(data: ProjectData, compilerOptions: ts.CompilerOptio
 	const host = ts.createIncrementalCompilerHost(compilerOptions);
 
 	let contentsToHash = "";
-
+	contentsToHash += `version=${COMPILER_VERSION},`;
 	contentsToHash += `type=${String(data.projectOptions.type)},`;
 	contentsToHash += `isPackage=${String(data.isPackage)},`;
 	contentsToHash += `plugins=${JSON.stringify(compilerOptions.plugins ?? [])},`;
@@ -18,15 +18,9 @@ function createCompilerHost(data: ProjectData, compilerOptions: ts.CompilerOptio
 		contentsToHash += fs.readFileSync(data.rojoConfigPath).toString();
 	}
 
-	// super hack!
-	// we set `ts.version` so that new versions of roblox-ts trigger full re-compile for incremental mode
-	// rojoHash makes it so that changes to the rojo config will trigger full re-compile
-
 	assert(host.createHash);
-
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
-	ts.version = `${COMPILER_VERSION}-hash-${host.createHash(contentsToHash)}`;
+	const origCreateHash = host.createHash;
+	host.createHash = (data: string) => origCreateHash(contentsToHash + data);
 
 	return host;
 }

--- a/src/Project/functions/validateCompilerOptions.ts
+++ b/src/Project/functions/validateCompilerOptions.ts
@@ -8,7 +8,7 @@ const ENFORCED_OPTIONS = {
 	target: ts.ScriptTarget.ESNext,
 	module: ts.ModuleKind.CommonJS,
 	moduleDetection: ts.ModuleDetectionKind.Force,
-	moduleResolution: ts.ModuleResolutionKind.NodeJs,
+	moduleResolution: ts.ModuleResolutionKind.Node10,
 	noLib: true,
 	strict: true,
 	allowSyntheticDefaultImports: true,

--- a/src/Project/transformers/builtin/transformPaths.ts
+++ b/src/Project/transformers/builtin/transformPaths.ts
@@ -142,7 +142,7 @@ export const transformPaths = (context: ts.TransformationContext) => (sourceFile
 		ts.isStringLiteral(node.arguments[0]) &&
 		node.arguments.length === 1;
 
-	function visit(node: ts.Node): ts.VisitResult<ts.Node> {
+	function visit(node: ts.Node): ts.VisitResult<ts.Node | undefined> {
 		if (isRequire(node) || isAsyncImport(node)) {
 			return unpathRequireAndAsyncImport(node);
 		}
@@ -218,7 +218,7 @@ export const transformPaths = (context: ts.TransformationContext) => (sourceFile
 
 		return ts.factory.updateExternalModuleReference(node, fileLiteral);
 	}
-	function unpathImportDeclaration(node: ts.ImportDeclaration): ts.VisitResult<ts.Statement> {
+	function unpathImportDeclaration(node: ts.ImportDeclaration): ts.VisitResult<ts.ImportDeclaration | undefined> {
 		if (!ts.isStringLiteral(node.moduleSpecifier)) {
 			return node;
 		}
@@ -233,14 +233,16 @@ export const transformPaths = (context: ts.TransformationContext) => (sourceFile
 			? ts.factory.updateImportDeclaration(node, node.modifiers, node.importClause, fileLiteral, undefined)
 			: undefined;
 	}
-	function visitImportClause(node: ts.ImportClause): ts.VisitResult<ts.ImportClause> {
+	function visitImportClause(node: ts.ImportClause): ts.VisitResult<ts.ImportClause | undefined> {
 		const name = resolver.isReferencedAliasDeclaration(node) ? node.name : undefined;
 		const namedBindings = ts.visitNode(node.namedBindings, visitNamedImportBindings as any, ts.isNamedImports);
 		return name || namedBindings
 			? ts.factory.updateImportClause(node, node.isTypeOnly, name, namedBindings)
 			: undefined;
 	}
-	function visitNamedImportBindings(node: ts.NamedImportBindings): ts.VisitResult<ts.NamedImportBindings> {
+	function visitNamedImportBindings(
+		node: ts.NamedImportBindings,
+	): ts.VisitResult<ts.NamedImportBindings | undefined> {
 		if (node.kind === ts.SyntaxKind.NamespaceImport) {
 			return resolver.isReferencedAliasDeclaration(node) ? node : undefined;
 		} else {
@@ -248,11 +250,11 @@ export const transformPaths = (context: ts.TransformationContext) => (sourceFile
 			return elements.some(e => e) ? ts.factory.updateNamedImports(node, elements) : undefined;
 		}
 	}
-	function visitImportSpecifier(node: ts.ImportSpecifier): ts.VisitResult<ts.ImportSpecifier> {
+	function visitImportSpecifier(node: ts.ImportSpecifier): ts.VisitResult<ts.ImportSpecifier | undefined> {
 		return resolver.isReferencedAliasDeclaration(node) ? node : undefined;
 	}
 
-	function unpathExportDeclaration(node: ts.ExportDeclaration): ts.VisitResult<ts.Statement> {
+	function unpathExportDeclaration(node: ts.ExportDeclaration): ts.VisitResult<ts.Statement | undefined> {
 		if (!node.moduleSpecifier || !ts.isStringLiteral(node.moduleSpecifier)) {
 			return node;
 		}
@@ -291,11 +293,11 @@ export const transformPaths = (context: ts.TransformationContext) => (sourceFile
 			  )
 			: undefined;
 	}
-	function visitNamedExports(node: ts.NamedExports): ts.VisitResult<ts.NamedExports> {
+	function visitNamedExports(node: ts.NamedExports): ts.VisitResult<ts.NamedExports | undefined> {
 		const elements = ts.visitNodes(node.elements, visitExportSpecifier as any, ts.isExportSpecifier);
 		return elements.some(e => e) ? ts.factory.updateNamedExports(node, elements) : undefined;
 	}
-	function visitExportSpecifier(node: ts.ExportSpecifier): ts.VisitResult<ts.ExportSpecifier> {
+	function visitExportSpecifier(node: ts.ExportSpecifier): ts.VisitResult<ts.ExportSpecifier | undefined> {
 		return resolver.isValueAliasDeclaration(node) ? node : undefined;
 	}
 
@@ -309,5 +311,5 @@ export const transformPaths = (context: ts.TransformationContext) => (sourceFile
 		return res;
 	}
 
-	return ts.visitNode(sourceFile, visit);
+	return ts.visitNode(sourceFile, visit) as ts.SourceFile;
 };

--- a/src/TSTransformer/nodes/jsx/transformJsxAttributes.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxAttributes.ts
@@ -76,7 +76,12 @@ function isFlatObject(expression: ts.ObjectLiteralExpression) {
 }
 
 function transformSpecialAttribute(state: TransformState, attribute: ts.JsxAttribute, attributesPtr: MapPointer) {
-	assert(attribute.initializer && ts.isJsxExpression(attribute.initializer) && attribute.initializer.expression);
+	assert(
+		attribute.initializer &&
+			ts.isJsxExpression(attribute.initializer) &&
+			attribute.initializer.expression &&
+			!ts.isJsxNamespacedName(attribute.name),
+	);
 	const expression = attribute.initializer.expression;
 	if (ts.isObjectLiteralExpression(expression) && isFlatObject(expression)) {
 		for (const property of expression.properties) {
@@ -117,7 +122,7 @@ function transformSpecialAttribute(state: TransformState, attribute: ts.JsxAttri
 }
 
 function isSpecialAttribute(state: TransformState, attribute: ts.JsxAttribute) {
-	assert(state.services.roactSymbolManager);
+	assert(state.services.roactSymbolManager && !ts.isJsxNamespacedName(attribute.name));
 	const contextualType = state.typeChecker.getContextualType(attribute.parent);
 	if (contextualType) {
 		const symbol = contextualType.getProperty(attribute.name.text);
@@ -135,6 +140,7 @@ function isSpecialAttribute(state: TransformState, attribute: ts.JsxAttribute) {
 }
 
 function transformJsxAttribute(state: TransformState, attribute: ts.JsxAttribute, attributesPtr: MapPointer) {
+	assert(!ts.isJsxNamespacedName(attribute.name));
 	const attributeName = attribute.name.text;
 	if (attributeName === KEY_ATTRIBUTE_NAME) return;
 

--- a/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
@@ -5,6 +5,7 @@ import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
+import { getAttributeNameText } from "TSTransformer/util/jsx/getAttributeName";
 import ts from "typescript";
 
 function transformJsxTagNameExpression(state: TransformState, node: ts.JsxTagNameExpression) {
@@ -24,8 +25,9 @@ function transformJsxTagNameExpression(state: TransformState, node: ts.JsxTagNam
 			DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(node.name));
 		}
 		return luau.property(convertToIndexableExpression(transformExpression(state, node.expression)), node.name.text);
+	} else if (ts.isJsxNamespacedName(node)) {
+		return luau.string(getAttributeNameText(node));
 	} else {
-		assert(!ts.isJsxNamespacedName(node));
 		return transformExpression(state, node);
 	}
 }

--- a/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
@@ -25,6 +25,7 @@ function transformJsxTagNameExpression(state: TransformState, node: ts.JsxTagNam
 		}
 		return luau.property(convertToIndexableExpression(transformExpression(state, node.expression)), node.name.text);
 	} else {
+		assert(!ts.isJsxNamespacedName(node));
 		return transformExpression(state, node);
 	}
 }

--- a/src/TSTransformer/util/jsx/getAttributeName.ts
+++ b/src/TSTransformer/util/jsx/getAttributeName.ts
@@ -1,0 +1,9 @@
+import ts from "typescript";
+
+export function getAttributeNameText(node: ts.JsxAttributeName) {
+	if (ts.isIdentifier(node)) {
+		return node.text;
+	} else {
+		return `${node.namespace.text}:${node.name.text}`;
+	}
+}

--- a/src/TSTransformer/util/jsx/getKeyAttributeInitializer.ts
+++ b/src/TSTransformer/util/jsx/getKeyAttributeInitializer.ts
@@ -1,16 +1,20 @@
+import assert from "assert";
 import { KEY_ATTRIBUTE_NAME } from "TSTransformer/util/jsx/constants";
 import { getAttributes } from "TSTransformer/util/jsx/getAttributes";
 import ts from "typescript";
 
 export function getKeyAttributeInitializer(element: ts.JsxElement | ts.JsxSelfClosingElement) {
 	for (const attribute of getAttributes(element).properties) {
-		if (ts.isJsxAttribute(attribute) && attribute.name.text === KEY_ATTRIBUTE_NAME && attribute.initializer) {
-			if (ts.isStringLiteral(attribute.initializer)) {
-				return attribute.initializer;
-			} else if (ts.isJsxExpression(attribute.initializer)) {
-				return attribute.initializer.expression;
+		if (ts.isJsxAttribute(attribute)) {
+			assert(!ts.isJsxNamespacedName(attribute.name));
+			if (attribute.name.text === KEY_ATTRIBUTE_NAME && attribute.initializer) {
+				if (ts.isStringLiteral(attribute.initializer)) {
+					return attribute.initializer;
+				} else if (ts.isJsxExpression(attribute.initializer)) {
+					return attribute.initializer.expression;
+				}
+				// embedded JSX elements are ignored because "Key" type doesn't support them by default
 			}
-			// embedded JSX elements are ignored because "Key" type doesn't support them by default
 		}
 	}
 }

--- a/src/TSTransformer/util/jsx/getKeyAttributeInitializer.ts
+++ b/src/TSTransformer/util/jsx/getKeyAttributeInitializer.ts
@@ -1,20 +1,21 @@
-import assert from "assert";
 import { KEY_ATTRIBUTE_NAME } from "TSTransformer/util/jsx/constants";
+import { getAttributeNameText } from "TSTransformer/util/jsx/getAttributeName";
 import { getAttributes } from "TSTransformer/util/jsx/getAttributes";
 import ts from "typescript";
 
 export function getKeyAttributeInitializer(element: ts.JsxElement | ts.JsxSelfClosingElement) {
 	for (const attribute of getAttributes(element).properties) {
-		if (ts.isJsxAttribute(attribute)) {
-			assert(!ts.isJsxNamespacedName(attribute.name));
-			if (attribute.name.text === KEY_ATTRIBUTE_NAME && attribute.initializer) {
-				if (ts.isStringLiteral(attribute.initializer)) {
-					return attribute.initializer;
-				} else if (ts.isJsxExpression(attribute.initializer)) {
-					return attribute.initializer.expression;
-				}
-				// embedded JSX elements are ignored because "Key" type doesn't support them by default
+		if (
+			ts.isJsxAttribute(attribute) &&
+			getAttributeNameText(attribute.name) === KEY_ATTRIBUTE_NAME &&
+			attribute.initializer
+		) {
+			if (ts.isStringLiteral(attribute.initializer)) {
+				return attribute.initializer;
+			} else if (ts.isJsxExpression(attribute.initializer)) {
+				return attribute.initializer.expression;
 			}
+			// embedded JSX elements are ignored because "Key" type doesn't support them by default
 		}
 	}
 }

--- a/tests/src/main.server.ts
+++ b/tests/src/main.server.ts
@@ -1,3 +1,5 @@
+/// <reference types="@rbxts/testez/globals" />
+
 import { ServerScriptService } from "@rbxts/services";
 import TestEZ from "@rbxts/testez";
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -14,7 +14,6 @@
 		"strict": true,
 		"target": "ESNext",
 		"typeRoots": ["node_modules/@rbxts"],
-		"types": ["@rbxts/testez/globals"],
 
 		// configurable
 		"rootDir": "src",


### PR DESCRIPTION
# Changes

### 1. Upgraded `typescript` and `ts-expose-internals` to 5.1.6

### 2. Removed [`ttypescript`](https://github.com/cevek/ttypescript#deprecation-notice) in favor of [`ts-patch`](https://github.com/nonara/ts-patch)
`ttypescript` was deprecated and does not support TypeScript 5.0+.

Only difference here should be building the compiler with `tspc` instead of `ttsc`.

### 3. Removed `ts.version` hack
Previously, we would overwrite `ts.version` with a new string containing compiler version + hashed several inputs including project type, "is package", list of plugins, and Rojo config contents.

TypeScript 5.0 no longer lets us do that because `version` is no longer part of a namespace, but exported from a module.

Instead, I've overwritten the `CompilerHost.createHash` function to include this. Seems to work the same.

### 4. `transformPaths.ts` Updates
A few types in here required a `| undefined` to avoid compiler errors.

### 5. JSX Changes
Added support for newly introduced type `ts.JsxNamespacedName` which had caused some compiler errors.

A "JSX namespaced name" is something like `<a:b />` or `<foo a:b={value} />`.

### 6. Unit Test Changes

For some reason, `"types"` in `tsconfig.json` seems to not work the same as it did before? I can't get it to inject the TestEZ globals. Placing a triple slash directive in `main.server.ts` seems to work fine.


### 7. `ts.ModuleResolutionKind.NodeJs` -> `ts.ModuleResolutionKind.Node10`
Enum value was deprecated + renamed from `NodeJs` to `Node10`. Still gives us the same enum value of `2`, so I don't think this is a behavior change.