### PR TITLE
Remove redundant capture around for-loop declarations

### DIFF
--- a/src/TSTransformer/nodes/statements/transformForStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForStatement.ts
@@ -143,15 +143,9 @@ function transformForStatementFallback(state: TransformState, node: ts.ForStatem
 			}
 
 			for (const declaration of initializer.declarations) {
-				const [decStatements, decPrereqs] = state.capture(() => {
-					const result = luau.list.make<luau.Statement>();
-					const [decStatements, decPrereqs] = state.capture(() =>
-						transformVariableDeclaration(state, declaration),
-					);
-					luau.list.pushList(result, decPrereqs);
-					luau.list.pushList(result, decStatements);
-					return result;
-				});
+				const [decStatements, decPrereqs] = state.capture(() =>
+					transformVariableDeclaration(state, declaration),
+				);
 				luau.list.pushList(result, decPrereqs);
 				luau.list.pushList(result, decStatements);
 			}


### PR DESCRIPTION
For-loop declarations were transformed inside two nested prerequisite captures. Remove the outer capture and intermediate list; append the captured prerequisites and declaration statements directly in the same order.

Validation: 137 compiler/diagnostic tests and 485 runtime tests passed with these changes; ESLint passed.
