### PR TITLE
WeakRef macro

### DIFF
--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -24,6 +24,7 @@ export const SYMBOL_NAMES = {
 	WeakMapConstructor: "WeakMapConstructor",
 	ReadonlyMapConstructor: "ReadonlyMapConstructor",
 	ReadonlySetConstructor: "ReadonlySetConstructor",
+	WeakRefConstructor: "WeakRefConstructor",
 
 	Array: "Array",
 	Generator: "Generator",
@@ -40,6 +41,7 @@ export const SYMBOL_NAMES = {
 	TemplateStringsArray: "TemplateStringsArray",
 	WeakMap: "WeakMap",
 	WeakSet: "WeakSet",
+	WeakRef: "WeakRef",
 
 	Iterable: "Iterable",
 
@@ -58,6 +60,7 @@ const MACRO_ONLY_CLASSES = new Set<string>([
 	SYMBOL_NAMES.ReadonlySet,
 	SYMBOL_NAMES.WeakSet,
 	SYMBOL_NAMES.Set,
+	SYMBOL_NAMES.WeakRef,
 	SYMBOL_NAMES.String,
 ]);
 

--- a/src/TSTransformer/macros/constructorMacros.ts
+++ b/src/TSTransformer/macros/constructorMacros.ts
@@ -95,6 +95,17 @@ const MapConstructor: ConstructorMacro = (state, node) => {
 	}
 };
 
+const WeakRefConstructor: ConstructorMacro = (state, node) => {
+	assert(node.arguments && node.arguments.length === 1);
+	const arg = node.arguments[0];
+	const transformed = transformExpression(state, arg);
+	return luau.call(luau.globals.setmetatable, [
+		luau.array([transformed]),
+		// TODO: Replace luau.string("v") with luau.strings.v when added to luau-ast
+		luau.map([[luau.strings.__mode, luau.string("v")]]),
+	]);
+};
+
 export const CONSTRUCTOR_MACROS: MacroList<ConstructorMacro> = {
 	ArrayConstructor,
 	SetConstructor,
@@ -103,4 +114,5 @@ export const CONSTRUCTOR_MACROS: MacroList<ConstructorMacro> = {
 	WeakMapConstructor: (state, node) => wrapWeak(state, node, MapConstructor),
 	ReadonlyMapConstructor: MapConstructor,
 	ReadonlySetConstructor: SetConstructor,
+	WeakRefConstructor,
 };

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -907,6 +907,14 @@ const MAP_METHODS: MacroList<PropertyCallMacro> = {
 	},
 };
 
+const WEAK_REF_METHODS: MacroList<PropertyCallMacro> = {
+	deref: (state, node, expression) =>
+		luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+			expression: convertToIndexableExpression(expression),
+			index: luau.number(1),
+		}),
+};
+
 const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
 	then: (state, node, expression, args) =>
 		luau.create(luau.SyntaxKind.MethodCallExpression, {
@@ -936,6 +944,7 @@ export const PROPERTY_CALL_MACROS: { [className: string]: MacroList<PropertyCall
 	ReadonlyMap: READONLY_MAP_METHODS,
 	Map: MAP_METHODS,
 	Promise: PROMISE_METHODS,
+	WeakRef: WEAK_REF_METHODS,
 };
 
 // comment logic


### PR DESCRIPTION
Adds a [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) macro class, part of JS as of ES2021.

~~Since roblox-ts is composed by many packages, I'm unsure of what order I should follow to add the type for it to [roblox-ts/compiler-types](https://github.com/roblox-ts/compiler-types). Please let me know in this PR if I should make a commit to add the type definition.~~ Types are added by [roblox-ts/compiler-types#526](https://github.com/roblox-ts/compiler-types/pull/526). Tests have not been added yet.

An expression in the code is also pending [this PR in luau-ast](https://github.com/roblox-ts/luau-ast/pull/547).