### PR TITLE
Add back `yargs.fail()`

### DIFF
--- a/src/CLI/cli.ts
+++ b/src/CLI/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { CLIError } from "CLI/errors/CLIError";
+import { LogService } from "Shared/classes/LogService";
 import { COMPILER_VERSION, PACKAGE_ROOT } from "Shared/constants";
 import yargs from "yargs";
 
@@ -25,6 +26,13 @@ yargs
 	.wrap(yargs.terminalWidth())
 
 	// execute
+	// .fail() is necessary to properly `.toString()` custom error objects like CLIError
+	.fail(str => {
+		process.exitCode = 1;
+		if (str) {
+			LogService.fatal(str);
+		}
+	})
 	.parseAsync()
 	.catch(e => {
 		if (e instanceof CLIError) {


### PR DESCRIPTION
This was removed in https://github.com/roblox-ts/roblox-ts/commit/553259333b450a284a5f6bce7349ed36bc3e353b because we thought it was effectively the same as the default behavior.

One key difference we missed: custom .fail() uses `console.log()` which automatically calls `.toString()` on the error. For custom error classes like CLIError, this is where we do the formatting for the output.

I've added it back + added a clarifying comment.