### PR TITLE
fix(switch): remove unnecessary parentheses for simple case expressions

### DIFF
--- a/src/TSTransformer/nodes/statements/transformSwitchStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformSwitchStatement.ts
@@ -14,7 +14,11 @@ function transformCaseClauseExpression(
 ) {
 	let [expression, prereqStatements] = state.capture(() => transformExpression(state, caseClauseExpression));
 
-	expression = luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression });
+	// Only wrap in parentheses if the expression is not simple (identifier, literal, etc.)
+	// This avoids unnecessary parentheses for enum values and simple comparisons
+	if (!luau.isSimple(expression)) {
+		expression = luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression });
+	}
 
 	let condition: luau.Expression = luau.binary(switchExpression, "==", expression);
 


### PR DESCRIPTION
## Problem

When using enums or simple values in switch cases, parentheses are always emitted even when not necessary. This is a remnant from #1304 which added parentheses for boolean expressions.

```ts
switch (i) {
    case MyEnum.Value:
        break;
}
```

Generates:
```luau
if i == (MyEnum.Value) then  -- unnecessary parentheses
```

## Fix

Only wrap case expressions in parentheses when they are not simple (identifiers, literals, etc.):

```diff
  let [expression, prereqStatements] = state.capture(() => transformExpression(state, caseClauseExpression));

- expression = luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression });
+ // Only wrap in parentheses if the expression is not simple (identifier, literal, etc.)
+ if (!luau.isSimple(expression)) {
+   expression = luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression });
+ }
```

Boolean expressions like `thing >= 0.75` are not simple, so they still get parentheses (preserving #1304 fix).

Fixes #2920
