### PR TITLE
Fix `Array.push` inserting multiple values for different tables

### DIFF
--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -585,6 +585,8 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 
 const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	push: (state, node, expression, args) => {
+		expression = state.pushToVarIfComplex(expression, "exp");
+
 		for (let i = 0; i < args.length; i++) {
 			state.prereq(
 				luau.create(luau.SyntaxKind.CallStatement, {

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -595,8 +595,7 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 			);
 		}
 
-		// for `a.push()` always emit luau.unary so the call doesn't disappear in emit
-		return !isUsedAsStatement(node) || args.length === 0 ? luau.unary("#", expression) : luau.none();
+		return !isUsedAsStatement(node) ? luau.unary("#", expression) : luau.none();
 	},
 
 	pop: (state, node, expression) => {

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -585,6 +585,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 
 const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	push: (state, node, expression, args) => {
+		// for `a.push()` always emit luau.unary so the call doesn't disappear in emit
 		if (args.length === 0) {
 			return luau.unary("#", expression);
 		}

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -585,6 +585,10 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 
 const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	push: (state, node, expression, args) => {
+		if (args.length === 0) {
+			return luau.unary("#", expression);
+		}
+
 		expression = state.pushToVarIfComplex(expression, "exp");
 
 		for (let i = 0; i < args.length; i++) {

--- a/tests/src/tests/array.spec.ts
+++ b/tests/src/tests/array.spec.ts
@@ -129,6 +129,7 @@ export = () => {
 		expect(arr[3]).to.equal(undefined);
 
 		expect([1, 2].push()).to.equal(2);
+		expect([1, 2, 3].push(4, 5, 6)).to.equal(6);
 	});
 
 	it("should support pop", () => {


### PR DESCRIPTION
The macro currently doesn't create a temporary variable for the target array, which clones the table expression for each insert call and returns the incorrect size of the changed array when it's captured.

This has been happening since the method rework in https://github.com/roblox-ts/roblox-ts/pull/1853.
```ts
print([1, 2, 3].push(4, 5, 6));
```

Current emit:
```lua
-- Compiled with roblox-ts v2.2.0
-- ▼ Array.push ▼
table.insert({ 1, 2, 3 }, 4)
table.insert({ 1, 2, 3 }, 5)
table.insert({ 1, 2, 3 }, 6)
-- ▲ Array.push ▲
print(#({ 1, 2, 3 }))
return nil
```

Expected:
```lua
-- Compiled with roblox-ts v2.2.0
local _exp = { 1, 2, 3 }
-- ▼ Array.push ▼
table.insert(_exp, 4)
table.insert(_exp, 5)
table.insert(_exp, 6)
-- ▲ Array.push ▲
print(#_exp)
return nil
```