### PR TITLE
Simplify prettier usage in eslint.config.ts

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,18 +1,13 @@
-import { FlatCompat } from "@eslint/eslintrc";
 import eslint from "@eslint/js";
 import comments from "@eslint-community/eslint-plugin-eslint-comments";
-import prettierConfig from "eslint-config-prettier";
-import prettierPlugin from "eslint-plugin-prettier";
+import prettier from "eslint-plugin-prettier/recommended";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
-
-const compat = new FlatCompat({ baseDirectory: __dirname });
 
 export default tseslint.config(
 	eslint.configs.recommended,
 	...tseslint.configs.recommended,
-	...compat.extends("plugin:prettier/recommended"),
-	prettierConfig,
+	prettier,
 	{
 		languageOptions: {
 			parser: tseslint.parser,
@@ -24,8 +19,6 @@ export default tseslint.config(
 			},
 		},
 		plugins: {
-			"@typescript-eslint": tseslint.plugin,
-			prettier: prettierPlugin,
 			"simple-import-sort": simpleImportSort,
 			"eslint-comments": comments,
 		},


### PR DESCRIPTION
Found a better way to do this: https://github.com/prettier/eslint-plugin-prettier?tab=readme-ov-file#configuration-new-eslintconfigjs

This enables `prettier/prettier` as error, so I kept the `"prettier/prettier": "warn",` line

also removed unnecessary `"@typescript-eslint": tseslint.plugin,` (it's already included by `...tseslint.configs.recommended`)