### PR TITLE
Add diagnostic for unsupported for-of iteration types

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -156,6 +156,13 @@ export const errors = {
 	noAsyncGeneratorFunctions: error("Async generator functions are not supported!"),
 	noNonStringModuleSpecifier: error("Module specifiers must be a string literal."),
 	noIterableIteration: error("Iterating on Iterable<T> is not supported! You must use a more specific type."),
+	noUnsupportedForOfIteration: error(
+		"Cannot iterate over this type in for-of loop!",
+		"roblox-ts needs to know the specific type to generate the correct loop.",
+		suggestion(
+			"Add a type annotation to specify the iterable type (e.g., `Array<T>`, `Set<T>`, `Map<K, V>`, etc.).",
+		),
+	),
 	noMixedTypeCall: error(
 		"Attempted to call a function with mixed types! All definitions must either be a method or a callback.",
 	),

--- a/src/TSTransformer/nodes/statements/transformForOfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForOfStatement.ts
@@ -430,7 +430,8 @@ function getLoopBuilder(state: TransformState, node: ts.Node, type: ts.Type): Lo
 		DiagnosticService.addDiagnostic(errors.noMacroUnion(node));
 		return () => luau.list.make();
 	} else {
-		assert(false, `ForOf iteration type not implemented: ${state.typeChecker.typeToString(type)}`);
+		DiagnosticService.addDiagnostic(errors.noUnsupportedForOfIteration(node));
+		return () => luau.list.make();
 	}
 }
 

--- a/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
+++ b/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
@@ -1,6 +1,5 @@
 import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
-import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
@@ -372,6 +371,7 @@ export function getAddIterableToArrayBuilder(
 		DiagnosticService.addDiagnostic(errors.noMacroUnion(node));
 		return () => luau.list.make();
 	} else {
-		assert(false, `Iteration type not implemented: ${state.typeChecker.typeToString(type)}`);
+		DiagnosticService.addDiagnostic(errors.noUnsupportedForOfIteration(node));
+		return () => luau.list.make();
 	}
 }


### PR DESCRIPTION
Introduces a new error message for cases where a for-of loop attempts to iterate over an unsupported or ambiguous type. Users now get clear error messages instead of compiler crashes. (see #2371, #2840, #2907, #2924)

