### PR TITLE
Remove redundant virtual project state

### DIFF
--- a/src/Project/classes/VirtualFileSystem.ts
+++ b/src/Project/classes/VirtualFileSystem.ts
@@ -2,12 +2,10 @@ import { assert } from "Shared/util/assert";
 import { getOrSetDefault } from "Shared/util/getOrSetDefault";
 
 interface VirtualFile {
-	name: string;
 	content: string;
 }
 
 interface VirtualDirectory {
-	name: string;
 	children: Map<string, VirtualDirectory | VirtualFile>;
 }
 
@@ -29,7 +27,6 @@ export class VirtualFileSystem {
 
 	constructor() {
 		this.root = {
-			name: "",
 			children: new Map(),
 		};
 	}
@@ -45,7 +42,6 @@ export class VirtualFileSystem {
 		let currentDir = this.root;
 		for (const name of pathParts) {
 			const child = getOrSetDefault(currentDir.children, name, () => ({
-				name,
 				children: new Map(),
 			}));
 			assert("children" in child);
@@ -53,7 +49,6 @@ export class VirtualFileSystem {
 		}
 
 		currentDir.children.set(fileName, {
-			name: fileName,
 			content,
 		});
 	}

--- a/src/Project/classes/VirtualProject.ts
+++ b/src/Project/classes/VirtualProject.ts
@@ -33,7 +33,6 @@ export class VirtualProject {
 	private readonly compilerHost: ts.CompilerHost;
 
 	private program: ts.Program | undefined;
-	private typeChecker: ts.TypeChecker | undefined;
 	private nodeModulesPathMapping = new Map<string, string>();
 
 	constructor() {
@@ -105,11 +104,11 @@ export class VirtualProject {
 
 		const rootNames = this.vfs
 			.getFilePaths()
-			.filter(v => v.endsWith(ts.Extension.Ts) || v.endsWith(ts.Extension.Tsx) || v.endsWith(ts.Extension.Dts));
+			.filter(v => v.endsWith(ts.Extension.Ts) || v.endsWith(ts.Extension.Tsx));
 		this.program = ts.createProgram(rootNames, this.compilerOptions, this.compilerHost, this.program);
-		this.typeChecker = this.program.getTypeChecker();
+		const typeChecker = this.program.getTypeChecker();
 
-		const services = createTransformServices(this.typeChecker);
+		const services = createTransformServices(typeChecker);
 		const pathTranslator = new PathTranslator(ROOT_DIR, OUT_DIR, undefined, false, this.data.projectOptions.luau);
 
 		const sourceFile = this.program.getSourceFile(PLAYGROUND_PATH);
@@ -136,7 +135,7 @@ export class VirtualProject {
 			this.pkgRojoResolvers,
 			this.nodeModulesPathMapping,
 			runtimeLibRbxPath,
-			this.typeChecker,
+			typeChecker,
 			projectType,
 			sourceFile,
 		);


### PR DESCRIPTION
Remove unused name fields from VirtualFile and VirtualDirectory, where directory map keys already hold the names. Keep the type checker local to VirtualProject.compileSource() and remove the redundant .d.ts suffix check, since .d.ts paths already match .ts.

Validation: 137 compiler/diagnostic tests and 485 runtime tests passed with these changes; ESLint passed.
