### PR TITLE
Remove enum inverse mapping for string values

### DIFF
--- a/src/TSTransformer/nodes/statements/transformEnumDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformEnumDeclaration.ts
@@ -45,13 +45,13 @@ export function transformEnumDeclaration(state: TransformState, node: ts.EnumDec
 
 	const id = transformIdentifierDefined(state, node.name);
 
-	if (!node.members.some(member => needsInverseEntry(state, member))) {
+	if (node.members.every(member => !needsInverseEntry(state, member))) {
 		return luau.list.make<luau.Statement>(
 			luau.create(luau.SyntaxKind.VariableDeclaration, {
 				left: id,
 				right: luau.map(
 					node.members.map(member => [
-						transformPropertyName(state, member.name),
+						state.pushToVarIfComplex(transformPropertyName(state, member.name)),
 						luau.string(state.typeChecker.getConstantValue(member) as string),
 					]),
 				),


### PR DESCRIPTION
Built on top of the ideas from #2062

- If all members of the enum do not allow reverse lookup, emit a simpler structure:
```ts
enum X {
	A = "A",
	"B" = "B",
}
```
```lua
local X = {
	A = "A",
	B = "B",
}
```
- Otherwise, fallback to inverse mapping emit, but only assign to inverse mapping if needed
```ts
enum X {
	A = "A",
	"B" = "B",
	C = 1,
}
```
```lua
local X
do
	local _inverse = {}
	X = setmetatable({}, {
		__index = _inverse,
	})
	X.A = "A"
	X.B = "B"
	X.C = 1
	_inverse[1] = "C"
end
```