### PR TITLE
Share the single-value iterable spread emitter

### DIFF
--- a/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
+++ b/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
@@ -71,88 +71,58 @@ const addArray: AddIterableToArrayBuilder = (
 	return result;
 };
 
-const addString: AddIterableToArrayBuilder = (state, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
-	const result = luau.list.make<luau.Statement>();
+function createForLoopArrayBuilder(
+	valueName: string,
+	getLoopExpression: (expression: luau.Expression) => luau.Expression = expression => expression,
+): AddIterableToArrayBuilder {
+	return (state, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
+		const result = luau.list.make<luau.Statement>();
 
-	if (amtElementsSinceUpdate > 0) {
-		luau.list.push(
-			result,
-			luau.create(luau.SyntaxKind.Assignment, {
-				left: lengthId,
-				operator: "+=",
-				right: luau.number(amtElementsSinceUpdate),
-			}),
-		);
-	}
-
-	const valueId = luau.tempId("char");
-	luau.list.push(
-		result,
-		luau.create(luau.SyntaxKind.ForStatement, {
-			ids: luau.list.make(valueId),
-			expression: luau.call(luau.globals.string.gmatch, [expression, luau.globals.utf8.charpattern]),
-			statements: luau.list.make(
+		if (amtElementsSinceUpdate > 0) {
+			luau.list.push(
+				result,
 				luau.create(luau.SyntaxKind.Assignment, {
 					left: lengthId,
 					operator: "+=",
-					right: luau.number(1),
+					right: luau.number(amtElementsSinceUpdate),
 				}),
-				luau.create(luau.SyntaxKind.Assignment, {
-					left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-						expression: arrayId,
-						index: lengthId,
-					}),
-					operator: "=",
-					right: valueId,
-				}),
-			),
-		}),
-	);
+			);
+		}
 
-	return result;
-};
+		const valueId = luau.tempId(valueName);
 
-const addSet: AddIterableToArrayBuilder = (state, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
-	const result = luau.list.make<luau.Statement>();
-
-	if (amtElementsSinceUpdate > 0) {
 		luau.list.push(
 			result,
-			luau.create(luau.SyntaxKind.Assignment, {
-				left: lengthId,
-				operator: "+=",
-				right: luau.number(amtElementsSinceUpdate),
+			luau.create(luau.SyntaxKind.ForStatement, {
+				ids: luau.list.make(valueId),
+				expression: getLoopExpression(expression),
+				statements: luau.list.make(
+					luau.create(luau.SyntaxKind.Assignment, {
+						left: lengthId,
+						operator: "+=",
+						right: luau.number(1),
+					}),
+					luau.create(luau.SyntaxKind.Assignment, {
+						left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+							expression: arrayId,
+							index: lengthId,
+						}),
+						operator: "=",
+						right: valueId,
+					}),
+				),
 			}),
 		);
-	}
 
-	const valueId = luau.tempId("v");
+		return result;
+	};
+}
 
-	luau.list.push(
-		result,
-		luau.create(luau.SyntaxKind.ForStatement, {
-			ids: luau.list.make(valueId),
-			expression,
-			statements: luau.list.make(
-				luau.create(luau.SyntaxKind.Assignment, {
-					left: lengthId,
-					operator: "+=",
-					right: luau.number(1),
-				}),
-				luau.create(luau.SyntaxKind.Assignment, {
-					left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-						expression: arrayId,
-						index: lengthId,
-					}),
-					operator: "=",
-					right: valueId,
-				}),
-			),
-		}),
-	);
-
-	return result;
-};
+const addString = createForLoopArrayBuilder("char", expression =>
+	luau.call(luau.globals.string.gmatch, [expression, luau.globals.utf8.charpattern]),
+);
+const addSet = createForLoopArrayBuilder("v");
+const addIterableFunction = createForLoopArrayBuilder("result");
 
 const addMap: AddIterableToArrayBuilder = (state, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
 	const result = luau.list.make<luau.Statement>();
@@ -188,54 +158,6 @@ const addMap: AddIterableToArrayBuilder = (state, expression, arrayId, lengthId,
 					}),
 					operator: "=",
 					right: luau.array([keyId, valueId]),
-				}),
-			),
-		}),
-	);
-
-	return result;
-};
-
-const addIterableFunction: AddIterableToArrayBuilder = (
-	state,
-	expression,
-	arrayId,
-	lengthId,
-	amtElementsSinceUpdate,
-) => {
-	const result = luau.list.make<luau.Statement>();
-
-	if (amtElementsSinceUpdate > 0) {
-		luau.list.push(
-			result,
-			luau.create(luau.SyntaxKind.Assignment, {
-				left: lengthId,
-				operator: "+=",
-				right: luau.number(amtElementsSinceUpdate),
-			}),
-		);
-	}
-
-	const valueId = luau.tempId("result");
-
-	luau.list.push(
-		result,
-		luau.create(luau.SyntaxKind.ForStatement, {
-			ids: luau.list.make<luau.AnyIdentifier>(valueId),
-			expression,
-			statements: luau.list.make<luau.Statement>(
-				luau.create(luau.SyntaxKind.Assignment, {
-					left: lengthId,
-					operator: "+=",
-					right: luau.number(1),
-				}),
-				luau.create(luau.SyntaxKind.Assignment, {
-					left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-						expression: arrayId,
-						index: lengthId,
-					}),
-					operator: "=",
-					right: valueId,
 				}),
 			),
 		}),


### PR DESCRIPTION
String, Set, and single-value IterableFunction spreads emitted the same append loop through separate implementations. createForLoopArrayBuilder now creates the named addString, addSet, and addIterableFunction builders from a shared implementation. Strings adapt their loop expression through string.gmatch; sets and iterator functions use the expression directly. getAddIterableToArrayBuilder keeps its return addX pattern.

Tuple-returning iterators, maps, arrays, and generators retain their specialized paths. The factory accepts a valueName parameter, preserving the original temporary-name hints: char for strings, v for sets, and result for iterator functions.

Validation: 137 compiler/diagnostic tests and 485 runtime tests passed with these changes; ESLint passed.

Emit verification: all 47 emitted Luau test files match the master implementation byte-for-byte, including temporary names and collision suffixes.
