### PR TITLE
Add TypeScript 6.0.3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@
 
 Ready to dive in? [Check out the documentation.](https://roblox-ts.com/docs)
 
+### TypeScript 6.0 migration
+
+This branch uses TypeScript 6.0.3. Keep `"module": "commonjs"`, switch to
+`"moduleResolution": "bundler"`, and remove `downlevelIteration` entirely
+(setting it to `false` still produces a deprecation error). Remove `baseUrl`; if
+imports depend on it, replace it with explicit `paths` mappings relative to the
+tsconfig, for example `"paths": { "*": ["./src/*"] }` for `"baseUrl": "src"`.
+Update inherited configurations too.
+
+The companion `@rbxts/compiler-types` change is required: `Iterable`,
+`IterableIterator`, `AsyncIterable`, and `AsyncIterableIterator` must accept three
+type parameters. The published `3.0.0-types.0` package does not include this fix.
+Until it is available upstream, install a checkout containing the fix into each
+consumer project. With `compiler-types` beside this repository, prepare the test
+dependencies from the repository root with:
+
+```sh
+cd tests
+npm install
+npm install --no-save --package-lock=false --install-links ../../compiler-types
+cd ..
+```
+
+Reapply the local installation after `npm run update-test-types`, which installs
+the upstream compiler-types revision.
+
 ## Join the Community!
 
 https://discord.roblox-ts.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"fs-extra": "^11.3.0",
 				"kleur": "^4.1.5",
 				"resolve": "^1.22.10",
-				"typescript": "=5.9.3",
+				"typescript": "=6.0.3",
 				"yargs": "^18.0.0"
 			},
 			"bin": {
@@ -32,7 +32,7 @@
 				"@types/node": "^24.0.4",
 				"@types/prompts": "^2.4.9",
 				"@types/resolve": "^1.20.6",
-				"@types/ts-expose-internals": "npm:@roblox-ts/ts-expose-internals@=5.9.3",
+				"@types/ts-expose-internals": "npm:@roblox-ts/ts-expose-internals@=6.0.3",
 				"@types/yargs": "^17.0.33",
 				"eslint": "^9.39.4",
 				"eslint-config-prettier": "^10.1.5",
@@ -41,7 +41,7 @@
 				"jest": "^30.0.3",
 				"jiti": "^2.4.2",
 				"prettier": "^3.6.1",
-				"ts-jest": "^29.1.1",
+				"ts-jest": "^29.4.12",
 				"ts-node": "^10.9.1",
 				"ts-patch": "^3.3.0",
 				"typescript-eslint": "^8.61.1",
@@ -1827,9 +1827,9 @@
 		},
 		"node_modules/@types/ts-expose-internals": {
 			"name": "@roblox-ts/ts-expose-internals",
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/@roblox-ts/ts-expose-internals/-/ts-expose-internals-5.9.3.tgz",
-			"integrity": "sha512-4j5E2TeJfSY+qUtLdHwkY+nVpfX5kb3ClsCZktTrKqNXP6fhuQ0KYrxazfoetdW5ISWIHbCUcUmPafB+5pfNQQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@roblox-ts/ts-expose-internals/-/ts-expose-internals-6.0.3.tgz",
+			"integrity": "sha512-Y5iGqLS6ePNcZOFHyvGU0HfnR34gdY4gRzvtsfQlXnMzX+sUC9SO5iCLmfOwu10hJY4dKLAgn8LF7nGxUbarrg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2521,13 +2521,6 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
-		"node_modules/async": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/babel-jest": {
 			"version": "30.0.2",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.2.tgz",
@@ -3003,22 +2996,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/ejs": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-			"integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"jake": "^10.8.5"
-			},
-			"bin": {
-				"ejs": "bin/cli.js"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.169",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.169.tgz",
@@ -3437,39 +3414,6 @@
 				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/filelist": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"minimatch": "^5.0.1"
-			}
-		},
-		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3734,6 +3678,28 @@
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"license": "ISC"
+		},
+		"node_modules/handlebars": {
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -4026,25 +3992,6 @@
 			},
 			"optionalDependencies": {
 				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
-		"node_modules/jake": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-			"integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"async": "^3.2.3",
-				"chalk": "^4.0.2",
-				"filelist": "^1.0.4",
-				"minimatch": "^3.1.2"
-			},
-			"bin": {
-				"jake": "bin/cli.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/jest": {
@@ -5038,6 +4985,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5922,19 +5876,19 @@
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "29.4.0",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
-			"integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+			"version": "29.4.12",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+			"integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
-				"ejs": "^3.1.10",
 				"fast-json-stable-stringify": "^2.1.0",
+				"handlebars": "^4.7.9",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.7.2",
+				"semver": "^7.8.5",
 				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
@@ -5951,7 +5905,7 @@
 				"babel-jest": "^29.0.0 || ^30.0.0",
 				"jest": "^29.0.0 || ^30.0.0",
 				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <6"
+				"typescript": ">=4.3 <7"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -6103,9 +6057,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -6174,6 +6128,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/uglify-js": {
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -6311,6 +6279,13 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/wrap-ansi": {
 			"version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"fs-extra": "^11.3.0",
 		"kleur": "^4.1.5",
 		"resolve": "^1.22.10",
-		"typescript": "=5.9.3",
+		"typescript": "=6.0.3",
 		"yargs": "^18.0.0"
 	},
 	"devDependencies": {
@@ -46,7 +46,7 @@
 		"@types/node": "^24.0.4",
 		"@types/prompts": "^2.4.9",
 		"@types/resolve": "^1.20.6",
-		"@types/ts-expose-internals": "npm:@roblox-ts/ts-expose-internals@=5.9.3",
+		"@types/ts-expose-internals": "npm:@roblox-ts/ts-expose-internals@=6.0.3",
 		"@types/yargs": "^17.0.33",
 		"eslint": "^9.39.4",
 		"eslint-config-prettier": "^10.1.5",
@@ -59,7 +59,7 @@
 		"typescript-transform-paths": "^3.5.5",
 		"@types/jest": "^30.0.0",
 		"jest": "^30.0.3",
-		"ts-jest": "^29.1.1",
+		"ts-jest": "^29.4.12",
 		"ts-node": "^10.9.1"
 	},
 	"files": [

--- a/src/Project/classes/VirtualProject.ts
+++ b/src/Project/classes/VirtualProject.ts
@@ -53,12 +53,11 @@ export class VirtualProject {
 
 		this.compilerOptions = {
 			allowSyntheticDefaultImports: true,
-			downlevelIteration: true,
 			noLib: true,
 			strict: true,
 			target: ts.ScriptTarget.ESNext,
 			module: ts.ModuleKind.CommonJS,
-			moduleResolution: ts.ModuleResolutionKind.Node10,
+			moduleResolution: ts.ModuleResolutionKind.Bundler,
 			moduleDetection: ts.ModuleDetectionKind.Force,
 			typeRoots: [RBXTS_SCOPE_PATH],
 			resolveJsonModule: true,

--- a/src/Project/functions/validateCompilerOptions.ts
+++ b/src/Project/functions/validateCompilerOptions.ts
@@ -9,6 +9,7 @@ const ENFORCED_OPTIONS = {
 	target: ts.ScriptTarget.ESNext,
 	module: ts.ModuleKind.CommonJS,
 	moduleDetection: ts.ModuleDetectionKind.Force,
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- retain legacy configs using ignoreDeprecations
 	moduleResolution: ts.ModuleResolutionKind.Node10,
 	noLib: true,
 	strict: true,
@@ -54,8 +55,11 @@ export function validateCompilerOptions(opts: ts.CompilerOptions, projectPath: s
 		errors.push(`${y(`"moduleDetection"`)} must be ${y(`"force"`)}`);
 	}
 
-	if (opts.moduleResolution !== ENFORCED_OPTIONS.moduleResolution) {
-		errors.push(`${y(`"moduleResolution"`)} must be ${y(`"Node"`)}`);
+	if (
+		opts.moduleResolution !== ENFORCED_OPTIONS.moduleResolution &&
+		opts.moduleResolution !== ts.ModuleResolutionKind.Bundler
+	) {
+		errors.push(`${y(`"moduleResolution"`)} must be ${y(`"Bundler"`)} or ${y(`"Node"`)}`);
 	}
 
 	if (opts.allowSyntheticDefaultImports !== ENFORCED_OPTIONS.allowSyntheticDefaultImports) {

--- a/tests/compiler/__snapshots__/iteration.test.ts.snap
+++ b/tests/compiler/__snapshots__/iteration.test.ts.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`compiles map spread and iteration without downlevelIteration 1`] = `
+"local values = {
+	a = 1,
+}
+local _array = {}
+local _length = #_array
+for _k, _v in values do
+	_length += 1
+	_array[_length] = { _k, _v }
+end
+local copy = _array
+for _k, _v in values do
+	local value = { _k, _v }
+	print(value)
+end
+print(copy)
+return nil
+"
+`;
+
+exports[`compiles set spread and iteration without downlevelIteration 1`] = `
+"local values = {
+	[1] = true,
+	[2] = true,
+}
+local _array = {}
+local _length = #_array
+for _v in values do
+	_length += 1
+	_array[_length] = _v
+end
+local copy = _array
+for value in values do
+	print(value)
+end
+print(copy)
+return nil
+"
+`;
+
+exports[`compiles string spread and iteration without downlevelIteration 1`] = `
+"local values = "abc"
+local _array = {}
+local _length = #_array
+for _char in string.gmatch(values, utf8.charpattern) do
+	_length += 1
+	_array[_length] = _char
+end
+local copy = _array
+for value in string.gmatch(values, utf8.charpattern) do
+	print(value)
+end
+print(copy)
+return nil
+"
+`;

--- a/tests/compiler/compilerOptions.test.ts
+++ b/tests/compiler/compilerOptions.test.ts
@@ -1,0 +1,36 @@
+import path from "path";
+import { validateCompilerOptions } from "Project/functions/validateCompilerOptions";
+import { PACKAGE_ROOT } from "Shared/constants";
+import { ProjectError } from "Shared/errors/ProjectError";
+import ts from "typescript";
+
+const projectPath = path.join(PACKAGE_ROOT, "tests");
+const options: ts.CompilerOptions = {
+	allowSyntheticDefaultImports: true,
+	moduleDetection: ts.ModuleDetectionKind.Force,
+	noLib: true,
+	outDir: path.join(projectPath, "out"),
+	rootDir: path.join(projectPath, "src"),
+	strict: true,
+	target: ts.ScriptTarget.ESNext,
+	typeRoots: [path.join(projectPath, "node_modules/@rbxts")],
+};
+
+it.each([
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- cover legacy configs using ignoreDeprecations
+	["CommonJS/Node", ts.ModuleKind.CommonJS, ts.ModuleResolutionKind.Node10],
+	["CommonJS/Bundler", ts.ModuleKind.CommonJS, ts.ModuleResolutionKind.Bundler],
+])("accepts %s", (name, module, moduleResolution) => {
+	expect(() => validateCompilerOptions({ ...options, module, moduleResolution }, projectPath)).not.toThrow();
+});
+
+it.each([
+	["CommonJS/NodeNext", ts.ModuleKind.CommonJS, ts.ModuleResolutionKind.NodeNext],
+	["Preserve/Bundler", ts.ModuleKind.Preserve, ts.ModuleResolutionKind.Bundler],
+	// eslint-disable-next-line @typescript-eslint/no-deprecated -- reject an invalid legacy resolution combination
+	["Preserve/Node", ts.ModuleKind.Preserve, ts.ModuleResolutionKind.Node10],
+	["NodeNext", ts.ModuleKind.NodeNext, ts.ModuleResolutionKind.NodeNext],
+	["ESNext/Bundler", ts.ModuleKind.ESNext, ts.ModuleResolutionKind.Bundler],
+])("rejects %s", (name, module, moduleResolution) => {
+	expect(() => validateCompilerOptions({ ...options, module, moduleResolution }, projectPath)).toThrow(ProjectError);
+});

--- a/tests/compiler/iteration.test.ts
+++ b/tests/compiler/iteration.test.ts
@@ -1,0 +1,18 @@
+import { createTestProject } from "./createTestProject";
+
+it.each([
+	["map", 'new Map([["a", 1]])'],
+	["set", "new Set([1, 2])"],
+	["string", '"abc"'],
+])("compiles %s spread and iteration without downlevelIteration", (name, expression) => {
+	const project = createTestProject();
+	const output = project.compileSource(`
+		const values = ${expression};
+		const copy = [...values];
+		for (const value of values) {
+			print(value);
+		}
+		print(copy);
+	`);
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});

--- a/tests/src/tests/type.spec.ts
+++ b/tests/src/tests/type.spec.ts
@@ -1,4 +1,21 @@
 export = () => {
+	it("should infer method callbacks that do not use this", () => {
+		function callIt<T>(callbacks: { consume(value: T): T; produce(value: number): T }): T {
+			return callbacks.consume(callbacks.produce(42));
+		}
+
+		const result = callIt({
+			consume(value) {
+				return value + 1;
+			},
+			produce(value: number) {
+				return value;
+			},
+		});
+
+		expect(result).to.equal(43);
+	});
+
 	it("should preserve array behavior through inherited interfaces and generic constraints", () => {
 		interface Values extends ReadonlyArray<number> {}
 		interface Left extends Values {}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,11 +3,10 @@
 	"compilerOptions": {
 		// required
 		"allowSyntheticDefaultImports": true,
-		"downlevelIteration": true,
 		"jsx": "react",
 		"jsxFactory": "Roact.jsx",
 		"module": "commonjs",
-		"moduleResolution": "Node",
+		"moduleResolution": "bundler",
 		"noLib": true,
 		"resolveJsonModule": true,
 		"forceConsistentCasingInFileNames": true,
@@ -20,6 +19,8 @@
 		// configurable
 		"rootDir": "src",
 		"outDir": "out",
-		"baseUrl": "src"
+		"paths": {
+			"*": ["./src/*"]
+		}
 	}
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"declaration": true,
 		"module": "commonjs",
+		"moduleResolution": "bundler",
 		"target": "ES2019",
 		"lib": ["ES2019"],
 		"strict": true,
@@ -13,9 +14,9 @@
 		"composite": true,
 		"sourceMap": true,
 		"outDir": "out",
-		"baseUrl": "src",
+		"types": ["node", "ts-expose-internals"],
 		"paths": {
-			"*": ["*"]
+			"*": ["./src/*"]
 		},
 		"plugins": [
 			{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
 	"files": [],
 	"compilerOptions": {
 		"composite": true,
-		"baseUrl": "src",
 		"outDir": "out"
 	},
 	"references": [


### PR DESCRIPTION
Upgrade roblox-ts to TypeScript 6.0.3 with the matching npm:@roblox-ts/ts-expose-internals@=6.0.3 declarations. Keep CommonJS, migrate deprecated compiler options to Bundler resolution and explicit paths, and update ts-jest for TypeScript 6 compatibility.

Add regressions for iterable spreads, accepted compiler options, and method inference, plus downstream migration instructions.

Depends on https://github.com/roblox-ts/compiler-types/pull/531. Kept draft until the companion iterator declarations are available upstream; local validation used that fix installed into the test project.

Generated with Codex.
