### PR TITLE
Avoid repeated inheritance traversal in type predicates

### DIFF
--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -14,7 +14,7 @@ function isDefinitelyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): bool
 		return type.types.some(t => isDefinitelyTypeInner(t, callbacks));
 	} else {
 		// recursion already visits ancestors; flattening them here repeats entire inheritance chains
-		if (type.isClassOrInterface() && type.getBaseTypes()!.some(t => isDefinitelyTypeInner(t, callbacks))) {
+		if (type.isClassOrInterface() && type.getBaseTypes()?.some(t => isDefinitelyTypeInner(t, callbacks))) {
 			return true;
 		}
 		return callbacks.some(cb => cb(type));
@@ -29,7 +29,7 @@ function isPossiblyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): boolea
 	if (type.isUnionOrIntersection()) {
 		return type.types.some(t => isPossiblyTypeInner(t, callbacks));
 	} else {
-		if (type.isClassOrInterface() && type.getBaseTypes()!.some(t => isPossiblyTypeInner(t, callbacks))) {
+		if (type.isClassOrInterface() && type.getBaseTypes()?.some(t => isPossiblyTypeInner(t, callbacks))) {
 			return true;
 		}
 

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -14,7 +14,7 @@ function isDefinitelyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): bool
 		return type.types.some(t => isDefinitelyTypeInner(t, callbacks));
 	} else {
 		// recursion already visits ancestors; flattening them here repeats entire inheritance chains
-		if (type.isClassOrInterface() && type.getBaseTypes()?.some(t => isDefinitelyTypeInner(t, callbacks))) {
+		if (type.getBaseTypes()?.some(t => isDefinitelyTypeInner(t, callbacks))) {
 			return true;
 		}
 		return callbacks.some(cb => cb(type));
@@ -29,7 +29,7 @@ function isPossiblyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): boolea
 	if (type.isUnionOrIntersection()) {
 		return type.types.some(t => isPossiblyTypeInner(t, callbacks));
 	} else {
-		if (type.isClassOrInterface() && type.getBaseTypes()?.some(t => isPossiblyTypeInner(t, callbacks))) {
+		if (type.getBaseTypes()?.some(t => isPossiblyTypeInner(t, callbacks))) {
 			return true;
 		}
 

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -14,6 +14,7 @@ function isDefinitelyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): bool
 		return type.types.some(t => isDefinitelyTypeInner(t, callbacks));
 	} else {
 		// recursion already visits ancestors; flattening them here repeats entire inheritance chains
+		// getBaseTypes() checks isClassOrInterface() internally
 		if (type.getBaseTypes()?.some(t => isDefinitelyTypeInner(t, callbacks))) {
 			return true;
 		}
@@ -29,6 +30,7 @@ function isPossiblyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): boolea
 	if (type.isUnionOrIntersection()) {
 		return type.types.some(t => isPossiblyTypeInner(t, callbacks));
 	} else {
+		// getBaseTypes() checks isClassOrInterface() internally
 		if (type.getBaseTypes()?.some(t => isPossiblyTypeInner(t, callbacks))) {
 			return true;
 		}

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -13,7 +13,6 @@ function isDefinitelyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): bool
 	} else if (type.isIntersection()) {
 		return type.types.some(t => isDefinitelyTypeInner(t, callbacks));
 	} else {
-		// recursion already visits ancestors; flattening them here repeats entire inheritance chains
 		// getBaseTypes() checks isClassOrInterface() internally
 		if (type.getBaseTypes()?.some(t => isDefinitelyTypeInner(t, callbacks))) {
 			return true;

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -7,28 +7,14 @@ import { isTemplateLiteralType } from "TSTransformer/typeGuards";
 import ts from "typescript";
 type TypeCheck = (type: ts.Type) => boolean;
 
-function getRecursiveBaseTypesInner(result: Array<ts.Type>, type: ts.InterfaceType) {
-	for (const baseType of type.getBaseTypes() ?? []) {
-		result.push(baseType);
-		if (baseType.isClassOrInterface()) {
-			getRecursiveBaseTypesInner(result, baseType);
-		}
-	}
-}
-
-function getRecursiveBaseTypes(type: ts.InterfaceType) {
-	const result = new Array<ts.Type>();
-	getRecursiveBaseTypesInner(result, type);
-	return result;
-}
-
 function isDefinitelyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): boolean {
 	if (type.isUnion()) {
 		return type.types.every(t => isDefinitelyTypeInner(t, callbacks));
 	} else if (type.isIntersection()) {
 		return type.types.some(t => isDefinitelyTypeInner(t, callbacks));
 	} else {
-		if (type.isClassOrInterface() && getRecursiveBaseTypes(type).some(t => isDefinitelyTypeInner(t, callbacks))) {
+		// recursion already visits ancestors; flattening them here repeats entire inheritance chains
+		if (type.isClassOrInterface() && type.getBaseTypes()!.some(t => isDefinitelyTypeInner(t, callbacks))) {
 			return true;
 		}
 		return callbacks.some(cb => cb(type));
@@ -43,7 +29,7 @@ function isPossiblyTypeInner(type: ts.Type, callbacks: Array<TypeCheck>): boolea
 	if (type.isUnionOrIntersection()) {
 		return type.types.some(t => isPossiblyTypeInner(t, callbacks));
 	} else {
-		if (type.isClassOrInterface() && getRecursiveBaseTypes(type).some(t => isPossiblyTypeInner(t, callbacks))) {
+		if (type.isClassOrInterface() && type.getBaseTypes()!.some(t => isPossiblyTypeInner(t, callbacks))) {
 			return true;
 		}
 

--- a/tests/src/diagnostics/noAny.6.ts
+++ b/tests/src/diagnostics/noAny.6.ts
@@ -1,0 +1,6 @@
+interface Values extends ReadonlyArray<any> {}
+interface Derived extends Values {}
+
+function first(values: Derived) {
+	return values[0];
+}

--- a/tests/src/diagnostics/noRestSpreadingOfRobloxTypes.2.ts
+++ b/tests/src/diagnostics/noRestSpreadingOfRobloxTypes.2.ts
@@ -1,0 +1,7 @@
+interface Direction extends Vector3 {}
+interface Velocity extends Direction {}
+
+function copy(velocity: Velocity) {
+	const { ...rest } = velocity;
+	return rest;
+}

--- a/tests/src/tests/type.spec.ts
+++ b/tests/src/tests/type.spec.ts
@@ -1,4 +1,30 @@
 export = () => {
+	it("should preserve array behavior through inherited interfaces and generic constraints", () => {
+		interface Values extends ReadonlyArray<number> {}
+		interface Left extends Values {}
+		interface Right extends Values {}
+		interface Combined extends Left, Right {}
+		interface Derived extends Combined {}
+
+		function sum<T extends Derived>(values: T) {
+			let total = 0;
+			for (const value of values) {
+				total += value;
+			}
+			return total;
+		}
+
+		function first(values: Derived | undefined) {
+			return values?.[0];
+		}
+
+		const values: Derived = [2, 3, 5];
+		expect(sum(values)).to.equal(10);
+		expect(first(values)).to.equal(2);
+		expect(first(undefined)).to.equal(undefined);
+		expect([...values][2]).to.equal(5);
+	});
+
 	it("should properly fetch types with parenthesis and nonNull assertions", () => {
 		function loop(array?: Array<number>) {
 			let i = 0;

--- a/tests/src/tests/type.spec.ts
+++ b/tests/src/tests/type.spec.ts
@@ -25,6 +25,17 @@ export = () => {
 		expect([...values][2]).to.equal(5);
 	});
 
+	it("should preserve numeric keys when indexing object types", () => {
+		function read(values: { [index: number]: number }, index: number) {
+			return values[index];
+		}
+
+		const values = { 0: 2, 1: 3, 2: 5 };
+		expect(read(values, 0)).to.equal(2);
+		expect(read(values, 1)).to.equal(3);
+		expect(read(values, 2)).to.equal(5);
+	});
+
 	it("should properly fetch types with parenthesis and nonNull assertions", () => {
 		function loop(array?: Array<number>) {
 			let i = 0;


### PR DESCRIPTION
`isDefinitelyType` and `isPossiblyType` flatten every ancestor and then recursively inspect each flattened type, repeatedly walking the same inheritance chains.

Visit direct base types recursively instead. This removes the intermediate arrays and two helpers without changing the predicate rules.

Adds source-level regressions for array behavior through generic constraints and diamond inheritance, numeric object indexing, inherited `any[]`, and rest destructuring of inherited Roblox types. The runtime and diagnostic suites and lint pass. All 217 emitted daring-descent files are byte-for-byte unchanged from master.

Changed-line and changed-branch coverage are both 100%, using source-level tests. `getBaseTypes()` already checks whether the type is a class or interface, so optional chaining handles other types without a redundant guard or non-null assertion.
