### PR TITLE
TypeScript 5.2.2 Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"lookpath": "^1.2.2",
 				"prompts": "^2.4.2",
 				"resolve": "^1.22.6",
-				"typescript": "=5.1.6",
+				"typescript": "=5.2.2",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -29,7 +29,7 @@
 				"@types/node": "^20.6.3",
 				"@types/prompts": "^2.4.4",
 				"@types/resolve": "^1.20.2",
-				"@types/ts-expose-internals": "npm:ts-expose-internals@=5.1.6",
+				"@types/ts-expose-internals": "npm:ts-expose-internals@=5.2.2",
 				"@types/yargs": "^17.0.24",
 				"@typescript-eslint/eslint-plugin": "^6.7.2",
 				"@typescript-eslint/parser": "^6.7.2",
@@ -801,9 +801,9 @@
 		},
 		"node_modules/@types/ts-expose-internals": {
 			"name": "ts-expose-internals",
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/ts-expose-internals/-/ts-expose-internals-5.1.6.tgz",
-			"integrity": "sha512-BC/RMnO1TF9r6zjAfozKco9gUE8h0qppNc+S54Vp+uoHzxU+cqavcXYiew+fMoPKKZPI7rvcsiYSnJgbxAbeNw==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ts-expose-internals/-/ts-expose-internals-5.2.2.tgz",
+			"integrity": "sha512-HYknqnfn3hQcNV1a00Ag4Nv+LM5wv2hUDzLH2oh+utspiKafKYtRYdv7a/iNhtqbzRJVV3FgVYRNoWKA3AZ3Uw==",
 			"dev": true
 		},
 		"node_modules/@types/yargs": {
@@ -3961,9 +3961,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"lookpath": "^1.2.2",
 		"prompts": "^2.4.2",
 		"resolve": "^1.22.6",
-		"typescript": "=5.1.6",
+		"typescript": "=5.2.2",
 		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
@@ -66,7 +66,7 @@
 		"@types/node": "^20.6.3",
 		"@types/prompts": "^2.4.4",
 		"@types/resolve": "^1.20.2",
-		"@types/ts-expose-internals": "npm:ts-expose-internals@=5.1.6",
+		"@types/ts-expose-internals": "npm:ts-expose-internals@=5.2.2",
 		"@types/yargs": "^17.0.24",
 		"@typescript-eslint/eslint-plugin": "^6.7.2",
 		"@typescript-eslint/parser": "^6.7.2",

--- a/src/TSTransformer/nodes/statements/transformForOfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForOfStatement.ts
@@ -319,7 +319,7 @@ const buildIterableFunctionLuaTupleLoop: (type: ts.Type) => LoopBuilder =
 				let name = "element";
 				if (tupleType.labeledElementDeclarations) {
 					const label = tupleType.labeledElementDeclarations[i];
-					if (ts.isIdentifier(label.name) && luau.isValidIdentifier(label.name.text)) {
+					if (label && ts.isIdentifier(label.name) && luau.isValidIdentifier(label.name.text)) {
 						name = label.name.text;
 					}
 				}


### PR DESCRIPTION
Previously, if you used tuple labels TypeScript required all members to have a label. Otherwise, you'd get this error:
```
error TS5084: Tuple members must all have names or all not have names.
```

TypeScript 5.2 removed this requirement so now we have to check if `label` exists before using it.