### PR TITLE
Static block declarations #2472

### DIFF
--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -23,6 +23,7 @@ export class TransformState {
 	private readonly sourceFileText: string;
 	public hasExportEquals = false;
 	public hasExportFrom = false;
+	public isInStaticBlockDeclaration = false;
 
 	public debugRender(node: luau.Node) {
 		const state = new RenderState();

--- a/src/TSTransformer/nodes/expressions/transformThisExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformThisExpression.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { SYMBOL_NAMES, TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import assert from "assert";
 import ts from "typescript";
 
 export function transformThisExpression(state: TransformState, node: ts.ThisExpression) {
@@ -10,5 +11,17 @@ export function transformThisExpression(state: TransformState, node: ts.ThisExpr
 		DiagnosticService.addDiagnostic(errors.noGlobalThis(node));
 	}
 
+	if (state.isInStaticBlockDeclaration && symbol) {
+		const type = state.typeChecker.getTypeOfSymbolAtLocation(symbol, node);
+		const classLikeDeclaration = symbol.valueDeclaration;
+		assert(classLikeDeclaration);
+		if (ts.isClassDeclaration(classLikeDeclaration)) {
+			const className = classLikeDeclaration.name;
+			assert(className);
+			return luau.id(className.text);
+		} else if (ts.isClassExpression(classLikeDeclaration)) {
+			// todo
+		}
+	}
 	return luau.globals.self;
 }

--- a/src/TSTransformer/nodes/transformOptionalChain.ts
+++ b/src/TSTransformer/nodes/transformOptionalChain.ts
@@ -260,7 +260,7 @@ function transformOptionalChainInner(
 				if (item.kind === OptionalChainItemKind.PropertyCall) {
 					baseExpression = luau.property(convertToIndexableExpression(baseExpression), item.name);
 				} else if (item.kind === OptionalChainItemKind.ElementCall) {
-					const [index, prereqs] = state.capture(() => transformExpression(state, item.argumentExpression));
+					const [index] = state.capture(() => transformExpression(state, item.argumentExpression));
 					const expType = state.typeChecker.getNonOptionalType(state.getType(item.expression.expression));
 
 					baseExpression = luau.create(luau.SyntaxKind.ComputedIndexExpression, {

--- a/src/TSTransformer/nodes/transformOptionalChain.ts
+++ b/src/TSTransformer/nodes/transformOptionalChain.ts
@@ -260,7 +260,7 @@ function transformOptionalChainInner(
 				if (item.kind === OptionalChainItemKind.PropertyCall) {
 					baseExpression = luau.property(convertToIndexableExpression(baseExpression), item.name);
 				} else if (item.kind === OptionalChainItemKind.ElementCall) {
-					const expType = state.typeChecker.getNonOptionalType(state.getType(item.expression.expression));
+					const expType = state.getType(item.expression.expression);
 
 					baseExpression = luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 						expression: convertToIndexableExpression(baseExpression),

--- a/src/TSTransformer/nodes/transformOptionalChain.ts
+++ b/src/TSTransformer/nodes/transformOptionalChain.ts
@@ -260,12 +260,11 @@ function transformOptionalChainInner(
 				if (item.kind === OptionalChainItemKind.PropertyCall) {
 					baseExpression = luau.property(convertToIndexableExpression(baseExpression), item.name);
 				} else if (item.kind === OptionalChainItemKind.ElementCall) {
-					const [index] = state.capture(() => transformExpression(state, item.argumentExpression));
 					const expType = state.typeChecker.getNonOptionalType(state.getType(item.expression.expression));
 
 					baseExpression = luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 						expression: convertToIndexableExpression(baseExpression),
-						index: addOneIfArrayType(state, expType, index),
+						index: addOneIfArrayType(state, expType, transformExpression(state, item.argumentExpression)),
 					});
 				}
 			}


### PR DESCRIPTION
fixes #2472 

I've gotten it to work, but I think the approach it can be cleaner.

Since typescript allows the use of this in static blocks, I have to replace occurrences of this with the actual class name.
I changed transformThisExpression to check if `this` is being used in a static block.
