### PR TITLE
Add unit tests for `$range` macro

### DIFF
--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -416,4 +416,73 @@ export = () => {
 			break;
 		}
 	})
+
+	it("should support the $range macro without step", () => {
+		const hit = new Set<number>();
+		let sum = 10;
+		for (const i of $range(0, 9)) {
+			hit.add(i);
+			sum--;
+		}
+		expect(sum).to.equal(0);
+		expect(hit.has(0)).to.equal(true);
+		expect(hit.has(1)).to.equal(true);
+		expect(hit.has(2)).to.equal(true);
+		expect(hit.has(3)).to.equal(true);
+		expect(hit.has(4)).to.equal(true);
+		expect(hit.has(5)).to.equal(true);
+		expect(hit.has(6)).to.equal(true);
+		expect(hit.has(7)).to.equal(true);
+		expect(hit.has(8)).to.equal(true);
+		expect(hit.has(9)).to.equal(true);
+	});
+
+	it("should support the $range macro with a negative step", () => {
+		const hit = new Set<number>();
+		let sum = 10;
+		for (const i of $range(9, 0, -1)) {
+			hit.add(i);
+			sum--;
+		}
+		expect(sum).to.equal(0);
+		expect(hit.has(0)).to.equal(true);
+		expect(hit.has(1)).to.equal(true);
+		expect(hit.has(2)).to.equal(true);
+		expect(hit.has(3)).to.equal(true);
+		expect(hit.has(4)).to.equal(true);
+		expect(hit.has(5)).to.equal(true);
+		expect(hit.has(6)).to.equal(true);
+		expect(hit.has(7)).to.equal(true);
+		expect(hit.has(8)).to.equal(true);
+		expect(hit.has(9)).to.equal(true);
+	});
+
+	it("should support the $range macro with a decimal step", () => {
+		const hit = new Set<number>();
+		let sum = 19;
+		for (const i of $range(0, 9, 0.5)) {
+			hit.add(i);
+			sum--;
+		}
+		expect(sum).to.equal(0);
+		expect(hit.has(0)).to.equal(true);
+		expect(hit.has(0.5)).to.equal(true);
+		expect(hit.has(1)).to.equal(true);
+		expect(hit.has(1.5)).to.equal(true);
+		expect(hit.has(2)).to.equal(true);
+		expect(hit.has(2.5)).to.equal(true);
+		expect(hit.has(3)).to.equal(true);
+		expect(hit.has(3.5)).to.equal(true);
+		expect(hit.has(4)).to.equal(true);
+		expect(hit.has(4.5)).to.equal(true);
+		expect(hit.has(5)).to.equal(true);
+		expect(hit.has(5.5)).to.equal(true);
+		expect(hit.has(6)).to.equal(true);
+		expect(hit.has(6.5)).to.equal(true);
+		expect(hit.has(7)).to.equal(true);
+		expect(hit.has(7.5)).to.equal(true);
+		expect(hit.has(8)).to.equal(true);
+		expect(hit.has(8.5)).to.equal(true);
+		expect(hit.has(9)).to.equal(true);
+	});
 };


### PR DESCRIPTION
Covers:
- `$range` without a step value
- `$range` with a negative step value
- `$range` with a decimal step value

closes #2507 