### PR TITLE
Fix transformer order

### DIFF
--- a/src/Project/transformers/createTransformerList.ts
+++ b/src/Project/transformers/createTransformerList.ts
@@ -76,8 +76,8 @@ export function flattenIntoTransformers(
 ): Array<ts.TransformerFactory<ts.SourceFile | ts.Bundle>> {
 	const result: Array<ts.TransformerFactory<ts.SourceFile | ts.Bundle>> = [];
 	result.push(
-		...(transformers.after as Array<ts.TransformerFactory<ts.SourceFile | ts.Bundle>>),
 		...(transformers.before as Array<ts.TransformerFactory<ts.SourceFile | ts.Bundle>>),
+		...(transformers.after as Array<ts.TransformerFactory<ts.SourceFile | ts.Bundle>>),
 		...(transformers.afterDeclarations as Array<ts.TransformerFactory<ts.SourceFile | ts.Bundle>>),
 	);
 	return result;


### PR DESCRIPTION
References that imply flattenIntoTransformers has (...had!) an incorrect order:
https://github.com/roblox-ts/roblox-ts/blob/9165cde342a8b3a5c2748649e22df175636f8c29/src/Project/transformers/createTransformerList.ts#L112-L120
https://github.com/roblox-ts/roblox-ts/blob/9165cde342a8b3a5c2748649e22df175636f8c29/src/Project/transformers/createTransformerList.ts#L7-L11
https://github.com/microsoft/TypeScript/blob/5026c6675cbbfd493011616639595084f899d513/src/compiler/types.ts#L4977-L4984