### PR TITLE
Additional fixes for `shouldWrapLuaTuple()`

### DIFF
--- a/src/TSTransformer/util/wrapReturnIfLuaTuple.ts
+++ b/src/TSTransformer/util/wrapReturnIfLuaTuple.ts
@@ -1,6 +1,7 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
 import { arrayBindingPatternContainsHoists } from "TSTransformer/util/arrayBindingPatternContainsHoists";
+import { arrayLikeExpressionContainsSpread } from "TSTransformer/util/arrayLikeExpressionContainsSpread";
 import { skipUpwards } from "TSTransformer/util/traversal";
 import { isLuaTupleType } from "TSTransformer/util/types";
 import ts from "typescript";
@@ -27,7 +28,9 @@ function shouldWrapLuaTuple(state: TransformState, node: ts.CallExpression, exp:
 	if (
 		ts.isVariableDeclaration(parent) &&
 		ts.isArrayBindingPattern(parent.name) &&
-		!arrayBindingPatternContainsHoists(state, parent.name)
+		!arrayBindingPatternContainsHoists(state, parent.name) &&
+		!arrayLikeExpressionContainsSpread(parent.name) &&
+		node.questionDotToken === undefined
 	) {
 		return false;
 	}

--- a/src/TSTransformer/util/wrapReturnIfLuaTuple.ts
+++ b/src/TSTransformer/util/wrapReturnIfLuaTuple.ts
@@ -36,7 +36,12 @@ function shouldWrapLuaTuple(state: TransformState, node: ts.CallExpression, exp:
 	}
 
 	// `[a] = foo()`
-	if (ts.isAssignmentExpression(parent) && ts.isArrayLiteralExpression(parent.left)) {
+	if (
+		ts.isAssignmentExpression(parent) &&
+		ts.isArrayLiteralExpression(parent.left) &&
+		!arrayLikeExpressionContainsSpread(parent.left) &&
+		node.questionDotToken === undefined
+	) {
 		return false;
 	}
 

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -855,7 +855,7 @@ export = () => {
 		expect(x).to.equal(123);
 	});
 
-	it("should support destructuring LuaTuple with spread", () => {
+	it("should support array binding pattern with LuaTuple with spread", () => {
 		function returnsLuaTuple() {
 			return $tuple(1, 2, 3, 4, 5);
 		}
@@ -865,5 +865,44 @@ export = () => {
 		expect(c).to.equal(3);
 		expect(rest[0]).to.equal(4);
 		expect(rest[1]).to.equal(5);
+	});
+
+	it("should support array assignment pattern with LuaTuple with spread", () => {
+		function returnsLuaTuple() {
+			return $tuple(1, 2, 3, 4, 5);
+		}
+		let a: number;
+		let b: number;
+		let c: number;
+		let rest: Array<number>;
+		[a, b, c, ...rest] = returnsLuaTuple();
+		expect(a).to.equal(1);
+		expect(b).to.equal(2);
+		expect(c).to.equal(3);
+		expect(rest[0]).to.equal(4);
+		expect(rest[1]).to.equal(5);
+	});
+
+	it("should support array binding pattern with LuaTuple with optional call", () => {
+		function returnsLuaTuple() {
+			return $tuple(1, 2, 3, 4, 5);
+		}
+		const [a, b, c] = returnsLuaTuple?.();
+		expect(a).to.equal(1);
+		expect(b).to.equal(2);
+		expect(c).to.equal(3);
+	});
+
+	it("should support array assignment pattern with LuaTuple with optional call", () => {
+		function returnsLuaTuple() {
+			return $tuple(1, 2, 3, 4, 5);
+		}
+		let a: number;
+		let b: number;
+		let c: number;
+		[a, b, c] = returnsLuaTuple?.();
+		expect(a).to.equal(1);
+		expect(b).to.equal(2);
+		expect(c).to.equal(3);
 	});
 };

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -854,4 +854,16 @@ export = () => {
 		b(123);
 		expect(x).to.equal(123);
 	});
+
+	it("should support destructuring LuaTuple with spread", () => {
+		function returnsLuaTuple() {
+			return $tuple(1, 2, 3, 4, 5);
+		}
+		const [a, b, c, ...rest] = returnsLuaTuple();
+		expect(a).to.equal(1);
+		expect(b).to.equal(2);
+		expect(c).to.equal(3);
+		expect(rest[0]).to.equal(4);
+		expect(rest[1]).to.equal(5);
+	});
 };

--- a/tests/src/tests/tuple.spec.ts
+++ b/tests/src/tests/tuple.spec.ts
@@ -237,14 +237,19 @@ export = () => {
 		}
 
 		function fnTuple(): LuaTuple<[number, () => LuaTuple<[string, () => number]>]> | undefined {
-			return $tuple(1, () => $tuple("2", () => 3))
+			return $tuple(1, () => $tuple("2", () => 3));
 		}
 
 		expect(foo()?.[1]).to.equal("2");
 		expect(bar()?.[1]).to.equal(undefined);
-		expect(fnTuple()?.[1]?.()?.[0]).to.equal("2")
-		expect(fnTuple()?.[1]?.()?.[1]?.()).to.equal(3)
-	})
+		expect(fnTuple()?.[1]?.()?.[0]).to.equal("2");
+		expect(fnTuple()?.[1]?.()?.[1]?.()).to.equal(3);
+
+		expect(foo?.()?.[1]).to.equal("2");
+		expect(bar?.()?.[1]).to.equal(undefined);
+		expect(fnTuple?.()?.[1]?.()?.[0]).to.equal("2");
+		expect(fnTuple?.()?.[1]?.()?.[1]?.()).to.equal(3);
+	});
 
 	it("should support $tuple macro", () => {
 		function luaTupleMacroReturn() {


### PR DESCRIPTION
#2929 added a fix for `foo()?.[0]` where `foo()` returns a `LuaTuple<T>`

When reviewing that PR, I discovered a few additional cases:
1. `const [a, b, ...rest] = foo();`
2. `[a, b, ...rest] = foo();`
3. `const [a, b, c] = foo?.();`
4. `[a, b, c] = foo?.();`

## Input
```ts
function returnsLuaTuple() {
	return $tuple(1, 2, 3, 4, 5);
}

// luatuple + spread + array binding pattern
{
	const [a, b, ...rest] = returnsLuaTuple();
}

// luatuple + spread + array assignment pattern
{
	let a: number;
	let b: number;
	let rest: number[];
	[a, b, ...rest] = returnsLuaTuple();
}

// luatuple + optional function call + array binding pattern
{
	const [a, b, c] = returnsLuaTuple?.();
}

// luatuple + optional function call + array assignment pattern
{
	let a: number;
	let b: number;
	let c: number;
	[a, b, c] = returnsLuaTuple?.();
}
```
## Before
```lua
local function returnsLuaTuple()
	return 1, 2, 3, 4, 5
end
-- luatuple + spread + array binding pattern
do
	local _binding = returnsLuaTuple()
	local a = _binding[1]
	local b = _binding[2]
	local rest = table.move(_binding, 3, #_binding, 1, {})
end
-- luatuple + spread + array assignment pattern
do
	local a
	local b
	local rest
	local _binding = returnsLuaTuple()
	a = _binding[1]
	b = _binding[2]
	rest = table.move(_binding, 3, #_binding, 1, {})
end
-- luatuple + optional function call + array binding pattern
do
	local _result = returnsLuaTuple
	if _result ~= nil then
		_result = _result()
	end
	local _binding = _result
	local a = _binding[1]
	local b = _binding[2]
	local c = _binding[3]
end
-- luatuple + optional function call + array assignment pattern
do
	local a
	local b
	local c
	local _result = returnsLuaTuple
	if _result ~= nil then
		_result = _result()
	end
	local _binding = _result
	a = _binding[1]
	b = _binding[2]
	c = _binding[3]
end
```

## After
```lua
local function returnsLuaTuple()
	return 1, 2, 3, 4, 5
end
-- luatuple + spread + array binding pattern
do
	local _binding = { returnsLuaTuple() }
	local a = _binding[1]
	local b = _binding[2]
	local rest = table.move(_binding, 3, #_binding, 1, {})
end
-- luatuple + spread + array assignment pattern
do
	local a
	local b
	local rest
	local _binding = { returnsLuaTuple() }
	a = _binding[1]
	b = _binding[2]
	rest = table.move(_binding, 3, #_binding, 1, {})
end
-- luatuple + optional function call + array binding pattern
do
	local _result = returnsLuaTuple
	if _result ~= nil then
		_result = { _result() }
	end
	local _binding = _result
	local a = _binding[1]
	local b = _binding[2]
	local c = _binding[3]
end
-- luatuple + optional function call + array assignment pattern
do
	local a
	local b
	local c
	local _result = returnsLuaTuple
	if _result ~= nil then
		_result = { _result() }
	end
	local _binding = _result
	a = _binding[1]
	b = _binding[2]
	c = _binding[3]
end
```