### PR TITLE
Fix `(Map|Set).delete` expression being cloned

### DIFF
--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -768,6 +768,7 @@ const SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
 		const valueIsUsed = !isUsedAsStatement(node);
 		let valueExistedId: luau.TemporaryIdentifier;
 		if (valueIsUsed) {
+			expression = state.pushToVarIfNonId(expression, "exp");
 			valueExistedId = state.pushToVar(
 				luau.create(luau.SyntaxKind.BinaryExpression, {
 					left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {

--- a/tests/src/tests/map.spec.ts
+++ b/tests/src/tests/map.spec.ts
@@ -194,4 +194,15 @@ export = () => {
 		const map = new Map([foo()]);
 		expect(map.get(123)).to.equal("abc");
 	});
+
+	it("should support delete with with Map constructor", () => {
+		let count = 0;
+		function foo<T>(input: T): T {
+			count++;
+			return input;
+		}
+		const wasRemoved = new Map([[foo("a"), foo("b")]]).delete("a");
+		expect(wasRemoved).to.equal(true);
+		expect(count).to.equal(2);
+	});
 };

--- a/tests/src/tests/set.spec.ts
+++ b/tests/src/tests/set.spec.ts
@@ -219,4 +219,15 @@ export = () => {
 		expect(set.has("bar")).to.equal(true);
 		expect(set.has("baz")).to.equal(true);
 	});
+
+	it("should support delete with with Set constructor", () => {
+		let count = 0;
+		function foo<T>(input: T): T {
+			count++;
+			return input;
+		}
+		const wasRemoved = new Set([foo("a"), foo("b")]).delete("a");
+		expect(wasRemoved).to.equal(true);
+		expect(count).to.equal(2);
+	});
 };


### PR DESCRIPTION
Similar to #2597, currently this doesn't create an id for the expression if it's a table literal. The difference is that the result won't change at runtime, but this still is the correct way it should emit.

```ts
const a = new Set(["a", "b"]).delete("a");

const b = new Map<string, number>([
	["a", 1],
	["b", 2],
]).delete("a");
```

Current emit:
```lua
-- Compiled with roblox-ts v2.2.0
-- ▼ Set.delete ▼
local _valueExisted = ({
	["a"] = true,
	["b"] = true,
}).a ~= nil
({
	["a"] = true,
	["b"] = true,
}).a = nil
-- ▲ Set.delete ▲
local a = _valueExisted
-- ▼ Map.delete ▼
local _valueExisted_1 = ({
	a = 1,
	b = 2,
}).a ~= nil
({
	a = 1,
	b = 2,
}).a = nil
-- ▲ Map.delete ▲
local b = _valueExisted_1
return nil
```

Expected emit:
```lua
-- Compiled with roblox-ts v2.2.0
local _exp = {
	["a"] = true,
	["b"] = true,
}
-- ▼ Set.delete ▼
local _valueExisted = _exp.a ~= nil
_exp.a = nil
-- ▲ Set.delete ▲
local a = _valueExisted
local _exp_1 = {
	a = 1,
	b = 2,
}
-- ▼ Map.delete ▼
local _valueExisted_1 = _exp_1.a ~= nil
_exp_1.a = nil
-- ▲ Map.delete ▲
local b = _valueExisted_1
return nil
```