### PR TITLE
Optimize binding pattern emit for variable creation

### DIFF
--- a/src/TSTransformer/nodes/statements/transformVariableStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformVariableStatement.ts
@@ -156,7 +156,14 @@ export function transformVariableDeclaration(
 			luau.list.pushList(
 				statements,
 				state.capturePrereqs(() =>
-					transformObjectBindingPattern(state, name, state.pushToVarIfNonId(value!, "binding")),
+					transformObjectBindingPattern(
+						state,
+						name,
+						// initializers could contain assignment expressions that can cause conflict
+						luau.isAnyIdentifier(value!) && name.elements.every(element => !element.initializer)
+							? value
+							: state.pushToVar(value, "binding"),
+					),
 				),
 			);
 		}

--- a/src/TSTransformer/nodes/statements/transformVariableStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformVariableStatement.ts
@@ -148,7 +148,7 @@ export function transformVariableDeclaration(
 				luau.list.pushList(
 					statements,
 					state.capturePrereqs(() =>
-						transformArrayBindingPattern(state, name, state.pushToVar(value, "binding")),
+						transformArrayBindingPattern(state, name, state.pushToVarIfNonId(value!, "binding")),
 					),
 				);
 			}
@@ -156,7 +156,7 @@ export function transformVariableDeclaration(
 			luau.list.pushList(
 				statements,
 				state.capturePrereqs(() =>
-					transformObjectBindingPattern(state, name, state.pushToVar(value, "binding")),
+					transformObjectBindingPattern(state, name, state.pushToVarIfNonId(value!, "binding")),
 				),
 			);
 		}

--- a/src/TSTransformer/nodes/statements/transformVariableStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformVariableStatement.ts
@@ -10,6 +10,7 @@ import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/tran
 import { transformInitializer } from "TSTransformer/nodes/transformInitializer";
 import { arrayBindingPatternContainsHoists } from "TSTransformer/util/arrayBindingPatternContainsHoists";
 import { arrayLikeExpressionContainsSpread } from "TSTransformer/util/arrayLikeExpressionContainsSpread";
+import { getTargetIdForBindingPattern } from "TSTransformer/util/binding/getTargetIdForBindingPattern";
 import { checkVariableHoist } from "TSTransformer/util/checkVariableHoist";
 import { isSymbolMutable } from "TSTransformer/util/isSymbolMutable";
 import { isLuaTupleType } from "TSTransformer/util/types";
@@ -148,7 +149,7 @@ export function transformVariableDeclaration(
 				luau.list.pushList(
 					statements,
 					state.capturePrereqs(() =>
-						transformArrayBindingPattern(state, name, state.pushToVarIfNonId(value!, "binding")),
+						transformArrayBindingPattern(state, name, getTargetIdForBindingPattern(state, name, value!)),
 					),
 				);
 			}
@@ -156,14 +157,7 @@ export function transformVariableDeclaration(
 			luau.list.pushList(
 				statements,
 				state.capturePrereqs(() =>
-					transformObjectBindingPattern(
-						state,
-						name,
-						// initializers could contain assignment expressions that can cause conflict
-						luau.isAnyIdentifier(value!) && name.elements.every(element => !element.initializer)
-							? value
-							: state.pushToVar(value, "binding"),
-					),
+					transformObjectBindingPattern(state, name, getTargetIdForBindingPattern(state, name, value!)),
 				),
 			);
 		}

--- a/src/TSTransformer/util/binding/getTargetIdForBindingPattern.ts
+++ b/src/TSTransformer/util/binding/getTargetIdForBindingPattern.ts
@@ -1,0 +1,14 @@
+import luau from "@roblox-ts/luau-ast";
+import { TransformState } from "TSTransformer/classes/TransformState";
+import ts from "typescript";
+
+/**
+ * Checks to see if the binding contains initializers and returns a new temporary identifier,
+ * since they could mutate the binding variable.
+ */
+export function getTargetIdForBindingPattern(state: TransformState, name: ts.BindingPattern, value: luau.Expression) {
+	return luau.isAnyIdentifier(value) &&
+		name.elements.every(element => ts.isOmittedExpression(element) || !element.initializer)
+		? value
+		: state.pushToVar(value, "binding");
+}

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -185,7 +185,7 @@ export = () => {
 		expect(z).to.equal(123);
 	});
 
-	it("should not keep variable changes inside binding elements", () => {
+	it("should not save variable changes made inside object binding elements", () => {
 		let notok = { foo: true, bar: false };
 		let ok = {
 			foo: undefined as boolean | undefined,
@@ -285,6 +285,16 @@ export = () => {
 		expect(obj.x).to.equal(1);
 		expect(obj.y).to.equal(2);
 		expect(obj.z).to.equal(3);
+	});
+
+	it("should not save variable changes made inside array binding elements", () => {
+		let notok = [false, true];
+		let ok = [undefined, false];
+		const [foo = (ok = notok), bar = ok[1]] = ok;
+
+		expect(ok[0]).to.equal(false);
+		expect(foo).to.equal(notok);
+		expect(bar).to.equal(false);
 	});
 
 	it("should support indexing a return value from a function", () => {

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -185,6 +185,19 @@ export = () => {
 		expect(z).to.equal(123);
 	});
 
+	it("should not keep variable changes inside binding elements", () => {
+		let notok = { foo: true, bar: false };
+		let ok = {
+			foo: undefined as boolean | undefined,
+			bar: true,
+		};
+		const { foo = (ok = notok).foo, bar } = ok;
+
+		expect(ok.foo).to.equal(true);
+		expect(foo).to.equal(true);
+		expect(bar).to.equal(true);
+	});
+
 	it("should not optimize array destructuring", () => {
 		function a() {
 			return [1, 2, 3];

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -288,13 +288,13 @@ export = () => {
 	});
 
 	it("should not save variable changes made inside array binding elements", () => {
-		let notok = [false, true];
-		let ok = [undefined, false];
-		const [foo = (ok = notok), bar = ok[1]] = ok;
+		let notok = [true, false];
+		let ok = [undefined, true];
+		const [foo = (ok = notok)[0], bar] = ok;
 
-		expect(ok[0]).to.equal(false);
-		expect(foo).to.equal(notok);
-		expect(bar).to.equal(false);
+		expect(ok[0]).to.equal(true);
+		expect(foo).to.equal(true);
+		expect(bar).to.equal(true);
 	});
 
 	it("should support indexing a return value from a function", () => {


### PR DESCRIPTION
Simple change. Using `pushToVarIfNonId` to reference the value from binding patterns eliminates the need of creating a new variable every time the value is indexed if it's already an ID.

Non-null assertions are used there because currently TypeScript doesn't remember the type narrowing changes you made before when using the variable inside a nested callback. See https://github.com/microsoft/TypeScript/issues/36436.

```ts
const omg = [1, 2, 3, 4, 5];
const [one, two] = omg;

const ok = { foo: true, bar: false };
const { foo, bar } = ok;
const { baz } = { baz: "hello" };
```

```luau
-- Checking to see if it's an id first
local omg = { 1, 2, 3, 4, 5 }
local one = omg[1]
local two = omg[2]
local ok = {
	foo = true,
	bar = false,
}
local foo = ok.foo
local bar = ok.bar
local _binding = {
	baz = "hello",
}
local baz = _binding.baz

-- Directly pushing to a new temp var (Current)
local omg = { 1, 2, 3, 4, 5 }
local _binding = omg
local one = _binding[1]
local two = _binding[2]
local ok = {
	foo = true,
	bar = false,
}
local _binding_1 = ok
local foo = _binding_1.foo
local bar = _binding_1.bar
local _binding_2 = {
	baz = "hello",
}
local baz = _binding_2.baz
```