### PR TITLE
Move @types to be dependencies instead of devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,13 @@
 				"@roblox-ts/luau-ast": "^1.0.11",
 				"@roblox-ts/path-translator": "^1.0.0",
 				"@roblox-ts/rojo-resolver": "^1.0.6",
+				"@types/fs-extra": "^11.0.4",
+				"@types/mocha": "^10.0.6",
+				"@types/node": "^20.11.17",
+				"@types/prompts": "^2.4.9",
+				"@types/resolve": "^1.20.6",
+				"@types/ts-expose-internals": "npm:ts-expose-internals@=5.3.3",
+				"@types/yargs": "^17.0.32",
 				"chokidar": "^3.6.0",
 				"fs-extra": "^11.2.0",
 				"kleur": "^4.1.5",
@@ -23,13 +30,6 @@
 				"rbxtsc": "out/CLI/cli.js"
 			},
 			"devDependencies": {
-				"@types/fs-extra": "^11.0.4",
-				"@types/mocha": "^10.0.6",
-				"@types/node": "^20.11.17",
-				"@types/prompts": "^2.4.9",
-				"@types/resolve": "^1.20.6",
-				"@types/ts-expose-internals": "npm:ts-expose-internals@=5.3.3",
-				"@types/yargs": "^17.0.32",
 				"@typescript-eslint/eslint-plugin": "^7.0.1",
 				"@typescript-eslint/parser": "^7.0.1",
 				"eslint": "^8.56.0",
@@ -830,7 +830,6 @@
 			"version": "11.0.4",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
 			"integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-			"dev": true,
 			"dependencies": {
 				"@types/jsonfile": "*",
 				"@types/node": "*"
@@ -844,7 +843,6 @@
 		},
 		"node_modules/@types/jsonfile": {
 			"version": "6.1.1",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
@@ -853,14 +851,12 @@
 		"node_modules/@types/mocha": {
 			"version": "10.0.6",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
-			"integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
-			"dev": true
+			"integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg=="
 		},
 		"node_modules/@types/node": {
 			"version": "20.11.17",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
 			"integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
-			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -869,7 +865,6 @@
 			"version": "2.4.9",
 			"resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
 			"integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
-			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
 				"kleur": "^3.0.3"
@@ -877,7 +872,6 @@
 		},
 		"node_modules/@types/prompts/node_modules/kleur": {
 			"version": "3.0.3",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -886,8 +880,7 @@
 		"node_modules/@types/resolve": {
 			"version": "1.20.6",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
-			"integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
-			"dev": true
+			"integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.2",
@@ -899,21 +892,18 @@
 			"name": "ts-expose-internals",
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/ts-expose-internals/-/ts-expose-internals-5.3.3.tgz",
-			"integrity": "sha512-0lW96u0pa08dq9QLYUBRbgGkvsD+LvPAVGe94kr2tHaRZAxgckwJ+qqc1BSRoR1rpkTZf7AWAa6DKrLGFmctwg==",
-			"dev": true
+			"integrity": "sha512-0lW96u0pa08dq9QLYUBRbgGkvsD+LvPAVGe94kr2tHaRZAxgckwJ+qqc1BSRoR1rpkTZf7AWAa6DKrLGFmctwg=="
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.32",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
 			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-			"dev": true,
 			"dependencies": {
 				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/@types/yargs-parser": {
 			"version": "21.0.0",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -4102,8 +4092,7 @@
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"node_modules/universalify": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,13 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
+		"@types/fs-extra": "^11.0.4",
+		"@types/mocha": "^10.0.6",
+		"@types/node": "^20.11.17",
+		"@types/prompts": "^2.4.9",
+		"@types/resolve": "^1.20.6",
+		"@types/ts-expose-internals": "npm:ts-expose-internals@=5.3.3",
+		"@types/yargs": "^17.0.32",
 		"@roblox-ts/luau-ast": "^1.0.11",
 		"@roblox-ts/path-translator": "^1.0.0",
 		"@roblox-ts/rojo-resolver": "^1.0.6",
@@ -59,13 +66,6 @@
 		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
-		"@types/fs-extra": "^11.0.4",
-		"@types/mocha": "^10.0.6",
-		"@types/node": "^20.11.17",
-		"@types/prompts": "^2.4.9",
-		"@types/resolve": "^1.20.6",
-		"@types/ts-expose-internals": "npm:ts-expose-internals@=5.3.3",
-		"@types/yargs": "^17.0.32",
 		"@typescript-eslint/eslint-plugin": "^7.0.1",
 		"@typescript-eslint/parser": "^7.0.1",
 		"eslint": "^8.56.0",


### PR DESCRIPTION
Latest `@next` where we upgraded from TypeScript 5.2.2 to 5.3.3 breaks the playground.

This is because new triple-slash directives were added for referenced ambient declarations.

We can fix this by making `@types` dependencies instead of devDependencies.

https://github.com/microsoft/TypeScript/pull/56015

![image](https://github.com/roblox-ts/roblox-ts/assets/9200592/94694477-5694-404a-b21b-fe332c5384d6)

![image](https://github.com/roblox-ts/roblox-ts/assets/9200592/ffd9f0ac-dabf-434e-9bea-fda56b84921b)
