### PR TITLE
Add shared compiler emit snapshot tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,11 +50,22 @@ It is not necessary to run the "devlink" script again.
 
 **roblox-ts** keeps a suite of automated unit tests inside of `/tests`.
 
-Effectively, this folder is a tiny **roblox-ts** game. Testing process is as follows:
+The tests run in two environments:
 
-1. Compile tests project to create a `/tests/out` folder containing `.lua` files
-2. Use `rojo build` to create `/tests/test.rbxl`
-3. Use `lune` to execute the tests
+- `tests/compiler/` contains Node/Jest tests for compiler behavior and exact Luau output.
+  Expected output is stored in Jest's `__snapshots__/` directories.
+- `tests/src/` is a tiny **roblox-ts** game containing runtime tests, diagnostic cases,
+  and supporting fixtures. It has a separate TypeScript configuration from the Node tests.
+
+Prefer source-level runtime tests for behavior and diagnostic tests for invalid source.
+Use emit snapshots to verify output quality that runtime assertions cannot observe,
+such as unnecessary temporary variables. Avoid testing transformer internals in isolation.
+
+The testing process is as follows:
+
+1. Run Jest to check compiler behavior, verify snapshots, and compile the Roblox test project into `tests/out`
+2. Use `rojo build` to create `tests/test.rbxl`
+3. Use `lune` to execute the runtime tests
 
 You can run this process yourself if you have [rokit](https://github.com/rojo-rbx/rokit) installed.
 
@@ -64,3 +75,7 @@ rokit install
 # Compile tests, build .rbxl, run with lune
 npm test
 ```
+
+After building the compiler, you can also run just the Jest tests with `npm run test-compile`.
+For an intentional emit change, update snapshots with `npm run test-compile -- --updateSnapshot`
+and review the resulting diff before committing.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,7 +15,12 @@ export default defineConfig(
 			parserOptions: {
 				ecmaVersion: "latest",
 				sourceType: "module",
-				project: ["./tsconfig.json", "./tsconfig.eslint.json", "./src/*/tsconfig.json"],
+				project: [
+					"./tsconfig.json",
+					"./tsconfig.eslint.json",
+					"./src/*/tsconfig.json",
+					"./tests/compiler/tsconfig.json",
+				],
 				ecmaFeatures: { jsx: true },
 			},
 		},
@@ -59,6 +64,22 @@ export default defineConfig(
 		},
 	},
 	{
-		ignores: ["node_modules/", "tests/", "out/", "coverage/", "devlink/", "jest.config.ts"],
+		files: ["tests/compiler/**/*.ts"],
+		rules: {
+			"no-restricted-imports": "off",
+		},
+	},
+	{
+		ignores: [
+			"node_modules/",
+			"tests/src/",
+			"tests/out/",
+			"tests/include/",
+			"tests/node_modules/",
+			"out/",
+			"coverage/",
+			"devlink/",
+			"jest.config.ts",
+		],
 	},
 );

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from "jest";
 const config: Config = {
 	preset: "ts-jest",
 	testEnvironment: "node",
-	testRegex: "/src/CLI/test\\.ts$",
+	testMatch: ["<rootDir>/tests/compiler/**/*.test.ts"],
 	modulePathIgnorePatterns: ["<rootDir>/out/"],
 	moduleNameMapper: {
 		"^(Project|Shared|CLI|TSTransformer)/(.*)$": "<rootDir>/src/$1/$2",
@@ -22,7 +22,7 @@ const config: Config = {
 	coverageReporters: ["lcov", "text"],
 	verbose: true,
 	transform: {
-		"^.+\\.tsx?$": ["ts-jest", { tsconfig: "src/CLI/tsconfig.json" }],
+		"^.+\\.tsx?$": ["ts-jest", { tsconfig: "tests/compiler/tsconfig.json" }],
 	},
 };
 

--- a/tests/compiler/__snapshots__/emit.test.ts.snap
+++ b/tests/compiler/__snapshots__/emit.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`emits a module export 1`] = `
+"local message = "hello"
+return {
+	message = message,
+}
+"
+`;

--- a/tests/compiler/compile.test.ts
+++ b/tests/compiler/compile.test.ts
@@ -1,5 +1,3 @@
-/// <reference types="jest" />
-
 import fs from "fs-extra";
 import path from "path";
 import { compileFiles } from "Project/functions/compileFiles";

--- a/tests/compiler/createTestProject.ts
+++ b/tests/compiler/createTestProject.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { VirtualProject } from "Project/classes/VirtualProject";
 import { PACKAGE_ROOT } from "Shared/constants";
 
-/** Creates an isolated compiler project with the test suite's Roblox type declarations. */
+// creates an isolated compiler project with the test suite's Roblox type declarations
 export function createTestProject() {
 	const project = new VirtualProject();
 	const root = path.join(PACKAGE_ROOT, "tests/node_modules/@rbxts");

--- a/tests/compiler/createTestProject.ts
+++ b/tests/compiler/createTestProject.ts
@@ -1,0 +1,26 @@
+import fs from "fs-extra";
+import path from "path";
+import { VirtualProject } from "Project/classes/VirtualProject";
+import { PACKAGE_ROOT } from "Shared/constants";
+
+/** Creates an isolated compiler project with the test suite's Roblox type declarations. */
+export function createTestProject() {
+	const project = new VirtualProject();
+	const root = path.join(PACKAGE_ROOT, "tests/node_modules/@rbxts");
+	function load(directory: string) {
+		for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+			const file = path.join(directory, entry.name);
+			if (entry.isDirectory()) {
+				load(file);
+			} else if (entry.name.endsWith(".d.ts") || entry.name === "package.json") {
+				project.vfs.writeFile(
+					`/node_modules/@rbxts/${path.relative(root, file).split(path.sep).join("/")}`,
+					fs.readFileSync(file, "utf8"),
+				);
+			}
+		}
+	}
+	load(path.join(root, "compiler-types"));
+	load(path.join(root, "types"));
+	return project;
+}

--- a/tests/compiler/emit.test.ts
+++ b/tests/compiler/emit.test.ts
@@ -1,3 +1,4 @@
+// keep tests alphabetized by name to match Jest's snapshot ordering
 import { createTestProject } from "./createTestProject";
 
 it("emits a module export", () => {

--- a/tests/compiler/emit.test.ts
+++ b/tests/compiler/emit.test.ts
@@ -1,0 +1,7 @@
+import { createTestProject } from "./createTestProject";
+
+it("emits a module export", () => {
+	const project = createTestProject();
+	const output = project.compileSource('export const message = "hello";');
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});

--- a/tests/compiler/tsconfig.json
+++ b/tests/compiler/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig-base.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": true,
+		"rootDir": "../..",
+		"types": ["node", "jest", "ts-expose-internals"]
+	},
+	"include": ["**/*.ts"]
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"include": ["src"],
 	"compilerOptions": {
 		// required
 		"allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Extracts the shared compiler snapshot-test setup from #3028 so emit regressions can be covered independently of the macro optimization changes.

Moves Node/Jest tests into `tests/compiler/`, separates their TypeScript configuration from the Roblox test project, and adds a reusable `VirtualProject` setup that loads the test suite's Roblox declarations. A module-export snapshot exercises the setup, and the contribution guide explains when to use snapshots and how to update them.

Validated against the published `@roblox-ts/luau-ast@2.0.0`: build and lint pass, 138 compiler tests and 1 snapshot pass in CI mode, and all 485 Lune runtime tests pass.
