### PR TITLE
fix(switch): cache switch expression to prevent multiple evaluation

### DIFF
--- a/src/TSTransformer/nodes/statements/transformSwitchStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformSwitchStatement.ts
@@ -110,7 +110,7 @@ function transformCaseClause(
 }
 
 export function transformSwitchStatement(state: TransformState, node: ts.SwitchStatement) {
-	const expression = state.pushToVarIfComplex(transformExpression(state, node.expression), "exp");
+	const expression = state.pushToVar(transformExpression(state, node.expression), "exp");
 	const fallThroughFlagId = luau.tempId("fallthrough");
 
 	let isFallThroughFlagNeeded = false;


### PR DESCRIPTION
## Problem

Switch statement evaluates the switch expression multiple times when case expressions have side effects.

```ts
let a = 1;
function increaseA() {
    a++;
    return 0;
}
switch (a) {
    case increaseA():  // evaluates `a` (1), then increaseA() modifies a to 2
        break;
    case 2:            // evaluates `a` again (now 2), matches!
        print("Should not print")  // but in TS this should NOT print
        break;
}
```

In TypeScript, `a` is evaluated once (value 1), so `1 == 0` is false and `1 == 2` is false. Nothing prints.

In roblox-ts, `a` is evaluated for each case clause because `pushToVarIfComplex` doesn't cache simple identifiers.

## Fix

Change `pushToVarIfComplex` to `pushToVar` to always cache the switch expression:

```diff
- const expression = state.pushToVarIfComplex(transformExpression(state, node.expression), "exp");
+ const expression = state.pushToVar(transformExpression(state, node.expression), "exp");
```

This ensures the switch expression is evaluated exactly once, matching TypeScript semantics.

Fixes #2900
