### PR TITLE
Avoid temporaries for enum switch cases

### DIFF
--- a/src/TSTransformer/util/expressionMightMutate.ts
+++ b/src/TSTransformer/util/expressionMightMutate.ts
@@ -4,6 +4,22 @@ import { isSymbolMutable } from "TSTransformer/util/isSymbolMutable";
 import { skipDownwards } from "TSTransformer/util/traversal";
 import ts from "typescript";
 
+function isEnumMemberAccess(state: TransformState, node: ts.Expression) {
+	if (!ts.isPropertyAccessExpression(node) && !ts.isElementAccessExpression(node)) {
+		return false;
+	}
+
+	const memberNode = ts.isPropertyAccessExpression(node) ? node.name : node.argumentExpression;
+	const memberSymbol = state.typeChecker.getSymbolAtLocation(memberNode);
+	const enumSymbol = state.typeChecker.getSymbolAtLocation(skipDownwards(node.expression));
+	return (
+		memberSymbol !== undefined &&
+		(memberSymbol.flags & ts.SymbolFlags.EnumMember) !== 0 &&
+		enumSymbol !== undefined &&
+		(ts.skipAlias(enumSymbol, state.typeChecker).flags & ts.SymbolFlags.Enum) !== 0
+	);
+}
+
 export function expressionMightMutate(
 	state: TransformState,
 	expression: luau.Expression,
@@ -41,7 +57,9 @@ export function expressionMightMutate(
 	} else {
 		if (node) {
 			node = skipDownwards(node);
-			if (ts.isIdentifier(node)) {
+			if (isEnumMemberAccess(state, node)) {
+				return false;
+			} else if (ts.isIdentifier(node)) {
 				const symbol = state.typeChecker.getSymbolAtLocation(node);
 				if (symbol && !isSymbolMutable(state, symbol)) {
 					return false;

--- a/tests/compiler/__snapshots__/switch.test.ts.snap
+++ b/tests/compiler/__snapshots__/switch.test.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`emits enum case values directly 1`] = `
+"local Kind = {
+	A = "A",
+	B = "B",
+}
+local function handle(value, enumAlias)
+	local _exp = value
+	repeat
+		if _exp == "missing" then
+			break
+		end
+		if _exp == Kind.A then
+			break
+		end
+		if _exp == Kind.B then
+			break
+		end
+		local _caseValue = enumAlias.B
+		if _exp == _caseValue then
+			break
+		end
+	until true
+end
+return nil
+"
+`;

--- a/tests/compiler/switch.test.ts
+++ b/tests/compiler/switch.test.ts
@@ -1,0 +1,24 @@
+import { createTestProject } from "./createTestProject";
+
+it("emits enum case values directly", () => {
+	const project = createTestProject();
+	const output = project.compileSource(`
+		enum Kind {
+			A = "A",
+			B = "B",
+		}
+		function handle(value: Kind | "missing", enumAlias: typeof Kind) {
+			switch (value) {
+				case "missing":
+					break;
+				case Kind.A:
+					break;
+				case Kind["B"]:
+					break;
+				case enumAlias.B:
+					break;
+			}
+		}
+	`);
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});


### PR DESCRIPTION
- Treat direct enum member accesses as stable when both the receiver and selected member resolve to enum symbols.
- Keep potentially mutable aliases and ordinary property accesses on the existing captured-value path.
- Add exact emit coverage for dot and bracket enum access.

```diff
-local _caseValue = Kind.A
-if _exp == _caseValue then
+if _exp == Kind.A then
```

Fixes #2920
