### PR TITLE
Fix "return nil" generation for complexly named files

### DIFF
--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -214,7 +214,9 @@ export function transformSourceFile(state: TransformState, node: ts.SourceFile) 
 	const lastStatement = getLastNonCommentStatement(statements.tail);
 	if (!lastStatement || !luau.isReturnStatement(lastStatement.value)) {
 		const outputPath = state.pathTranslator.getOutputPath(node.fileName);
-		if (state.rojoResolver.getRbxTypeFromFilePath(outputPath) === RbxType.ModuleScript) {
+		const outputFileType = state.rojoResolver.getRbxTypeFromFilePath(outputPath);
+
+		if (outputFileType !== RbxType.Script && outputFileType !== RbxType.LocalScript) {
 			luau.list.push(statements, luau.create(luau.SyntaxKind.ReturnStatement, { expression: luau.nil() }));
 		}
 	}


### PR DESCRIPTION
Fixes #2851, caused by rojo-resolver returning RbxType.Unknown for files named like ``module.require.luau`` and not one of the standard formats such as ``module.luau``, ``module.server.luau``, or ``module.client.luau``.