### PR TITLE
Upgrade TypeScript to 5.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"fs-extra": "^11.2.0",
 				"kleur": "^4.1.5",
 				"resolve": "^1.22.6",
-				"typescript": "=5.5.3",
+				"typescript": "=5.6.2",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -32,7 +32,7 @@
 				"@types/node": "^22.5.4",
 				"@types/prompts": "^2.4.9",
 				"@types/resolve": "^1.20.6",
-				"@types/ts-expose-internals": "npm:ts-expose-internals@=5.5.3",
+				"@types/ts-expose-internals": "npm:ts-expose-internals@=5.6.2",
 				"@types/yargs": "^17.0.33",
 				"eslint": "^9.9.1",
 				"eslint-config-prettier": "^9.1.0",
@@ -945,10 +945,11 @@
 		},
 		"node_modules/@types/ts-expose-internals": {
 			"name": "ts-expose-internals",
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/ts-expose-internals/-/ts-expose-internals-5.5.3.tgz",
-			"integrity": "sha512-/HejRD2f0jpndM0ftNiqjHkQBK3A/8z+hE3hwe9rQba4cMG+gKsEpgnjQxNTGaMPwxuBzR9uKrNi+bJTjsBi7g==",
-			"dev": true
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/ts-expose-internals/-/ts-expose-internals-5.6.2.tgz",
+			"integrity": "sha512-PkkiNh2AHcFu2YsfxndL+gx/YPbjIKDJiT9poDsIY0k7ayMEIJVhXXtg/llbejNYBoccfzAsvOAHvVwBbzAw9Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.33",
@@ -3679,9 +3680,10 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"fs-extra": "^11.2.0",
 		"kleur": "^4.1.5",
 		"resolve": "^1.22.6",
-		"typescript": "=5.5.3",
+		"typescript": "=5.6.2",
 		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
@@ -68,7 +68,7 @@
 		"@types/node": "^22.5.4",
 		"@types/prompts": "^2.4.9",
 		"@types/resolve": "^1.20.6",
-		"@types/ts-expose-internals": "npm:ts-expose-internals@=5.5.3",
+		"@types/ts-expose-internals": "npm:ts-expose-internals@=5.6.2",
 		"@types/yargs": "^17.0.33",
 		"eslint": "^9.9.1",
 		"eslint-config-prettier": "^9.1.0",

--- a/src/Project/functions/getChangedFilePaths.ts
+++ b/src/Project/functions/getChangedFilePaths.ts
@@ -11,7 +11,7 @@ import ts from "typescript";
  */
 export function getChangedFilePaths(program: ts.BuilderProgram, pathHints?: Array<string>) {
 	const compilerOptions = program.getCompilerOptions();
-	const buildState = program.getState();
+	const buildState = program.state;
 
 	// buildState.referencedMap is sourceFile -> files that this file imports
 	// but we need sourceFile -> files that import this file

--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -14,7 +14,9 @@ import ts from "typescript";
 function getExportPair(state: TransformState, exportSymbol: ts.Symbol): [name: string, id: luau.AnyIdentifier] {
 	const declaration = exportSymbol.getDeclarations()?.[0];
 	if (declaration && ts.isExportSpecifier(declaration)) {
-		return [declaration.name.text, transformIdentifierDefined(state, declaration.propertyName ?? declaration.name)];
+		const exportName = declaration.propertyName ?? declaration.name;
+		assert(!ts.isStringLiteral(exportName));
+		return [declaration.name.text, transformIdentifierDefined(state, exportName)];
 	} else {
 		let name = exportSymbol.name;
 		if (

--- a/src/TSTransformer/util/assertNever.ts
+++ b/src/TSTransformer/util/assertNever.ts
@@ -44,7 +44,7 @@ function error(message: string): never {
  */
 export function assertNever(value: never, message: string): never {
 	/* istanbul ignore */
-	const isTsNode = typeof value === "object" && "kind" in value && ts.isNode(value);
+	const isTsNode = typeof value === "object" && "kind" in value && ts.isNodeKind((value as ts.Node).kind);
 	error(
 		`${message}, value was ${isTsNode ? `a TS node of kind ${getKindName((value as ts.Node).kind)}` : util.inspect(value)}`,
 	);

--- a/src/TSTransformer/util/binding/objectAccessor.ts
+++ b/src/TSTransformer/util/binding/objectAccessor.ts
@@ -31,6 +31,9 @@ export const objectAccessor = (
 	} else if (ts.isPrivateIdentifier(name)) {
 		DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(name));
 		return luau.none();
+	} else if (ts.isBigIntLiteral(name)) {
+		DiagnosticService.addDiagnostic(errors.noBigInt(name));
+		return luau.none();
 	}
 	return assertNever(name, "objectAccessor");
 };


### PR DESCRIPTION
### Update `typescript` ✅

```
Exception during run: TypeError: program.getState is not a function
```
- Fixed this by switching `program.getState()` -> `program.state`. Needs testing.

```
transformSourceFile.ts:17:68 - error TS2345: Argument of type 'ModuleExportName' is not assignable to parameter of type 'Identifier'.
```
- WIP, right now I just `assert(!ts.isStringLiteral(exportName)`

```
assertNever.ts:47:70 - error TS2339: Property 'isNode' does not exist on type 'typeof import("typescript")'.
```
- Swapped `ts.isNode(value)` for `ts.isNodeKind((value as ts.Node).kind)` (this is what `ts.isNode()` did internally before it was removed)

```
objectAccessor.ts:35:21 - error TS2345: Argument of type 'BigIntLiteral' is not assignable to parameter of type 'never'.
```
- Added check + throw diagnostic for BigIntLiteral in `objectAccessor`

### Update `ts-expose-internals` ✅ 
### Update `typescript-transform-paths`
  - `TypeError: tsInstance.getOriginalSourceFile is not a function`
