### PR TITLE
Fix #2791

### DIFF
--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -103,7 +103,7 @@ function handleExports(
 				continue;
 			}
 
-			if (originalSymbol.valueDeclaration) {
+			if (originalSymbol.valueDeclaration && originalSymbol.valueDeclaration.getSourceFile() === sourceFile) {
 				const statement = getAncestor(originalSymbol.valueDeclaration, ts.isStatement);
 				const modifiers = statement && ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
 				if (modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword)) {

--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -10,7 +10,6 @@ import { isSymbolMutable } from "TSTransformer/util/isSymbolMutable";
 import { isSymbolOfValue } from "TSTransformer/util/isSymbolOfValue";
 import { getAncestor } from "TSTransformer/util/traversal";
 import ts from "typescript";
-import { terminalWidth } from "yargs";
 
 function getExportPair(state: TransformState, exportSymbol: ts.Symbol): [name: string, id: luau.AnyIdentifier] {
 	const declaration = exportSymbol.getDeclarations()?.[0];

--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -75,12 +75,14 @@ function getIgnoredExportSymbols(state: TransformState, sourceFile: ts.SourceFil
  * ```
  * this mimics TypeScript behavior
  */
-function isExportSymbolOnlyFromDeclare(exportSymbol: ts.Symbol) {
-	return exportSymbol.declarations?.every(declaration => {
-		const statement = getAncestor(declaration, ts.isStatement);
-		const modifiers = statement && ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
-		return modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword);
-	});
+function isExportSymbolOnlyFromDeclare(exportSymbol: ts.Symbol): boolean {
+	return (
+		exportSymbol.declarations?.every(declaration => {
+			const statement = getAncestor(declaration, ts.isStatement);
+			const modifiers = statement && ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
+			return modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword);
+		}) ?? false
+	);
 }
 
 /**


### PR DESCRIPTION
Currently, we ignore any exports where the original symbol's value declaration comes from the form of `export declare const x: T;`.

However, this prevents re-exporting imports from other modules, i.e.
```ts
import { t } from "@rbxts/t";
export { t };
```

To fix this, I rewrote the check to better match vanilla TypeScript behavior. It will now look at the local export symbol (instead of the original) and only omit the export if it comes from the form `export declare const x: T;`

This also makes it so this
```ts
declare const x: T;
export { x };
```
will emit
```
return {
    x = x,
}
```
which [better matches vanilla TypeScript behavior](https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBAE2AYwDYEMrDsiA7AZ3hAC448BXAWwCNgoBuAKCdElkRQyx3yLgCeZSrXrM20eAG9BcAL4MgA).