### PR TITLE
fix: for-of over iterable function luatuple with variadic elements

### DIFF
--- a/src/TSTransformer/nodes/statements/transformForOfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForOfStatement.ts
@@ -309,7 +309,7 @@ const buildIterableFunctionLuaTupleLoop: (type: ts.Type) => LoopBuilder =
 		if (
 			ts.isVariableDeclarationList(initializer) &&
 			state.typeChecker.isTupleType(tupleArgType) &&
-			!((tupleArgType as ts.TupleTypeReference).target.combinedFlags & ts.ElementFlags.Rest)
+			!((tupleArgType as ts.TupleTypeReference).target.combinedFlags & ts.ElementFlags.Variable)
 		) {
 			const tupleType = (tupleArgType as ts.TupleTypeReference).target;
 			for (let i = 0; i < tupleType.elementFlags.length; i++) {

--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -495,6 +495,52 @@ export = () => {
 		}
 	});
 
+	it("should support iterator function with rest tuple elements when indexing as array", () => {
+		let callCount = 0;
+		const restIterator: IterableFunction<LuaTuple<[number, ...number[]]>> = (() => {
+			callCount++;
+			if (callCount === 1) {
+				return [10, 20, 30] as unknown as LuaTuple<[number, ...number[]]>;
+			}
+			return undefined as unknown as LuaTuple<[number, ...number[]]>;
+		}) as never;
+
+		for (const tuple of restIterator) {
+			expect(tuple.size()).to.equal(3);
+			expect(tuple[0]).to.equal(10);
+			expect(tuple[1]).to.equal(20);
+			expect(tuple[2]).to.equal(30);
+			break;
+		}
+	});
+
+	it("should support iterator function with variadic tuple elements when indexing as array", () => {
+		function collectFirst<T extends unknown[]>(
+			iter: IterableFunction<LuaTuple<[number, ...T]>>,
+		): Array<unknown> | undefined {
+			for (const entry of iter) {
+				return entry as unknown as Array<unknown>;
+			}
+			return undefined;
+		}
+
+		let callCount = 0;
+		const iter: IterableFunction<LuaTuple<[number, number, number]>> = (() => {
+			callCount++;
+			if (callCount === 1) {
+				return [10, 20, 30] as LuaTuple<[number, number, number]>;
+			}
+			return undefined as unknown as LuaTuple<[number, number, number]>;
+		}) as never;
+
+		const result = collectFirst<[number, number]>(iter);
+		expect(result).to.be.ok();
+		expect(result!.size()).to.equal(3);
+		expect(result![0]).to.equal(10);
+		expect(result![1]).to.equal(20);
+		expect(result![2]).to.equal(30);
+	});
+
 	it("should support the $range macro without step", () => {
 		const hit = new Set<number>();
 		let sum = 10;


### PR DESCRIPTION
## Problem

`for (const entry of iter)` over `IterableFunction<LuaTuple<T>>` uses a fixed-arity `for a, b in fn` fast path when the tuple has a known element count. The guard only rejected rest elements (`ElementFlags.Rest`), so a variadic spread such as `LuaTuple<[number, ...T]>` (`ElementFlags.Variadic`) slipped through. The loop then bound one Lua name per declared element and silently dropped the rest of the tuple.

```ts
function collectFirst<T extends unknown[]>(iter: IterableFunction<LuaTuple<[number, ...T]>>) {
	for (const entry of iter) {
		return entry; // emitted `for entry, _ in iter` -> entry is a number, not the tuple
	}
}
```

## Fix

Check `ElementFlags.Variable` (`Rest | Variadic`) instead, so both variable-length forms fall to the existing while-loop branch that packs the full tuple.

## Tests

Two runtime specs in `loop.spec.ts`: one for rest elements, one for variadic elements. The variadic spec fails before the fix (tuple size 2 instead of 3) and passes after. Full suite: 348 compile tests and 651 runtime tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
