### PR TITLE
Add support for `.luau`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@roblox-ts/luau-ast": "=2.0.0",
-				"@roblox-ts/path-translator": "=1.0.0",
-				"@roblox-ts/rojo-resolver": "=1.0.7",
+				"@roblox-ts/path-translator": "^1.1.0",
+				"@roblox-ts/rojo-resolver": "^1.1.0",
 				"chokidar": "^3.6.0",
 				"fs-extra": "^11.2.0",
 				"kleur": "^4.1.5",
@@ -815,20 +815,22 @@
 			"integrity": "sha512-cmMi093IdwBOLVxwuordhM8AmtbyTIyRpsTbB0D/JauidW4SXsQRQowSwWjHo4QP0DRJBXvOIlxtqEQi50uNzQ=="
 		},
 		"node_modules/@roblox-ts/path-translator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@roblox-ts/path-translator/-/path-translator-1.0.0.tgz",
-			"integrity": "sha512-Lp6qVUqjmXIrICy2KPKRiX8IkJ+lNqn6RqoUplLiTr+4JehIN+mJv0tTnE72XRyIfcx0VWl5nKrRwUuqcOj1yg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@roblox-ts/path-translator/-/path-translator-1.1.0.tgz",
+			"integrity": "sha512-D0akTmnNYqBw+ZIek5JxocT3BjmbgGOuOy0x1nIIxHBPNLGCpzseToY8jyYs/0mlvnN2xnSP/k8Tv+jvGOQSwQ==",
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.12.0",
 				"fs-extra": "^11.2.0"
 			}
 		},
 		"node_modules/@roblox-ts/rojo-resolver": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@roblox-ts/rojo-resolver/-/rojo-resolver-1.0.7.tgz",
-			"integrity": "sha512-LG0RM191h06bmCYf0TTGKyLuKBR1464I2IwZxYqP434XD5ALRDg0xbtyQQqww++cPoTDBR6aPYH/dGdn6Wle8g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@roblox-ts/rojo-resolver/-/rojo-resolver-1.1.0.tgz",
+			"integrity": "sha512-QmvVryu1EeME+3QUoG5j/gHGJoJUaffCgZ92mhlG7cJSd1uyhgpY4CNWriZAwZJYkTlzd5Htkpn+18yDFbOFXA==",
+			"license": "MIT",
 			"dependencies": {
-				"ajv": "^8.16.0",
+				"ajv": "^8.17.1",
 				"fs-extra": "^11.2.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
 	"license": "MIT",
 	"dependencies": {
 		"@roblox-ts/luau-ast": "=2.0.0",
-		"@roblox-ts/path-translator": "=1.0.0",
-		"@roblox-ts/rojo-resolver": "=1.0.7",
+		"@roblox-ts/path-translator": "^1.1.0",
+		"@roblox-ts/rojo-resolver": "^1.1.0",
 		"chokidar": "^3.6.0",
 		"fs-extra": "^11.2.0",
 		"kleur": "^4.1.5",

--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -111,6 +111,9 @@ export = ts.identity<yargs.CommandModule<object, BuildFlags & Partial<ProjectOpt
 			.option("allowCommentDirectives", {
 				boolean: true,
 				hidden: true,
+			})
+			.option("luau", {
+				boolean: true,
 			}),
 
 	handler: async argv => {
@@ -134,7 +137,7 @@ export = ts.identity<yargs.CommandModule<object, BuildFlags & Partial<ProjectOpt
 				setupProjectWatchProgram(data, projectOptions.usePolling);
 			} else {
 				const program = createProjectProgram(data);
-				const pathTranslator = createPathTranslator(program);
+				const pathTranslator = createPathTranslator(program, data);
 				cleanup(pathTranslator);
 				copyInclude(data);
 				copyFiles(data, pathTranslator, new Set(getRootDirs(program.getCompilerOptions())));

--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -114,6 +114,7 @@ export = ts.identity<yargs.CommandModule<object, BuildFlags & Partial<ProjectOpt
 			})
 			.option("luau", {
 				boolean: true,
+				describe: "emit files with .luau extension",
 			}),
 
 	handler: async argv => {

--- a/src/CLI/test.ts
+++ b/src/CLI/test.ts
@@ -27,7 +27,7 @@ describe("should compile tests project", () => {
 		}),
 	);
 	const program = createProjectProgram(data);
-	const pathTranslator = createPathTranslator(program);
+	const pathTranslator = createPathTranslator(program, data);
 
 	// clean outDir between test runs
 	fs.removeSync(program.getCompilerOptions().outDir!);

--- a/src/Project/classes/VirtualProject.ts
+++ b/src/Project/classes/VirtualProject.ts
@@ -110,7 +110,7 @@ export class VirtualProject {
 		this.typeChecker = this.program.getTypeChecker();
 
 		const services = createTransformServices(this.typeChecker);
-		const pathTranslator = new PathTranslator(ROOT_DIR, OUT_DIR, undefined, false);
+		const pathTranslator = new PathTranslator(ROOT_DIR, OUT_DIR, undefined, false, this.data.projectOptions.luau);
 
 		const sourceFile = this.program.getSourceFile(PLAYGROUND_PATH);
 		assert(sourceFile);

--- a/src/Project/functions/createPathTranslator.ts
+++ b/src/Project/functions/createPathTranslator.ts
@@ -1,10 +1,11 @@
 import { PathTranslator } from "@roblox-ts/path-translator";
 import path from "path";
+import { ProjectData } from "Shared/types";
 import { findAncestorDir } from "Shared/util/findAncestorDir";
 import { getRootDirs } from "Shared/util/getRootDirs";
 import ts from "typescript";
 
-export function createPathTranslator(program: ts.BuilderProgram) {
+export function createPathTranslator(program: ts.BuilderProgram, data: ProjectData) {
 	const compilerOptions = program.getCompilerOptions();
 	const rootDir = findAncestorDir([program.getProgram().getCommonSourceDirectory(), ...getRootDirs(compilerOptions)]);
 	const outDir = compilerOptions.outDir!;
@@ -13,5 +14,5 @@ export function createPathTranslator(program: ts.BuilderProgram) {
 		buildInfoPath = path.normalize(buildInfoPath);
 	}
 	const declaration = compilerOptions.declaration === true;
-	return new PathTranslator(rootDir, outDir, buildInfoPath, declaration);
+	return new PathTranslator(rootDir, outDir, buildInfoPath, declaration, data.projectOptions.luau);
 }

--- a/src/Project/functions/setupProjectWatchProgram.ts
+++ b/src/Project/functions/setupProjectWatchProgram.ts
@@ -75,7 +75,7 @@ export function setupProjectWatchProgram(data: ProjectData, usePolling: boolean)
 	const createProgram = createProgramFactory(data, options);
 	function refreshProgram() {
 		program = createProgram([...fileNamesSet], options);
-		pathTranslator = createPathTranslator(program);
+		pathTranslator = createPathTranslator(program, data);
 	}
 
 	function runInitialCompile() {

--- a/src/Shared/constants.ts
+++ b/src/Shared/constants.ts
@@ -51,4 +51,5 @@ export const DEFAULT_PROJECT_OPTIONS: ProjectOptions = {
 	writeTransformedFiles: false,
 	optimizedLoops: true,
 	allowCommentDirectives: false,
+	luau: true,
 };

--- a/src/Shared/types.ts
+++ b/src/Shared/types.ts
@@ -14,6 +14,7 @@ export interface ProjectOptions {
 	writeTransformedFiles: boolean;
 	optimizedLoops: boolean;
 	allowCommentDirectives: boolean;
+	luau: boolean;
 }
 
 export interface ProjectData {

--- a/tests/default.project.json
+++ b/tests/default.project.json
@@ -18,7 +18,7 @@
 		"ServerScriptService": {
 			"$className": "ServerScriptService",
 			"main": {
-				"$path": "out/main.server.lua"
+				"$path": "out/main.server.luau"
 			},
 			"tests": {
 				"$path": "out/tests"
@@ -36,7 +36,7 @@
 		"StarterGui": {
 			"$className": "StarterGui",
 			"isolated": {
-				"$path": "out/helpers/rojo/isolated.lua"
+				"$path": "out/helpers/rojo/isolated.luau"
 			}
 		}
 	}


### PR DESCRIPTION
Depends on:
- https://github.com/roblox-ts/path-translator/pull/2
- https://github.com/roblox-ts/rojo-resolver/pull/496

Allows for both emitting .luau files to `outDir` and importing packages contain `.luau` files (or `.lua` for backwards compatibility).

Unit tests pass with the above two PR branches installed locally.