### PR TITLE
Fix unnecessary check for internal name

### DIFF
--- a/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
+++ b/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
@@ -252,7 +252,7 @@ export function transformClassLikeDeclaration(state: TransformState, node: ts.Cl
 
 	let internalName: luau.Identifier | luau.TemporaryIdentifier;
 	if (shouldUseInternalName) {
-		internalName = node.name ? transformIdentifierDefined(state, node.name) : luau.tempId("class");
+		internalName = transformIdentifierDefined(state, node.name);
 	} else {
 		internalName = returnVar;
 	}


### PR DESCRIPTION
Since `shouldUseInternalName` already checks that `node.name !== undefined`, this second check does nothing.