### PR TITLE
Fix optional function call crash

### DIFF
--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -199,7 +199,7 @@ export function isEmptyStringType(type: ts.Type) {
 export function isRobloxType(state: TransformState): TypeCheck {
 	const typesPath = path.join(state.data.nodeModulesPath, RBXTS_SCOPE, "types");
 	return type =>
-		type.symbol.declarations?.some(d => {
+		type.symbol?.declarations?.some(d => {
 			const filePath = d.getSourceFile()?.fileName;
 			return filePath !== undefined && isPathDescendantOf(filePath, typesPath);
 		}) ?? false;

--- a/tests/src/tests/optional.spec.ts
+++ b/tests/src/tests/optional.spec.ts
@@ -1,0 +1,6 @@
+export = () => {
+	describe("should support optional function calls", () => {
+		const foo = (() => "bar") as (() => void) | undefined;
+		expect(foo?.()).to.equal("bar");
+	});
+};


### PR DESCRIPTION
### Callstack
```
TypeError: Cannot read properties of undefined (reading 'declarations')
    at roblox-ts/out/tstransformer/util/types.js:198:41
    at roblox-ts/out/tstransformer/util/types.js:64:37
    at Array.some (<anonymous>)
    at isPossiblyTypeInner (roblox-ts/out/tstransformer/util/types.js:64:26)
    at roblox-ts/out/tstransformer/util/types.js:49:37
    at Array.some (<anonymous>)
    at isPossiblyTypeInner (roblox-ts/out/tstransformer/util/types.js:49:27)
    at isPossiblyType (roblox-ts/out/tstransformer/util/types.js:69:12)
    at fixVoidArgumentsForRobloxFunctions (roblox-ts/out/tstransformer/nodes/expressions/transformCallExpression.js:67:36)
    at transformCallExpressionInner (roblox-ts/out/tstransformer/nodes/expressions/transformCallExpression.js:100:5)
```

Regression accidentally introduced by #2672

`type.symbol` will not exist in the case of `undefined` type, so reading `type.symbol.declarations` causes a crash.

Discovered this issue while compiling this line in slither.(https://github.com/littensy/slither/blob/67ec115a66444a01603919721a52d26b42d6b449/src/client/components/ui/primary-button.tsx#L46)