### PR TITLE
Remove unused createTypeCheck helper

### DIFF
--- a/src/TSTransformer/util/createTypeCheck.ts
+++ b/src/TSTransformer/util/createTypeCheck.ts
@@ -1,5 +1,0 @@
-import luau from "@roblox-ts/luau-ast";
-
-export function createTypeCheck(expression: luau.Expression, typeName: luau.StringLiteral) {
-	return luau.binary(luau.call(luau.globals.type, [expression]), "==", typeName);
-}


### PR DESCRIPTION
Delete src/TSTransformer/util/createTypeCheck.ts. The helper has no callers or barrel exports; its deletion does not change emitted code.

Validation: 137 compiler/diagnostic tests and 485 runtime tests passed with these changes; ESLint passed.
