### PR TITLE
Add type annotations

### DIFF
--- a/src/TSTransformer/nodes/class/transformClassConstructorType.ts
+++ b/src/TSTransformer/nodes/class/transformClassConstructorType.ts
@@ -1,0 +1,50 @@
+import luau from "@roblox-ts/luau-ast";
+import { TransformState } from "TSTransformer";
+import { getExtendsNode } from "TSTransformer/util/getExtendsNode";
+import ts from "typescript";
+import { transformType } from "../types/transformType";
+
+export function transformImplicitClassConstructorType(
+	state: TransformState,
+	node: ts.ClassLikeDeclaration,
+	name: luau.TypeIdentifier,
+): luau.TypeFunction {
+	const parameters = luau.list.make<luau.TypeParameter>();
+
+	let hasDotDotDot = false;
+	if (getExtendsNode(node)) {
+		hasDotDotDot = true;
+	}
+
+	return luau.create(luau.SyntaxKind.TypeFunction, {
+		parameters,
+		dotDotDot: undefined,
+		returnType: name,
+	});
+}
+
+export function transformClassConstructorType(
+	state: TransformState,
+	node: ts.ConstructorDeclaration & { body: ts.Block },
+	name: luau.TypeIdentifier,
+): luau.TypeFunction {
+	const parameters = luau.list.make<luau.TypeParameter>();
+
+	for (const parameter of node.parameters) {
+		if (ts.isParameterPropertyDeclaration(parameter, parameter.parent)) {
+			luau.list.push(
+				parameters,
+				luau.create(luau.SyntaxKind.TypeParameter, {
+					name: undefined,
+					value: (parameter.type && transformType(state, state.getType(parameter), parameter)) ?? luau.any(),
+				}),
+			);
+		}
+	}
+
+	return luau.create(luau.SyntaxKind.TypeFunction, {
+		parameters,
+		dotDotDot: undefined,
+		returnType: name,
+	});
+}

--- a/src/TSTransformer/nodes/class/transformClassLikeDeclarationType.ts
+++ b/src/TSTransformer/nodes/class/transformClassLikeDeclarationType.ts
@@ -1,0 +1,224 @@
+import luau from "@roblox-ts/luau-ast";
+import { TransformState } from "TSTransformer";
+import { findConstructor } from "TSTransformer/util/findConstructor";
+import { isMethodFromType } from "TSTransformer/util/isMethod";
+import ts from "typescript";
+import { transformCallSignature, transformType } from "../types/transformType";
+import { transformClassConstructorType, transformImplicitClassConstructorType } from "./transformClassConstructorType";
+
+export function transformClassLikeDeclarationType(
+	state: TransformState,
+	node: ts.ClassLikeDeclaration,
+	name: luau.Identifier,
+): [luau.List<luau.Statement>, luau.TypeIdentifier, luau.TypeIdentifier] {
+	// TODO
+	const typeName = name.name;
+	const classType = state.getType(node);
+	const staticClassType = state.typeChecker.getTypeOfSymbol(classType.symbol);
+
+	const typeIdentifier = luau.create(luau.SyntaxKind.TypeIdentifier, {
+		module: undefined,
+		name: typeName,
+	});
+
+	const typeImplIdentifier = luau.create(luau.SyntaxKind.TypeIdentifier, {
+		module: undefined,
+		name: `${typeName}Impl`,
+	});
+
+	const staticTypeDeclarations = luau.list.make<luau.TypeMixedTableField | luau.TypeMixedTableIndexedField>();
+	const propertyTypeDeclarations = luau.list.make<luau.TypeMixedTableField | luau.TypeMixedTableIndexedField>();
+
+	// for (const member of node.members) {
+	// 	if (ts.isMethodDeclaration(member)) {
+	// 		luau.list.push(staticTypeDeclarations, luau.create(luau.SyntaxKind.TypeMixedTableField, {
+	// 			index: luau.create(luau.SyntaxKind.TypeIdentifier, {
+	// 				module: undefined,
+	// 				name: member.name.getText()
+	// 			}),
+	// 			value: transformCallSignature(state, state.getType(member), member, typeIdentifier) ?? luau.any(),
+	// 		}));
+	// 	}
+
+	// 	if (ts.isPropertyDeclaration(member)) {
+	// 		luau.list.push(ts.hasStaticModifier(member) ? staticTypeDeclarations : propertyTypeDeclarations, luau.create(luau.SyntaxKind.TypeMixedTableField, {
+	// 			index: luau.create(luau.SyntaxKind.TypeIdentifier, {
+	// 				module: undefined,
+	// 				name: member.name.getText()
+	// 			}),
+	// 			value: transformType(state, state.getType(member), member) ?? luau.any(),
+	// 		}));
+	// 	}
+	// }
+
+	for (const property of classType.getProperties() ?? []) {
+		const member = state.typeChecker.getTypeOfSymbol(property);
+		if (isMethodFromType(state, node, member)) {
+			luau.list.push(
+				staticTypeDeclarations,
+				luau.create(luau.SyntaxKind.TypeMixedTableField, {
+					index: luau.create(luau.SyntaxKind.TypeIdentifier, {
+						module: undefined,
+						name: property.getName(),
+					}),
+					value: transformCallSignature(state, member, node, typeIdentifier) ?? luau.any(),
+				}),
+			);
+			continue;
+		}
+
+		luau.list.push(
+			propertyTypeDeclarations,
+			luau.create(luau.SyntaxKind.TypeMixedTableField, {
+				index: luau.create(luau.SyntaxKind.TypeIdentifier, {
+					module: undefined,
+					name: property.getName(),
+				}),
+				value: transformType(state, member, node) ?? luau.any(),
+			}),
+		);
+	}
+
+	for (const property of staticClassType.getProperties() ?? []) {
+		const member = state.typeChecker.getTypeOfSymbol(property);
+		if (isMethodFromType(state, node, member)) {
+			luau.list.push(
+				staticTypeDeclarations,
+				luau.create(luau.SyntaxKind.TypeMixedTableField, {
+					index: luau.create(luau.SyntaxKind.TypeIdentifier, {
+						module: undefined,
+						name: property.getName(),
+					}),
+					value: transformCallSignature(state, member, node, typeImplIdentifier) ?? luau.any(),
+				}),
+			);
+			continue;
+		}
+
+		luau.list.push(
+			staticTypeDeclarations,
+			luau.create(luau.SyntaxKind.TypeMixedTableField, {
+				index: luau.create(luau.SyntaxKind.TypeIdentifier, {
+					module: undefined,
+					name: property.getName(),
+				}),
+				value: transformType(state, member, node) ?? luau.any(),
+			}),
+		);
+	}
+
+	luau.list.push(
+		staticTypeDeclarations,
+		luau.create(luau.SyntaxKind.TypeMixedTableField, {
+			index: luau.create(luau.SyntaxKind.TypeIdentifier, {
+				module: undefined,
+				name: luau.strings.__index.value,
+			}),
+			value: typeImplIdentifier,
+		}),
+	);
+
+	const isAbstract = ts.hasAbstractModifier(node);
+	if (!isAbstract) {
+		const constructor = findConstructor(node);
+		if (constructor) {
+			luau.list.push(
+				staticTypeDeclarations,
+				luau.create(luau.SyntaxKind.TypeMixedTableField, {
+					index: luau.typeId("new"),
+					value: transformClassConstructorType(state, constructor, typeIdentifier),
+				}),
+			);
+		} else {
+			luau.list.push(
+				staticTypeDeclarations,
+				luau.create(luau.SyntaxKind.TypeMixedTableField, {
+					index: luau.typeId("new"),
+					value: transformImplicitClassConstructorType(state, node, typeIdentifier),
+				}),
+			);
+		}
+
+		luau.list.push(
+			staticTypeDeclarations,
+			luau.create(luau.SyntaxKind.TypeMixedTableField, {
+				index: luau.typeId("constructor"),
+				value: luau.create(luau.SyntaxKind.TypeFunction, {
+					parameters: luau.list.make(
+						luau.create(luau.SyntaxKind.TypeParameter, {
+							name: "self",
+							value: typeIdentifier,
+						}),
+					),
+					dotDotDot: luau.any(),
+					returnType: luau.any(),
+				}),
+			}),
+		);
+	}
+
+	let impl: luau.TypeExpression = luau.create(luau.SyntaxKind.TypeMixedTable, {
+		fields: staticTypeDeclarations,
+	});
+
+	// This causes autocomplete to break in Luau
+	// This probably isn't worth the benefit of being 100% correct - all that's missing is __tostring
+	// const extendsNode = getExtendsNode(node);
+	// if (!(isAbstract && !extendsNode)) {
+	// 	impl = luau.create(luau.SyntaxKind.TypeTypeOf, {
+	// 		expression: luau.call(luau.globals.setmetatable, [
+	// 			luau.cast(
+	// 				luau.map(),
+	// 				impl,
+	// 			),
+	// 			luau.cast(
+	// 				luau.map(),
+	// 				luau.create(luau.SyntaxKind.TypeMixedTable, {
+	// 					fields: luau.list.make(
+	// 						luau.create(luau.SyntaxKind.TypeMixedTableField, {
+	// 							index: luau.typeId("__tostring"),
+	// 							value: luau.create(luau.SyntaxKind.TypeFunction, {
+	// 								parameters: luau.list.make(
+	// 									// luau.create(luau.SyntaxKind.TypeParameter, {
+	// 									// 	name: undefined,
+	// 									// 	value: typeImplIdentifier
+	// 									// })
+	// 								),
+	// 								dotDotDot: undefined,
+	// 								returnType: luau.typeId("string"),
+	// 							})
+	// 						})
+	// 					)
+	// 				}),
+	// 			),
+	// 		])
+	// 	});
+	// }
+
+	const instance = luau.create(luau.SyntaxKind.TypeTypeOf, {
+		expression: luau.call(luau.globals.setmetatable, [
+			luau.cast(
+				luau.map(),
+				luau.create(luau.SyntaxKind.TypeMixedTable, {
+					fields: propertyTypeDeclarations,
+				}),
+			),
+			luau.cast(luau.cast(luau.map(), luau.any()), typeImplIdentifier),
+		]),
+	});
+
+	return [
+		luau.list.make(
+			luau.create(luau.SyntaxKind.TypeStatement, {
+				identifier: typeImplIdentifier,
+				expression: impl,
+			}),
+			luau.create(luau.SyntaxKind.TypeStatement, {
+				identifier: typeIdentifier,
+				expression: instance,
+			}),
+		),
+		typeImplIdentifier,
+		typeIdentifier,
+	];
+}

--- a/src/TSTransformer/nodes/expressions/transformIdentifier.ts
+++ b/src/TSTransformer/nodes/expressions/transformIdentifier.ts
@@ -10,8 +10,9 @@ import { isSymbolMutable } from "TSTransformer/util/isSymbolMutable";
 import { getAncestor, isAncestorOf, skipDownwards, skipUpwards } from "TSTransformer/util/traversal";
 import { getFirstConstructSymbol } from "TSTransformer/util/types";
 import ts from "typescript";
+import { transformType } from "../types/transformType";
 
-export function transformIdentifierDefined(state: TransformState, node: ts.Identifier) {
+export function transformIdentifierDefined(state: TransformState, node: ts.Identifier, annotation?: ts.Type) {
 	const symbol = ts.isShorthandPropertyAssignment(node.parent)
 		? state.typeChecker.getShorthandAssignmentValueSymbol(node.parent)
 		: state.typeChecker.getSymbolAtLocation(node);
@@ -24,6 +25,7 @@ export function transformIdentifierDefined(state: TransformState, node: ts.Ident
 
 	return luau.create(luau.SyntaxKind.Identifier, {
 		name: node.text,
+		annotation: annotation && transformType(state, annotation, node),
 	});
 }
 
@@ -113,7 +115,7 @@ export function transformIdentifier(state: TransformState, node: ts.Identifier) 
 	// JSX EntityName functions like `getJsxFactoryEntity()` will return synthetic nodes
 	// and transformEntityName will eventually end up here
 	if (!node.parent || ts.positionIsSynthesized(node.pos)) {
-		return luau.create(luau.SyntaxKind.Identifier, { name: node.text });
+		return luau.create(luau.SyntaxKind.Identifier, { name: node.text, annotation: undefined });
 	}
 
 	const symbol = ts.isShorthandPropertyAssignment(node.parent)

--- a/src/TSTransformer/nodes/statements/transformFunctionDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformFunctionDeclaration.ts
@@ -9,6 +9,7 @@ import { transformStatementList } from "TSTransformer/nodes/transformStatementLi
 import { validateIdentifier } from "TSTransformer/util/validateIdentifier";
 import { wrapStatementsAsGenerator } from "TSTransformer/util/wrapStatementsAsGenerator";
 import ts from "typescript";
+import { transformType } from "../types/transformType";
 
 export function transformFunctionDeclaration(state: TransformState, node: ts.FunctionDeclaration) {
 	if (!node.body) {
@@ -70,7 +71,14 @@ export function transformFunctionDeclaration(state: TransformState, node: ts.Fun
 		}
 	} else {
 		return luau.list.make(
-			luau.create(luau.SyntaxKind.FunctionDeclaration, { localize, name, statements, parameters, hasDotDotDot }),
+			luau.create(luau.SyntaxKind.FunctionDeclaration, {
+				localize,
+				name,
+				statements,
+				parameters,
+				hasDotDotDot,
+				returnType: node.type && transformType(state, state.getType(node.type), node),
+			}),
 		);
 	}
 }

--- a/src/TSTransformer/nodes/statements/transformVariableStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformVariableStatement.ts
@@ -16,7 +16,12 @@ import { validateIdentifier } from "TSTransformer/util/validateIdentifier";
 import { wrapExpressionStatement } from "TSTransformer/util/wrapExpressionStatement";
 import ts from "typescript";
 
-export function transformVariable(state: TransformState, identifier: ts.Identifier, right?: luau.Expression) {
+export function transformVariable(
+	state: TransformState,
+	identifier: ts.Identifier,
+	right?: luau.Expression,
+	annotation?: ts.Type,
+) {
 	validateIdentifier(state, identifier);
 
 	const symbol = state.typeChecker.getSymbolAtLocation(identifier);
@@ -39,7 +44,7 @@ export function transformVariable(state: TransformState, identifier: ts.Identifi
 		}
 	}
 
-	const left: luau.AnyIdentifier = transformIdentifierDefined(state, identifier);
+	const left: luau.AnyIdentifier = transformIdentifierDefined(state, identifier, annotation);
 
 	checkVariableHoist(state, identifier, symbol);
 	if (state.isHoisted.get(symbol) === true) {
@@ -117,7 +122,7 @@ export function transformVariableDeclaration(
 	if (ts.isIdentifier(name)) {
 		luau.list.pushList(
 			statements,
-			state.capturePrereqs(() => transformVariable(state, name, value)),
+			state.capturePrereqs(() => transformVariable(state, name, value, state.getType(node))),
 		);
 	} else {
 		// in destructuring, rhs must be executed first

--- a/src/TSTransformer/nodes/transformMethodDeclaration.ts
+++ b/src/TSTransformer/nodes/transformMethodDeclaration.ts
@@ -10,6 +10,7 @@ import { isMethod } from "TSTransformer/util/isMethod";
 import { assignToMapPointer, Pointer } from "TSTransformer/util/pointer";
 import { wrapStatementsAsGenerator } from "TSTransformer/util/wrapStatementsAsGenerator";
 import ts from "typescript";
+import { transformType } from "./types/transformType";
 
 export function transformMethodDeclaration(
 	state: TransformState,
@@ -80,6 +81,7 @@ export function transformMethodDeclaration(
 					statements,
 					parameters,
 					hasDotDotDot,
+					returnType: node.type && transformType(state, state.getType(node), node),
 				}),
 			);
 		}

--- a/src/TSTransformer/nodes/transformParameters.ts
+++ b/src/TSTransformer/nodes/transformParameters.ts
@@ -74,7 +74,7 @@ export function transformParameters(state: TransformState, node: ts.SignatureDec
 
 		let paramId: luau.Identifier | luau.TemporaryIdentifier;
 		if (ts.isIdentifier(parameter.name)) {
-			paramId = transformIdentifierDefined(state, parameter.name);
+			paramId = transformIdentifierDefined(state, parameter.name, state.getType(parameter));
 			validateIdentifier(state, parameter.name);
 		} else {
 			paramId = luau.tempId("param");

--- a/src/TSTransformer/nodes/types/transformType.ts
+++ b/src/TSTransformer/nodes/types/transformType.ts
@@ -1,0 +1,71 @@
+import luau from "@roblox-ts/luau-ast";
+import assert from "assert";
+import { TransformState } from "TSTransformer/classes/TransformState";
+import { isMethodFromType } from "TSTransformer/util/isMethod";
+import { isDefinitelyType, isNumberType, isStringType } from "TSTransformer/util/types";
+import ts from "typescript";
+
+export function transformCallSignature(
+	state: TransformState,
+	type: ts.Type,
+	reference: ts.Node,
+	self?: luau.TypeIdentifier,
+) {
+	const signatures = type.getCallSignatures();
+	assert(signatures.length > 0);
+
+	let returnType: luau.TypeExpression | undefined = luau.any();
+	let dotDotDot: luau.TypeExpression | undefined = undefined;
+	let parameters = luau.list.make<luau.TypeParameter>();
+
+	if (signatures.length === 1) {
+		const call = signatures[0];
+		if (isMethodFromType(state, reference, type)) {
+			luau.list.push(
+				parameters,
+				luau.create(luau.SyntaxKind.TypeParameter, {
+					name: "self",
+					value: self ?? luau.any(),
+				}),
+			);
+		}
+		returnType = transformType(state, call.getReturnType(), reference) ?? luau.any();
+		const parameterSymbols = call.getParameters();
+		for (let i = 0; i < parameterSymbols.length; i++) {
+			const parameter = call.getTypeParameterAtPosition(i);
+			luau.list.push(
+				parameters,
+				luau.create(luau.SyntaxKind.TypeParameter, {
+					name: parameterSymbols[i].getName(),
+					value: transformType(state, parameter, reference) ?? luau.any(),
+				}),
+			);
+		}
+	}
+
+	return luau.create(luau.SyntaxKind.TypeFunction, {
+		dotDotDot,
+		parameters,
+		returnType,
+	});
+}
+
+export function transformType(
+	state: TransformState,
+	type: ts.Type,
+	reference: ts.Node,
+): luau.TypeExpression | undefined {
+	if (type.getCallSignatures().length > 0) {
+		return transformCallSignature(state, type, reference);
+	} else if (isDefinitelyType(type, isStringType)) {
+		return luau.create(luau.SyntaxKind.TypeIdentifier, {
+			module: undefined,
+			name: "string",
+		});
+	} else if (isDefinitelyType(type, isNumberType)) {
+		return luau.create(luau.SyntaxKind.TypeIdentifier, {
+			module: undefined,
+			name: "number",
+		});
+	}
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6eaa9407-0a6f-4610-9e65-045069c3b585)

My use case is to be able to write Luau packages in TypeScript with full types. Depends on this pull request: https://github.com/roblox-ts/luau-ast/pull/546