### PR TITLE
refactor: make prerequisite collection explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ The main pipeline is TypeScript source → TypeScript AST/type checker → Luau 
 | `src/Project/classes/VirtualProject.ts`             | In-memory compilation used by the playground and compiler snapshots, backed by `VirtualFileSystem.ts`. Preserve this path alongside filesystem builds.                                                                             |
 | `src/Project/functions/setupProjectWatchProgram.ts` | Incremental builds and file lifecycle. Also inspect `createProgramFactory.ts` and `getChangedFilePaths.ts` for invalidation and dependent files.                                                                                   |
 | `src/TSTransformer/nodes/`                          | Syntax lowering. `transformSourceFile.ts` handles module wrapping; `expressions/transformExpression.ts` and `statements/transformStatement.ts` dispatch by syntax kind. Binding, class, and JSX transforms have their own folders. |
-| `src/TSTransformer/classes/`                        | `TransformState` owns per-file transformation context and prerequisite statements; `MultiTransformState` owns caches for one compilation; `MacroManager` binds macros to TypeScript symbols.                                       |
+| `src/TSTransformer/classes/`                        | `TransformState` owns per-file transformation context; `Prereqs` owns an explicit statement destination; `MultiTransformState` owns caches for one compilation; `MacroManager` binds macros to TypeScript symbols.                 |
 | `src/TSTransformer/macros/`                         | Identifier, constructor, call, and property-call macros. Array, map, set, string, and Roblox arithmetic methods are expanded here.                                                                                                 |
 | `src/TSTransformer/util/`                           | Shared lowering rules: evaluation order, type classification, truthiness, imports, assignments, tuples, and string conversion.                                                                                                     |
 | `src/Shared/`                                       | Options and defaults, diagnostic factories, errors, logging, and common utilities.                                                                                                                                                 |
@@ -109,10 +109,16 @@ For an engine-specific issue, verify the actual API and use an appropriate Roblo
 
 ## Compiler invariants and common traps
 
-- **Prerequisites and evaluation order:** `state.capture()` returns an expression and its prerequisite statements;
-  `state.prereq()` / `state.prereqList()` emit them into the enclosing capture. Keep prerequisites in the correct
-  branch, loop iteration, and source evaluation order. Start with `ensureTransformOrder.ts`, `transformWritable.ts`,
-  and `transformCallExpression.ts` when changing captures. Calls also pass through `transformOptionalChain.ts`.
+- **Prerequisites and evaluation order:** Pass an explicit `Prereqs` collector to transforms that emit caller
+  prerequisites. Create a separate `new Prereqs()` for each statement destination, then attach its `.statements`
+  to the appropriate branch, loop, or enclosing list. `prereqs.push()` / `prereqs.pushList()` append to that
+  collector. Pass the intended collector explicitly through callbacks instead of closing over an outer one.
+  Statement transforms return their complete statement lists, with any prerequisite collectors kept local.
+  Assemble final output in plain Luau lists; append each collector after its collection phase is complete,
+  since `luau.list.pushList()` consumes the appended list. Thin forwarding helpers may return `.statements` directly.
+  Keep prerequisites in the correct branch, loop iteration, and source evaluation order. Start with
+  `ensureTransformOrder.ts`, `transformWritable.ts`, and `transformCallExpression.ts` when changing destinations.
+  Calls also pass through `transformOptionalChain.ts`.
 - **Macro operands:** Macros can reorder, repeat, or discard inputs and invoke callbacks. Removing a temporary needs
   evidence that reads, writes, receiver rebinding, errors, conditional execution, and allocation identity remain
   correct. A simple identifier can still be mutable. Inspect both used-result and statement-only forms.

--- a/src/TSTransformer/classes/Prereqs.ts
+++ b/src/TSTransformer/classes/Prereqs.ts
@@ -1,0 +1,51 @@
+import luau from "@roblox-ts/luau-ast";
+import { valueToIdStr } from "TSTransformer/util/valueToIdStr";
+
+// each collector owns one destination for generated statements
+export class Prereqs {
+	public readonly statements = luau.list.make<luau.Statement>();
+
+	public push(statement: luau.Statement) {
+		luau.list.push(this.statements, statement);
+	}
+
+	public pushList(statements: luau.List<luau.Statement>) {
+		luau.list.pushList(this.statements, statements);
+	}
+
+	public unshift(statement: luau.Statement) {
+		luau.list.unshift(this.statements, statement);
+	}
+
+	public unshiftList(statements: luau.List<luau.Statement>) {
+		luau.list.unshiftList(this.statements, statements);
+	}
+
+	public pushToVar(expression: luau.Expression | undefined, name?: string) {
+		const temp = luau.tempId(name || (expression && valueToIdStr(expression)));
+		this.push(
+			luau.create(luau.SyntaxKind.VariableDeclaration, {
+				left: temp,
+				right: expression,
+			}),
+		);
+		return temp;
+	}
+
+	public pushToVarIfComplex<T extends luau.Expression>(
+		expression: T,
+		name?: string,
+	): Extract<T, luau.SimpleTypes> | luau.TemporaryIdentifier {
+		if (luau.isSimple(expression)) {
+			return expression as Extract<T, luau.SimpleTypes>;
+		}
+		return this.pushToVar(expression, name);
+	}
+
+	public pushToVarIfNonId<T extends luau.Expression>(expression: T, name?: string): luau.AnyIdentifier {
+		if (luau.isAnyIdentifier(expression)) {
+			return expression;
+		}
+		return this.pushToVar(expression, name);
+	}
+}

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -10,12 +10,12 @@ import { getCanonicalFileName } from "Shared/util/getCanonicalFileName";
 import { getOrSetDefault } from "Shared/util/getOrSetDefault";
 import { MultiTransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
 import { TransformServices, TryUses } from "TSTransformer/types";
 import { createGetService } from "TSTransformer/util/createGetService";
 import { propertyAccessExpressionChain } from "TSTransformer/util/expressionChain";
 import { getModuleAncestor, skipUpwards } from "TSTransformer/util/traversal";
-import { valueToIdStr } from "TSTransformer/util/valueToIdStr";
 import ts from "typescript";
 
 /**
@@ -97,42 +97,6 @@ export class TransformState {
 		this.tryUsesStack.pop();
 	}
 
-	public readonly prereqStatementsStack = new Array<luau.List<luau.Statement>>();
-
-	/**
-	 * Pushes a new prerequisite statement onto the list stack.
-	 * @param statement
-	 */
-	public prereq(statement: luau.Statement) {
-		luau.list.push(this.prereqStatementsStack[this.prereqStatementsStack.length - 1], statement);
-	}
-
-	/**
-	 * Pushes a new prerequisite list of statement onto the list stack.
-	 * @param statements
-	 */
-	public prereqList(statements: luau.List<luau.Statement>) {
-		luau.list.pushList(this.prereqStatementsStack[this.prereqStatementsStack.length - 1], statements);
-	}
-
-	/**
-	 * Creates and pushes a new list of `luau.Statement`s onto the prerequisite stack.
-	 */
-	public pushPrereqStatementsStack() {
-		const prereqStatements = luau.list.make<luau.Statement>();
-		this.prereqStatementsStack.push(prereqStatements);
-		return prereqStatements;
-	}
-
-	/**
-	 * Pops and returns the top item of the prerequisite stack.
-	 */
-	public popPrereqStatementsStack() {
-		const poppedValue = this.prereqStatementsStack.pop();
-		assert(poppedValue);
-		return poppedValue;
-	}
-
 	/**
 	 * Returns the leading comments of a `ts.Node` as an array of strings.
 	 * @param node
@@ -151,31 +115,6 @@ export class TransformState {
 				),
 			),
 		);
-	}
-
-	/**
-	 * Returns the prerequisite statements created by `callback`.
-	 */
-	public capturePrereqs(callback: () => void) {
-		this.pushPrereqStatementsStack();
-		callback();
-		return this.popPrereqStatementsStack();
-	}
-
-	/**
-	 * Returns the result and prerequisite statements created by `callback`.
-	 */
-	public capture<T>(callback: () => T): [value: T, prereqs: luau.List<luau.Statement>] {
-		let value!: T;
-		const prereqs = this.capturePrereqs(() => (value = callback()));
-		return [value, prereqs];
-	}
-
-	public noPrereqs(callback: () => luau.Expression) {
-		let expression!: luau.Expression;
-		const statements = this.capturePrereqs(() => (expression = callback()));
-		assert(luau.list.isEmpty(statements));
-		return expression;
 	}
 
 	public readonly hoistsByStatement = new Map<ts.Statement | ts.CaseClause, Array<ts.Identifier>>();
@@ -265,47 +204,6 @@ export class TransformState {
 		}
 	}
 
-	/**
-	 * Declares and defines a new Luau variable. Pushes that new variable to a new luau.TemporaryIdentifier.
-	 * Can also be used to initialise a new tempId without a value
-	 * @param expression
-	 */
-	public pushToVar(expression: luau.Expression | undefined, name?: string) {
-		const temp = luau.tempId(name || (expression && valueToIdStr(expression)));
-		this.prereq(
-			luau.create(luau.SyntaxKind.VariableDeclaration, {
-				left: temp,
-				right: expression,
-			}),
-		);
-		return temp;
-	}
-
-	/**
-	 * Uses `state.pushToVar(expression)` unless `luau.isSimple(expression)`
-	 * @param expression the expression to push
-	 */
-	public pushToVarIfComplex<T extends luau.Expression>(
-		expression: T,
-		name?: string,
-	): Extract<T, luau.SimpleTypes> | luau.TemporaryIdentifier {
-		if (luau.isSimple(expression)) {
-			return expression as Extract<T, luau.SimpleTypes>;
-		}
-		return this.pushToVar(expression, name);
-	}
-
-	/**
-	 * Uses `state.pushToVar(expression)` unless `luau.isAnyIdentifier(expression)`
-	 * @param expression the expression to push
-	 */
-	public pushToVarIfNonId<T extends luau.Expression>(expression: T, name?: string): luau.AnyIdentifier {
-		if (luau.isAnyIdentifier(expression)) {
-			return expression;
-		}
-		return this.pushToVar(expression, name);
-	}
-
 	public getModuleExports(moduleSymbol: ts.Symbol) {
 		return getOrSetDefault(this.multiTransformState.getModuleExportsCache, moduleSymbol, () =>
 			this.typeChecker.getExportsOfModule(moduleSymbol),
@@ -319,7 +217,10 @@ export class TransformState {
 				const originalSymbol = ts.skipAlias(exportSymbol, this.typeChecker);
 				const declaration = exportSymbol.getDeclarations()?.[0];
 				if (declaration && ts.isExportSpecifier(declaration)) {
-					aliasMap.set(originalSymbol, transformPropertyName(this, declaration.name));
+					const namePrereqs = new Prereqs();
+					const name = transformPropertyName(this, namePrereqs, declaration.name);
+					assert(luau.list.isEmpty(namePrereqs.statements));
+					aliasMap.set(originalSymbol, name);
 				} else {
 					aliasMap.set(originalSymbol, luau.string(exportSymbol.name));
 				}

--- a/src/TSTransformer/macros/callMacros.ts
+++ b/src/TSTransformer/macros/callMacros.ts
@@ -20,14 +20,14 @@ const PRIMITIVE_LUAU_TYPES = new Set([
 ]);
 
 export const CALL_MACROS: MacroList<CallMacro> = {
-	assert: (state, node, expression, args) => {
-		args[0] = createTruthinessChecks(state, args[0], node.arguments[0]);
+	assert: (state, prereqs, node, expression, args) => {
+		args[0] = createTruthinessChecks(state, prereqs, args[0], node.arguments[0]);
 		return luau.call(luau.globals.assert, args);
 	},
 
-	typeOf: (state, node, expression, args) => luau.call(luau.globals.typeof, args),
+	typeOf: (state, prereqs, node, expression, args) => luau.call(luau.globals.typeof, args),
 
-	typeIs: (state, node, expression, args) => {
+	typeIs: (state, prereqs, node, expression, args) => {
 		const [value, typeStr] = args;
 		const typeFunc =
 			luau.isStringLiteral(typeStr) && PRIMITIVE_LUAU_TYPES.has(typeStr.value)
@@ -36,24 +36,24 @@ export const CALL_MACROS: MacroList<CallMacro> = {
 		return luau.binary(luau.call(typeFunc, [value]), "==", typeStr);
 	},
 
-	classIs: (state, node, expression, args) => {
+	classIs: (state, prereqs, node, expression, args) => {
 		const [value, typeStr] = args;
 		return luau.binary(luau.property(convertToIndexableExpression(value), "ClassName"), "==", typeStr);
 	},
 
-	identity: (state, node, expression, args) => args[0],
+	identity: (state, prereqs, node, expression, args) => args[0],
 
-	$range: (state, node) => {
+	$range: (state, prereqs, node) => {
 		DiagnosticService.addDiagnostic(errors.noRangeMacroOutsideForOf(node.expression));
 		return luau.none();
 	},
 
-	$tuple: (state, node) => {
+	$tuple: (state, prereqs, node) => {
 		DiagnosticService.addDiagnostic(errors.noTupleMacroOutsideReturn(node));
 		return luau.none();
 	},
 
-	$getModuleTree: (state, node) => {
+	$getModuleTree: (state, prereqs, node) => {
 		const parts = getImportParts(state, node.getSourceFile(), node.arguments[0]);
 		// converts the flat array into { root, { "rest", "of", "path" } }
 		return luau.array([parts.shift()!, luau.array(parts)]);

--- a/src/TSTransformer/macros/constructorMacros.ts
+++ b/src/TSTransformer/macros/constructorMacros.ts
@@ -1,41 +1,42 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { ConstructorMacro, MacroList } from "TSTransformer/macros/types";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import ts from "typescript";
 
-function wrapWeak(state: TransformState, node: ts.NewExpression, macro: ConstructorMacro) {
+function wrapWeak(state: TransformState, prereqs: Prereqs, node: ts.NewExpression, macro: ConstructorMacro) {
 	return luau.call(luau.globals.setmetatable, [
-		macro(state, node),
+		macro(state, prereqs, node),
 		luau.map([[luau.strings.__mode, luau.strings.k]]),
 	]);
 }
 
-const ArrayConstructor: ConstructorMacro = (state, node) => {
+const ArrayConstructor: ConstructorMacro = (state, prereqs, node) => {
 	if (node.arguments && node.arguments.length > 0) {
-		const args = ensureTransformOrder(state, node.arguments);
+		const args = ensureTransformOrder(state, prereqs, node.arguments);
 		return luau.call(luau.globals.table.create, args);
 	}
 	return luau.array();
 };
 
-const SetConstructor: ConstructorMacro = (state, node) => {
+const SetConstructor: ConstructorMacro = (state, prereqs, node) => {
 	if (!node.arguments || node.arguments.length === 0) {
 		return luau.set();
 	}
 	const arg = node.arguments[0];
 	// spreads cause prereq array, which cannot be optimised like this
 	if (ts.isArrayLiteralExpression(arg) && !arg.elements.some(ts.isSpreadElement)) {
-		return luau.set(ensureTransformOrder(state, arg.elements));
+		return luau.set(ensureTransformOrder(state, prereqs, arg.elements));
 	} else {
-		const id = state.pushToVar(luau.set(), "set");
+		const id = prereqs.pushToVar(luau.set(), "set");
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make<luau.AnyIdentifier>(luau.tempId(), valueId),
-				expression: transformExpression(state, arg),
+				expression: transformExpression(state, prereqs, arg),
 				statements: luau.list.make(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
@@ -52,12 +53,12 @@ const SetConstructor: ConstructorMacro = (state, node) => {
 	}
 };
 
-const MapConstructor: ConstructorMacro = (state, node) => {
+const MapConstructor: ConstructorMacro = (state, prereqs, node) => {
 	if (!node.arguments || node.arguments.length === 0) {
 		return luau.map();
 	}
 	const arg = node.arguments[0];
-	const transformed = transformExpression(state, arg);
+	const transformed = transformExpression(state, prereqs, arg);
 	if (luau.isArray(transformed) && luau.list.every(transformed.members, member => luau.isArray(member))) {
 		const elements = luau.list.toArray(transformed.members).map(e => {
 			// non-null and type assertion because array will always have 2 members,
@@ -67,9 +68,9 @@ const MapConstructor: ConstructorMacro = (state, node) => {
 		});
 		return luau.map(elements);
 	} else {
-		const id = state.pushToVar(luau.map(), "map");
+		const id = prereqs.pushToVar(luau.map(), "map");
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make<luau.AnyIdentifier>(luau.tempId(), valueId),
 				expression: transformed,
@@ -99,8 +100,8 @@ export const CONSTRUCTOR_MACROS: MacroList<ConstructorMacro> = {
 	ArrayConstructor,
 	SetConstructor,
 	MapConstructor,
-	WeakSetConstructor: (state, node) => wrapWeak(state, node, SetConstructor),
-	WeakMapConstructor: (state, node) => wrapWeak(state, node, MapConstructor),
+	WeakSetConstructor: (state, prereqs, node) => wrapWeak(state, prereqs, node, SetConstructor),
+	WeakMapConstructor: (state, prereqs, node) => wrapWeak(state, prereqs, node, MapConstructor),
 	ReadonlyMapConstructor: MapConstructor,
 	ReadonlySetConstructor: SetConstructor,
 };

--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { MacroList, PropertyCallMacro } from "TSTransformer/macros/types";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
@@ -15,7 +16,7 @@ import {
 import ts from "typescript";
 
 function makeMathMethod(operator: luau.BinaryOperator): PropertyCallMacro {
-	return (state, node, expression, args) => {
+	return (state, prereqs, node, expression, args) => {
 		let rhs = args[0];
 		if (!luau.isSimple(rhs)) {
 			rhs = luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression: rhs });
@@ -43,13 +44,13 @@ function makeMathSet(...operators: Array<luau.BinaryOperator>) {
 }
 
 function makeStringCallback(strCallback: luau.PropertyAccessExpression): PropertyCallMacro {
-	return (state, node, expression, args) => {
+	return (state, prereqs, node, expression, args) => {
 		return luau.call(strCallback, [expression, ...args]);
 	};
 }
 
 const STRING_CALLBACKS: MacroList<PropertyCallMacro> = {
-	size: (state, node, expression) => luau.unary("#", expression),
+	size: (state, prereqs, node, expression) => luau.unary("#", expression),
 
 	byte: makeStringCallback(luau.globals.string.byte),
 	find: makeStringCallback(luau.globals.string.find),
@@ -73,15 +74,15 @@ function makeEveryOrSomeMethod(
 	) => Array<luau.Expression>,
 	initialState: boolean,
 ): PropertyCallMacro {
-	return (state, node, expression, args) => {
-		const resultId = state.pushToVar(luau.bool(initialState), "result");
+	return (state, prereqs, node, expression, args) => {
+		const resultId = prereqs.pushToVar(luau.bool(initialState), "result");
 		const callbackId = convertToIndexableExpression(args[0]);
 
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
 
 		const callCallback = luau.call(callbackId, callbackArgsListMaker(keyId, valueId, expression));
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(keyId, valueId),
 				expression,
@@ -153,13 +154,13 @@ function argumentsWithDefaults(
 }
 
 const ARRAY_LIKE_METHODS: MacroList<PropertyCallMacro> = {
-	size: (state, node, expression) => luau.unary("#", expression),
+	size: (state, prereqs, node, expression) => luau.unary("#", expression),
 };
 
 const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
-	isEmpty: (state, node, expression) => luau.binary(luau.unary("#", expression), "==", luau.number(0)),
+	isEmpty: (state, prereqs, node, expression) => luau.binary(luau.unary("#", expression), "==", luau.number(0)),
 
-	join: (state, node, expression, args) => {
+	join: (state, prereqs, node, expression, args) => {
 		args = argumentsWithDefaults(state, node, args, [luau.strings[", "]]);
 		const indexType = state.typeChecker.getIndexTypeOfType(
 			state.getType(node.expression.expression),
@@ -168,10 +169,10 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 
 		// table.concat only works on string and number types, so call tostring() otherwise
 		if (indexType && !isDefinitelyType(indexType, isStringType, isNumberType)) {
-			const id = state.pushToVar(luau.call(luau.globals.table.create, [luau.unary("#", expression)]), "result");
+			const id = prereqs.pushToVar(luau.call(luau.globals.table.create, [luau.unary("#", expression)]), "result");
 			const keyId = luau.tempId("k");
 			const valueId = luau.tempId("v");
-			state.prereq(
+			prereqs.push(
 				luau.create(luau.SyntaxKind.ForStatement, {
 					ids: luau.list.make(keyId, valueId),
 					expression,
@@ -194,7 +195,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return luau.call(luau.globals.table.concat, [expression, args[0]]);
 	},
 
-	move: (state, node, expression, args) => {
+	move: (state, prereqs, node, expression, args) => {
 		const moveArgs = [expression, offset(args[0], 1), offset(args[1], 1), offset(args[2], 1)];
 		if (args[3]) {
 			moveArgs.push(args[3]);
@@ -202,7 +203,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return luau.call(luau.globals.table.move, moveArgs);
 	},
 
-	includes: (state, node, expression, args) => {
+	includes: (state, prereqs, node, expression, args) => {
 		const callArgs = [expression, args[0]];
 		if (args[1]) {
 			callArgs.push(offset(args[1], 1));
@@ -210,7 +211,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return luau.binary(luau.call(luau.globals.table.find, callArgs), "~=", luau.nil());
 	},
 
-	indexOf: (state, node, expression, args) => {
+	indexOf: (state, prereqs, node, expression, args) => {
 		const findArgs = [expression, args[0]];
 
 		if (args.length > 1) {
@@ -231,11 +232,11 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 
 	some: makeSomeMethod((keyId, valueId, expression) => [valueId, offset(keyId, -1), expression]),
 
-	forEach: (state, node, expression, args) => {
+	forEach: (state, prereqs, node, expression, args) => {
 		const callbackId = convertToIndexableExpression(args[0]);
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(keyId, valueId),
 				expression,
@@ -250,15 +251,15 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return !isUsedAsStatement(node) ? luau.nil() : luau.none();
 	},
 
-	map: (state, node, expression, args) => {
-		const newValueId = state.pushToVar(
+	map: (state, prereqs, node, expression, args) => {
+		const newValueId = prereqs.pushToVar(
 			luau.call(luau.globals.table.create, [luau.unary("#", expression)]),
 			"newValue",
 		);
 		const callbackId = convertToIndexableExpression(args[0]);
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(keyId, valueId),
 				expression,
@@ -278,14 +279,14 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return newValueId;
 	},
 
-	mapFiltered: (state, node, expression, args) => {
-		const newValueId = state.pushToVar(luau.array(), "newValue");
+	mapFiltered: (state, prereqs, node, expression, args) => {
+		const newValueId = prereqs.pushToVar(luau.array(), "newValue");
 		const callbackId = convertToIndexableExpression(args[0]);
-		const lengthId = state.pushToVar(luau.number(0), "length");
+		const lengthId = prereqs.pushToVar(luau.number(0), "length");
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
 		const resultId = luau.tempId("result");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(keyId, valueId),
 				expression,
@@ -320,10 +321,10 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return newValueId;
 	},
 
-	filterUndefined: (state, node, expression) => {
-		const lengthId = state.pushToVar(luau.number(0), "length");
+	filterUndefined: (state, prereqs, node, expression) => {
+		const lengthId = prereqs.pushToVar(luau.number(0), "length");
 		const indexId1 = luau.tempId("i");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(indexId1),
 				expression,
@@ -343,11 +344,11 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 			}),
 		);
 
-		const resultId = state.pushToVar(luau.array(), "result");
-		const resultLengthId = state.pushToVar(luau.number(0), "resultLength");
+		const resultId = prereqs.pushToVar(luau.array(), "result");
+		const resultLengthId = prereqs.pushToVar(luau.number(0), "resultLength");
 		const indexId2 = luau.tempId("i");
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.NumericForStatement, {
 				id: indexId2,
 				start: luau.number(1),
@@ -388,13 +389,13 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return resultId;
 	},
 
-	filter: (state, node, expression, args) => {
-		const newValueId = state.pushToVar(luau.array(), "newValue");
+	filter: (state, prereqs, node, expression, args) => {
+		const newValueId = prereqs.pushToVar(luau.array(), "newValue");
 		const callbackId = convertToIndexableExpression(args[0]);
-		const lengthId = state.pushToVar(luau.number(0), "length");
+		const lengthId = prereqs.pushToVar(luau.number(0), "length");
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(keyId, valueId),
 				expression,
@@ -429,7 +430,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return newValueId;
 	},
 
-	reduce: (state, node, expression, args) => {
+	reduce: (state, prereqs, node, expression, args) => {
 		let start: luau.Expression = luau.number(1);
 		const end = luau.unary("#", expression);
 		const step = 1;
@@ -439,7 +440,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		let resultId;
 		// if there was no initialValue supplied
 		if (args.length < 2) {
-			state.prereq(
+			prereqs.push(
 				luau.create(luau.SyntaxKind.IfStatement, {
 					condition: luau.binary(lengthExp, "==", luau.number(0)),
 					statements: luau.list.make<luau.Statement>(
@@ -454,7 +455,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 					elseBody: luau.list.make(),
 				}),
 			);
-			resultId = state.pushToVar(
+			resultId = prereqs.pushToVar(
 				luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: convertToIndexableExpression(expression),
 					index: start,
@@ -463,12 +464,12 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 			);
 			start = offset(start, step);
 		} else {
-			resultId = state.pushToVar(args[1], "result");
+			resultId = prereqs.pushToVar(args[1], "result");
 		}
 		const callbackId = convertToIndexableExpression(args[0]);
 
 		const iteratorId = luau.tempId("i");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.NumericForStatement, {
 				id: iteratorId,
 				start,
@@ -495,13 +496,13 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return resultId;
 	},
 
-	find: (state, node, expression, args) => {
+	find: (state, prereqs, node, expression, args) => {
 		const callbackId = convertToIndexableExpression(args[0]);
 		const loopId = luau.tempId("i");
 		const valueId = luau.tempId("v");
-		const resultId = state.pushToVar(undefined, "result");
+		const resultId = prereqs.pushToVar(undefined, "result");
 
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				expression,
 				ids: luau.list.make(loopId, valueId),
@@ -529,13 +530,13 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return resultId;
 	},
 
-	findIndex: (state, node, expression, args) => {
+	findIndex: (state, prereqs, node, expression, args) => {
 		const callbackId = convertToIndexableExpression(args[0]);
 		const loopId = luau.tempId("i");
 		const valueId = luau.tempId("v");
-		const resultId = state.pushToVar(luau.number(-1), "result");
+		const resultId = prereqs.pushToVar(luau.number(-1), "result");
 
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				expression,
 				ids: luau.list.make(loopId, valueId),
@@ -565,14 +566,14 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 };
 
 const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
-	push: (state, node, expression, args) => {
+	push: (state, prereqs, node, expression, args) => {
 		// for `a.push()` always emit luau.unary so the call doesn't disappear in emit
 		if (args.length === 0) {
 			return luau.unary("#", expression);
 		}
 
 		for (let i = 0; i < args.length; i++) {
-			state.prereq(
+			prereqs.push(
 				luau.create(luau.SyntaxKind.CallStatement, {
 					expression: luau.call(luau.globals.table.insert, [expression, args[i]]),
 				}),
@@ -582,14 +583,14 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return !isUsedAsStatement(node) ? luau.unary("#", expression) : luau.none();
 	},
 
-	pop: (state, node, expression) => {
+	pop: (state, prereqs, node, expression) => {
 		let lengthExp: luau.Expression = luau.unary("#", expression);
 
 		const returnValueIsUsed = !isUsedAsStatement(node);
 		let retValue: luau.TemporaryIdentifier;
 		if (returnValueIsUsed) {
-			lengthExp = state.pushToVar(lengthExp, "length");
-			retValue = state.pushToVar(
+			lengthExp = prereqs.pushToVar(lengthExp, "length");
+			retValue = prereqs.pushToVar(
 				luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: convertToIndexableExpression(expression),
 					index: lengthExp,
@@ -598,7 +599,7 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 			);
 		}
 
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: convertToIndexableExpression(expression),
@@ -612,12 +613,12 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return returnValueIsUsed ? retValue! : luau.none();
 	},
 
-	shift: (state, node, expression) => luau.call(luau.globals.table.remove, [expression, luau.number(1)]),
+	shift: (state, prereqs, node, expression) => luau.call(luau.globals.table.remove, [expression, luau.number(1)]),
 
-	unshift: (state, node, expression, args) => {
+	unshift: (state, prereqs, node, expression, args) => {
 		for (let i = args.length - 1; i >= 0; i--) {
 			const arg = args[i];
-			state.prereq(
+			prereqs.push(
 				luau.create(luau.SyntaxKind.CallStatement, {
 					expression: luau.call(luau.globals.table.insert, [expression, luau.number(1), arg]),
 				}),
@@ -627,19 +628,20 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return !isUsedAsStatement(node) ? luau.unary("#", expression) : luau.none();
 	},
 
-	insert: (state, node, expression, args) => {
+	insert: (state, prereqs, node, expression, args) => {
 		return luau.call(luau.globals.table.insert, [expression, offset(args[0], 1), args[1]]);
 	},
 
-	remove: (state, node, expression, args) => luau.call(luau.globals.table.remove, [expression, offset(args[0], 1)]),
+	remove: (state, prereqs, node, expression, args) =>
+		luau.call(luau.globals.table.remove, [expression, offset(args[0], 1)]),
 
-	unorderedRemove: (state, node, expression, args) => {
-		const indexExp = state.pushToVarIfComplex(offset(args[0], 1), "index");
+	unorderedRemove: (state, prereqs, node, expression, args) => {
+		const indexExp = prereqs.pushToVarIfComplex(offset(args[0], 1), "index");
 
-		const lengthId = state.pushToVar(luau.unary("#", expression), "length");
+		const lengthId = prereqs.pushToVar(luau.unary("#", expression), "length");
 
 		const valueIsUsed = !isUsedAsStatement(node);
-		const valueId = state.pushToVar(
+		const valueId = prereqs.pushToVar(
 			luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 				expression: convertToIndexableExpression(expression),
 				index: indexExp,
@@ -647,7 +649,7 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 			"value",
 		);
 
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.IfStatement, {
 				condition: luau.binary(valueId, "~=", luau.nil()),
 				statements: luau.list.make(
@@ -678,12 +680,12 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return valueIsUsed ? valueId : luau.none();
 	},
 
-	sort: (state, node, expression, args) => {
+	sort: (state, prereqs, node, expression, args) => {
 		const valueIsUsed = !isUsedAsStatement(node);
 
 		args.unshift(expression);
 
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				expression: luau.call(luau.globals.table.sort, args),
 			}),
@@ -692,8 +694,8 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 		return valueIsUsed ? expression : luau.none();
 	},
 
-	clear: (state, node, expression) => {
-		state.prereq(
+	clear: (state, prereqs, node, expression) => {
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				expression: luau.call(luau.globals.table.clear, [expression]),
 			}),
@@ -703,11 +705,12 @@ const ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 };
 
 const READONLY_SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
-	isEmpty: (state, node, expression) => luau.binary(luau.call(luau.globals.next, [expression]), "==", luau.nil()),
+	isEmpty: (state, prereqs, node, expression) =>
+		luau.binary(luau.call(luau.globals.next, [expression]), "==", luau.nil()),
 
-	size: (state, node, expression) => {
-		const sizeId = state.pushToVar(luau.number(0), "size");
-		state.prereq(
+	size: (state, prereqs, node, expression) => {
+		const sizeId = prereqs.pushToVar(luau.number(0), "size");
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(luau.tempId()),
 				expression,
@@ -723,7 +726,7 @@ const READONLY_SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
 		return sizeId;
 	},
 
-	has: (state, node, expression, args) => {
+	has: (state, prereqs, node, expression, args) => {
 		const left = luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 			expression: convertToIndexableExpression(expression),
 			index: args[0],
@@ -733,12 +736,12 @@ const READONLY_SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
 };
 
 const SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
-	delete: (state, node, expression, args) => {
+	delete: (state, prereqs, node, expression, args) => {
 		const arg = args[0];
 		const valueIsUsed = !isUsedAsStatement(node);
 		let valueExistedId: luau.TemporaryIdentifier;
 		if (valueIsUsed) {
-			valueExistedId = state.pushToVar(
+			valueExistedId = prereqs.pushToVar(
 				luau.create(luau.SyntaxKind.BinaryExpression, {
 					left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 						expression: convertToIndexableExpression(expression),
@@ -751,7 +754,7 @@ const SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
 			);
 		}
 
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: convertToIndexableExpression(expression),
@@ -765,8 +768,8 @@ const SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
 		return valueIsUsed ? valueExistedId! : luau.none();
 	},
 
-	clear: (state, node, expression) => {
-		state.prereq(
+	clear: (state, prereqs, node, expression) => {
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				expression: luau.call(luau.globals.table.clear, [expression]),
 			}),
@@ -778,10 +781,10 @@ const SET_MAP_SHARED_METHODS: MacroList<PropertyCallMacro> = {
 const READONLY_SET_METHODS: MacroList<PropertyCallMacro> = {
 	...READONLY_SET_MAP_SHARED_METHODS,
 
-	forEach: (state, node, expression, args) => {
+	forEach: (state, prereqs, node, expression, args) => {
 		const callbackId = convertToIndexableExpression(args[0]);
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(valueId),
 				expression,
@@ -800,9 +803,9 @@ const READONLY_SET_METHODS: MacroList<PropertyCallMacro> = {
 const SET_METHODS: MacroList<PropertyCallMacro> = {
 	...SET_MAP_SHARED_METHODS,
 
-	add: (state, node, expression, args) => {
+	add: (state, prereqs, node, expression, args) => {
 		const valueIsUsed = !isUsedAsStatement(node);
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: convertToIndexableExpression(expression),
@@ -819,11 +822,11 @@ const SET_METHODS: MacroList<PropertyCallMacro> = {
 const READONLY_MAP_METHODS: MacroList<PropertyCallMacro> = {
 	...READONLY_SET_MAP_SHARED_METHODS,
 
-	forEach: (state, node, expression, args) => {
+	forEach: (state, prereqs, node, expression, args) => {
 		const callbackId = convertToIndexableExpression(args[0]);
 		const keyId = luau.tempId("k");
 		const valueId = luau.tempId("v");
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(keyId, valueId),
 				expression,
@@ -838,7 +841,7 @@ const READONLY_MAP_METHODS: MacroList<PropertyCallMacro> = {
 		return !isUsedAsStatement(node) ? luau.nil() : luau.none();
 	},
 
-	get: (state, node, expression, args) =>
+	get: (state, prereqs, node, expression, args) =>
 		luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 			expression: convertToIndexableExpression(expression),
 			index: args[0],
@@ -848,10 +851,10 @@ const READONLY_MAP_METHODS: MacroList<PropertyCallMacro> = {
 const MAP_METHODS: MacroList<PropertyCallMacro> = {
 	...SET_MAP_SHARED_METHODS,
 
-	set: (state, node, expression, args) => {
+	set: (state, prereqs, node, expression, args) => {
 		const [keyExp, valueExp] = args;
 		const valueIsUsed = !isUsedAsStatement(node);
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: convertToIndexableExpression(expression),
@@ -866,7 +869,7 @@ const MAP_METHODS: MacroList<PropertyCallMacro> = {
 };
 
 const PROMISE_METHODS: MacroList<PropertyCallMacro> = {
-	then: (state, node, expression, args) =>
+	then: (state, prereqs, node, expression, args) =>
 		luau.create(luau.SyntaxKind.MethodCallExpression, {
 			expression: convertToIndexableExpression(expression),
 			name: "andThen",
@@ -908,13 +911,14 @@ function footer(text: string) {
 }
 
 function wrapComments(methodName: string, callback: PropertyCallMacro): PropertyCallMacro {
-	return (state, callNode, callExp, args) => {
-		const [expression, prereqs] = state.capture(() => callback(state, callNode, callExp, args));
-		if (luau.list.size(prereqs) > 1) {
-			luau.list.unshift(prereqs, header(methodName));
-			luau.list.push(prereqs, footer(methodName));
+	return (state, prereqs, callNode, callExp, args) => {
+		const expressionPrereqs = new Prereqs();
+		const expression = callback(state, expressionPrereqs, callNode, callExp, args);
+		if (luau.list.size(expressionPrereqs.statements) > 1) {
+			expressionPrereqs.unshift(header(methodName));
+			expressionPrereqs.push(footer(methodName));
 		}
-		state.prereqList(prereqs);
+		prereqs.pushList(expressionPrereqs.statements);
 		return expression;
 	};
 }

--- a/src/TSTransformer/macros/types.ts
+++ b/src/TSTransformer/macros/types.ts
@@ -1,17 +1,19 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import ts from "typescript";
 
 export type MacroList<T> = { [index: string]: T };
 
 export type IdentifierMacro = (state: TransformState, node: ts.Identifier) => luau.Expression;
 
-export type ConstructorMacro = (state: TransformState, node: ts.NewExpression) => luau.Expression;
+export type ConstructorMacro = (state: TransformState, prereqs: Prereqs, node: ts.NewExpression) => luau.Expression;
 
 // operands are opaque values: assigning to them or transforming their source again
 // bypasses evaluation planning. Use pushToVar only for the macro's own working state.
 export type CallMacro = (
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.CallExpression,
 	expression: luau.Expression,
 	args: Array<luau.Expression>,
@@ -19,6 +21,7 @@ export type CallMacro = (
 
 export type PropertyCallMacro = (
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.CallExpression & { expression: ts.PropertyAccessExpression | ts.ElementAccessExpression },
 	expression: luau.Expression,
 	args: Array<luau.Expression>,

--- a/src/TSTransformer/nodes/binding/transformArrayAssignmentPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformArrayAssignmentPattern.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformObjectAssignmentPattern } from "TSTransformer/nodes/binding/transformObjectAssignmentPattern";
 import { transformInitializer } from "TSTransformer/nodes/transformInitializer";
 import { transformWritableExpression } from "TSTransformer/nodes/transformWritable";
@@ -14,6 +15,7 @@ import ts from "typescript";
 
 export function transformArrayAssignmentPattern(
 	state: TransformState,
+	prereqs: Prereqs,
 	assignmentPattern: ts.ArrayLiteralExpression,
 	parentId: luau.AnyIdentifier,
 ) {
@@ -26,7 +28,7 @@ export function transformArrayAssignmentPattern(
 
 	for (let element of assignmentPattern.elements) {
 		if (ts.isOmittedExpression(element)) {
-			accessor(state, parentId, index, idStack, true);
+			accessor(prereqs, parentId, index, idStack, true);
 		} else {
 			let initializer: ts.Expression | undefined;
 			if (ts.isBinaryExpression(element)) {
@@ -35,8 +37,8 @@ export function transformArrayAssignmentPattern(
 			}
 
 			const value = ts.isSpreadElement(element)
-				? destructor(state, parentId, index, idStack)
-				: accessor(state, parentId, index, idStack, false);
+				? destructor(prereqs, parentId, index, idStack)
+				: accessor(prereqs, parentId, index, idStack, false);
 
 			// diagnostic is needed because getTypeOfAssignmentPattern is implemented incorrectly:
 			// it errors, if that parent of node being passed in is ts.SpreadElement
@@ -56,10 +58,11 @@ export function transformArrayAssignmentPattern(
 			) {
 				const id = transformWritableExpression(
 					state,
+					prereqs,
 					ts.isSpreadElement(element) ? element.expression : element,
 					initializer !== undefined,
 				);
-				state.prereq(
+				prereqs.push(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: id,
 						operator: "=",
@@ -67,20 +70,20 @@ export function transformArrayAssignmentPattern(
 					}),
 				);
 				if (initializer) {
-					state.prereq(transformInitializer(state, id, initializer));
+					prereqs.push(transformInitializer(state, id, initializer));
 				}
 			} else if (ts.isArrayLiteralExpression(element)) {
-				const id = state.pushToVar(value, "binding");
+				const id = prereqs.pushToVar(value, "binding");
 				if (initializer) {
-					state.prereq(transformInitializer(state, id, initializer));
+					prereqs.push(transformInitializer(state, id, initializer));
 				}
-				transformArrayAssignmentPattern(state, element, id);
+				transformArrayAssignmentPattern(state, prereqs, element, id);
 			} else if (ts.isObjectLiteralExpression(element)) {
-				const id = state.pushToVar(value, "binding");
+				const id = prereqs.pushToVar(value, "binding");
 				if (initializer) {
-					state.prereq(transformInitializer(state, id, initializer));
+					prereqs.push(transformInitializer(state, id, initializer));
 				}
-				transformObjectAssignmentPattern(state, element, id);
+				transformObjectAssignmentPattern(state, prereqs, element, id);
 			} else {
 				assert(false, `transformArrayAssignmentPattern invalid element: ${getKindName(element.kind)}`);
 			}

--- a/src/TSTransformer/nodes/binding/transformArrayBindingPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformArrayBindingPattern.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformObjectBindingPattern } from "TSTransformer/nodes/binding/transformObjectBindingPattern";
 import { transformVariable } from "TSTransformer/nodes/statements/transformVariableStatement";
 import { transformInitializer } from "TSTransformer/nodes/transformInitializer";
@@ -10,6 +11,7 @@ import ts from "typescript";
 
 export function transformArrayBindingPattern(
 	state: TransformState,
+	prereqs: Prereqs,
 	bindingPattern: ts.ArrayBindingPattern,
 	parentId: luau.AnyIdentifier,
 ) {
@@ -22,29 +24,29 @@ export function transformArrayBindingPattern(
 
 	for (const element of bindingPattern.elements) {
 		if (ts.isOmittedExpression(element)) {
-			accessor(state, parentId, index, idStack, true);
+			accessor(prereqs, parentId, index, idStack, true);
 		} else {
 			const name = element.name;
 
 			const isSpreadElement = element.dotDotDotToken !== undefined;
 			const value = isSpreadElement
-				? destructor(state, parentId, index, idStack)
-				: accessor(state, parentId, index, idStack, false);
+				? destructor(prereqs, parentId, index, idStack)
+				: accessor(prereqs, parentId, index, idStack, false);
 
 			if (ts.isIdentifier(name)) {
-				const id = transformVariable(state, name, value);
+				const id = transformVariable(state, prereqs, name, value);
 				if (element.initializer) {
-					state.prereq(transformInitializer(state, id, element.initializer));
+					prereqs.push(transformInitializer(state, id, element.initializer));
 				}
 			} else {
-				const id = state.pushToVar(value, "binding");
+				const id = prereqs.pushToVar(value, "binding");
 				if (element.initializer) {
-					state.prereq(transformInitializer(state, id, element.initializer));
+					prereqs.push(transformInitializer(state, id, element.initializer));
 				}
 				if (ts.isArrayBindingPattern(name)) {
-					transformArrayBindingPattern(state, name, id);
+					transformArrayBindingPattern(state, prereqs, name, id);
 				} else {
-					transformObjectBindingPattern(state, name, id);
+					transformObjectBindingPattern(state, prereqs, name, id);
 				}
 			}
 		}

--- a/src/TSTransformer/nodes/binding/transformBindingName.ts
+++ b/src/TSTransformer/nodes/binding/transformBindingName.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayBindingPattern } from "TSTransformer/nodes/binding/transformArrayBindingPattern";
 import { transformObjectBindingPattern } from "TSTransformer/nodes/binding/transformObjectBindingPattern";
 import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
@@ -15,16 +16,13 @@ export function transformBindingName(
 		id = transformIdentifierDefined(state, name);
 	} else {
 		id = luau.tempId("binding");
-		luau.list.pushList(
-			initializers,
-			state.capturePrereqs(() => {
-				if (ts.isArrayBindingPattern(name)) {
-					transformArrayBindingPattern(state, name, id);
-				} else {
-					transformObjectBindingPattern(state, name, id);
-				}
-			}),
-		);
+		const bindingPrereqs = new Prereqs();
+		if (ts.isArrayBindingPattern(name)) {
+			transformArrayBindingPattern(state, bindingPrereqs, name, id);
+		} else {
+			transformObjectBindingPattern(state, bindingPrereqs, name, id);
+		}
+		luau.list.pushList(initializers, bindingPrereqs.statements);
 	}
 	return id;
 }

--- a/src/TSTransformer/nodes/binding/transformObjectAssignmentPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformObjectAssignmentPattern.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayAssignmentPattern } from "TSTransformer/nodes/binding/transformArrayAssignmentPattern";
 import { transformInitializer } from "TSTransformer/nodes/transformInitializer";
 import { transformWritableExpression } from "TSTransformer/nodes/transformWritable";
@@ -14,6 +15,7 @@ import ts from "typescript";
 
 export function transformObjectAssignmentPattern(
 	state: TransformState,
+	prereqs: Prereqs,
 	assignmentPattern: ts.ObjectLiteralExpression,
 	parentId: luau.AnyIdentifier,
 ) {
@@ -23,14 +25,20 @@ export function transformObjectAssignmentPattern(
 			const name = property.name;
 			const value = objectAccessor(
 				state,
+				prereqs,
 				parentId,
 				state.typeChecker.getTypeOfAssignmentPattern(assignmentPattern),
 				name,
 			);
 			preSpreadNames.push(value);
 
-			const id = transformWritableExpression(state, name, property.objectAssignmentInitializer !== undefined);
-			state.prereq(
+			const id = transformWritableExpression(
+				state,
+				prereqs,
+				name,
+				property.objectAssignmentInitializer !== undefined,
+			);
+			prereqs.push(
 				luau.create(luau.SyntaxKind.Assignment, {
 					left: id,
 					operator: "=",
@@ -39,10 +47,10 @@ export function transformObjectAssignmentPattern(
 			);
 			assert(luau.isAnyIdentifier(id));
 			if (property.objectAssignmentInitializer) {
-				state.prereq(transformInitializer(state, id, property.objectAssignmentInitializer));
+				prereqs.push(transformInitializer(state, id, property.objectAssignmentInitializer));
 			}
 		} else if (ts.isSpreadAssignment(property)) {
-			const value = spreadDestructureObject(state, parentId, preSpreadNames);
+			const value = spreadDestructureObject(prereqs, parentId, preSpreadNames);
 			const expression = property.expression;
 
 			// diagnostic is needed because getTypeOfAssignmentPattern is implemented incorrectly:
@@ -56,8 +64,8 @@ export function transformObjectAssignmentPattern(
 				ts.isIdentifier(expression),
 				"transformObjectAssignmentPattern unexpected expression type: " + getKindName(expression.kind),
 			);
-			const id = transformWritableExpression(state, expression, true);
-			state.prereq(
+			const id = transformWritableExpression(state, prereqs, expression, true);
+			prereqs.push(
 				luau.create(luau.SyntaxKind.Assignment, {
 					left: id,
 					operator: "=",
@@ -75,6 +83,7 @@ export function transformObjectAssignmentPattern(
 
 			const value = objectAccessor(
 				state,
+				prereqs,
 				parentId,
 				state.typeChecker.getTypeOfAssignmentPattern(assignmentPattern),
 				name,
@@ -82,8 +91,8 @@ export function transformObjectAssignmentPattern(
 			preSpreadNames.push(value);
 
 			if (ts.isIdentifier(init) || ts.isElementAccessExpression(init) || ts.isPropertyAccessExpression(init)) {
-				const id = transformWritableExpression(state, init, initializer !== undefined);
-				state.prereq(
+				const id = transformWritableExpression(state, prereqs, init, initializer !== undefined);
+				prereqs.push(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: id,
 						operator: "=",
@@ -91,21 +100,21 @@ export function transformObjectAssignmentPattern(
 					}),
 				);
 				if (initializer) {
-					state.prereq(transformInitializer(state, id, initializer));
+					prereqs.push(transformInitializer(state, id, initializer));
 				}
 			} else if (ts.isArrayLiteralExpression(init)) {
-				const id = state.pushToVar(value, "binding");
+				const id = prereqs.pushToVar(value, "binding");
 				if (initializer) {
-					state.prereq(transformInitializer(state, id, initializer));
+					prereqs.push(transformInitializer(state, id, initializer));
 				}
 				assert(ts.isIdentifier(name));
-				transformArrayAssignmentPattern(state, init, id);
+				transformArrayAssignmentPattern(state, prereqs, init, id);
 			} else if (ts.isObjectLiteralExpression(init)) {
-				const id = state.pushToVar(value, "binding");
+				const id = prereqs.pushToVar(value, "binding");
 				if (initializer) {
-					state.prereq(transformInitializer(state, id, initializer));
+					prereqs.push(transformInitializer(state, id, initializer));
 				}
-				transformObjectAssignmentPattern(state, init, id);
+				transformObjectAssignmentPattern(state, prereqs, init, id);
 			} else {
 				assert(false, `transformObjectAssignmentPattern invalid initializer: ${getKindName(init.kind)}`);
 			}

--- a/src/TSTransformer/nodes/binding/transformObjectBindingPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformObjectBindingPattern.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayBindingPattern } from "TSTransformer/nodes/binding/transformArrayBindingPattern";
 import { transformVariable } from "TSTransformer/nodes/statements/transformVariableStatement";
 import { transformInitializer } from "TSTransformer/nodes/transformInitializer";
@@ -14,6 +15,7 @@ import ts from "typescript";
 
 export function transformObjectBindingPattern(
 	state: TransformState,
+	prereqs: Prereqs,
 	bindingPattern: ts.ObjectBindingPattern,
 	parentId: luau.AnyIdentifier,
 ) {
@@ -26,8 +28,8 @@ export function transformObjectBindingPattern(
 
 		if (ts.isIdentifier(name)) {
 			const value = isSpread
-				? spreadDestructureObject(state, parentId, preSpreadNames)
-				: objectAccessor(state, parentId, state.getType(bindingPattern), prop ?? name);
+				? spreadDestructureObject(prereqs, parentId, preSpreadNames)
+				: objectAccessor(state, prereqs, parentId, state.getType(bindingPattern), prop ?? name);
 			preSpreadNames.push(value);
 
 			if (isSpread && isPossiblyType(state.getType(bindingPattern), isRobloxType(state))) {
@@ -35,26 +37,26 @@ export function transformObjectBindingPattern(
 				continue;
 			}
 
-			const id = transformVariable(state, name, value);
+			const id = transformVariable(state, prereqs, name, value);
 			if (element.initializer) {
-				state.prereq(transformInitializer(state, id, element.initializer));
+				prereqs.push(transformInitializer(state, id, element.initializer));
 			}
 		} else {
 			// if name is not identifier, it must be a binding pattern
 			// in that case, prop is guaranteed to exist
 			assert(prop);
 			assert(!isSpread);
-			const value = objectAccessor(state, parentId, state.getType(bindingPattern), prop);
+			const value = objectAccessor(state, prereqs, parentId, state.getType(bindingPattern), prop);
 			preSpreadNames.push(value);
 
-			const id = state.pushToVar(value, "binding");
+			const id = prereqs.pushToVar(value, "binding");
 			if (element.initializer) {
-				state.prereq(transformInitializer(state, id, element.initializer));
+				prereqs.push(transformInitializer(state, id, element.initializer));
 			}
 			if (ts.isArrayBindingPattern(name)) {
-				transformArrayBindingPattern(state, name, id);
+				transformArrayBindingPattern(state, prereqs, name, id);
 			} else {
-				transformObjectBindingPattern(state, name, id);
+				transformObjectBindingPattern(state, prereqs, name, id);
 			}
 		}
 	}

--- a/src/TSTransformer/nodes/class/transformClassConstructor.ts
+++ b/src/TSTransformer/nodes/class/transformClassConstructor.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
 import { transformParameters } from "TSTransformer/nodes/transformParameters";
@@ -28,11 +29,13 @@ function transformPropertyInitializers(state: TransformState, node: ts.ClassLike
 		const initializer = member.initializer;
 		if (!initializer) continue;
 
-		const [index, indexPrereqs] = state.capture(() => transformPropertyName(state, name));
-		luau.list.pushList(statements, indexPrereqs);
+		const indexPrereqs = new Prereqs();
+		const index = transformPropertyName(state, indexPrereqs, name);
+		luau.list.pushList(statements, indexPrereqs.statements);
 
-		const [right, rightPrereqs] = state.capture(() => transformExpression(state, initializer));
-		luau.list.pushList(statements, rightPrereqs);
+		const rightPrereqs = new Prereqs();
+		const right = transformExpression(state, rightPrereqs, initializer);
+		luau.list.pushList(statements, rightPrereqs.statements);
 
 		luau.list.push(
 			statements,

--- a/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
+++ b/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import {
 	transformClassConstructor,
 	transformImplicitClassConstructor,
@@ -85,11 +86,10 @@ function createBoilerplate(
 		);
 
 		if (extendsNode) {
-			const [extendsExp, extendsExpPrereqs] = state.capture(() =>
-				transformExpression(state, extendsNode.expression),
-			);
+			const extendsExpPrereqs = new Prereqs();
+			const extendsExp = transformExpression(state, extendsExpPrereqs, extendsNode.expression);
 			const superId = luau.id("super");
-			luau.list.pushList(statements, extendsExpPrereqs);
+			luau.list.pushList(statements, extendsExpPrereqs.statements);
 			luau.list.push(
 				statements,
 				luau.create(luau.SyntaxKind.VariableDeclaration, {
@@ -203,7 +203,7 @@ export function transformClassLikeDeclaration(state: TransformState, node: ts.Cl
 	const isExportDefault = ts.hasSyntacticModifier(node, ts.ModifierFlags.ExportDefault);
 
 	if (node.name) {
-		validateIdentifier(state, node.name);
+		validateIdentifier(node.name);
 	}
 
 	/*
@@ -318,10 +318,12 @@ export function transformClassLikeDeclaration(state: TransformState, node: ts.Cl
 			}
 		}
 
-		const [statements, prereqs] = state.capture(() =>
-			transformMethodDeclaration(state, method, { name: "name", value: internalName }),
-		);
-		luau.list.pushList(statementsInner, prereqs);
+		const methodPrereqs = new Prereqs();
+		const statements = transformMethodDeclaration(state, methodPrereqs, method, {
+			name: "name",
+			value: internalName,
+		});
+		luau.list.pushList(statementsInner, methodPrereqs.statements);
 		luau.list.pushList(statementsInner, statements);
 	}
 
@@ -351,10 +353,9 @@ export function transformClassLikeDeclaration(state: TransformState, node: ts.Cl
 		if (ts.isClassStaticBlockDeclaration(declaration)) {
 			luau.list.pushList(statementsInner, transformBlock(state, declaration.body));
 		} else {
-			const [statements, prereqs] = state.capture(() =>
-				transformPropertyDeclaration(state, declaration, internalName),
-			);
-			luau.list.pushList(statementsInner, prereqs);
+			const propertyPrereqs = new Prereqs();
+			const statements = transformPropertyDeclaration(state, propertyPrereqs, declaration, internalName);
+			luau.list.pushList(statementsInner, propertyPrereqs.statements);
 			luau.list.pushList(statementsInner, statements);
 		}
 	}

--- a/src/TSTransformer/nodes/class/transformDecorators.ts
+++ b/src/TSTransformer/nodes/class/transformDecorators.ts
@@ -1,6 +1,7 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
@@ -67,9 +68,10 @@ function transformMemberDecorators(
 
 	for (let i = 0; i < decorators.length; i++) {
 		const decorator = decorators[i];
-		let [expression, prereqs] = state.capture(() => transformExpression(state, decorator.expression));
+		const expressionPrereqs = new Prereqs();
+		let expression = transformExpression(state, expressionPrereqs, decorator.expression);
 
-		luau.list.pushList(initializers, prereqs);
+		luau.list.pushList(initializers, expressionPrereqs.statements);
 
 		const isLastDecorator = i === decorators.length - 1;
 
@@ -163,7 +165,9 @@ function transformPropertyDecorators(
 ): luau.List<luau.Statement> {
 	const [initializers, finalizers] = transformMemberDecorators(state, member, expression => {
 		// typescript enforces that property keys are static, so they shouldn't have prereqs
-		const key = state.noPrereqs(() => transformPropertyName(state, member.name));
+		const keyPrereqs = new Prereqs();
+		const key = transformPropertyName(state, keyPrereqs, member.name);
+		assert(luau.list.isEmpty(keyPrereqs.statements));
 
 		// decorator(Class, "name")
 		return luau.list.make(

--- a/src/TSTransformer/nodes/class/transformPropertyDeclaration.ts
+++ b/src/TSTransformer/nodes/class/transformPropertyDeclaration.ts
@@ -2,12 +2,14 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
 import ts from "typescript";
 
 export function transformPropertyDeclaration(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.PropertyDeclaration,
 	name: luau.AnyIdentifier,
 ) {
@@ -28,10 +30,10 @@ export function transformPropertyDeclaration(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 				expression: name,
-				index: transformPropertyName(state, node.name),
+				index: transformPropertyName(state, prereqs, node.name),
 			}),
 			operator: "=",
-			right: transformExpression(state, node.initializer),
+			right: transformExpression(state, prereqs, node.initializer),
 		}),
 	);
 }

--- a/src/TSTransformer/nodes/expressions/transformArrayLiteralExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformArrayLiteralExpression.ts
@@ -1,15 +1,20 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { getAddIterableToArrayBuilder } from "TSTransformer/util/getAddIterableToArrayBuilder";
 import { createArrayPointer, disableArrayInline } from "TSTransformer/util/pointer";
 import ts from "typescript";
 
-export function transformArrayLiteralExpression(state: TransformState, node: ts.ArrayLiteralExpression) {
+export function transformArrayLiteralExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.ArrayLiteralExpression,
+) {
 	if (!node.elements.find(element => ts.isSpreadElement(element))) {
-		return luau.array(ensureTransformOrder(state, node.elements));
+		return luau.array(ensureTransformOrder(state, prereqs, node.elements));
 	}
 
 	const ptr = createArrayPointer("array");
@@ -20,7 +25,7 @@ export function transformArrayLiteralExpression(state: TransformState, node: ts.
 	function updateLengthId() {
 		const right = luau.unary("#", ptr.value);
 		if (lengthInitialized) {
-			state.prereq(
+			prereqs.push(
 				luau.create(luau.SyntaxKind.Assignment, {
 					left: lengthId,
 					operator: "=",
@@ -28,7 +33,7 @@ export function transformArrayLiteralExpression(state: TransformState, node: ts.
 				}),
 			);
 		} else {
-			state.prereq(
+			prereqs.push(
 				luau.create(luau.SyntaxKind.VariableDeclaration, {
 					left: lengthId,
 					right,
@@ -43,18 +48,18 @@ export function transformArrayLiteralExpression(state: TransformState, node: ts.
 		const element = node.elements[i];
 		if (ts.isSpreadElement(element)) {
 			if (luau.isArray(ptr.value)) {
-				disableArrayInline(state, ptr);
+				disableArrayInline(prereqs, ptr);
 				updateLengthId();
 			}
 			assert(luau.isAnyIdentifier(ptr.value));
 
 			const type = state.getType(element.expression);
 			const addIterableToArrayBuilder = getAddIterableToArrayBuilder(state, element.expression, type);
-			const spreadExp = transformExpression(state, element.expression);
+			const spreadExp = transformExpression(state, prereqs, element.expression);
 			const shouldUpdateLengthId = i < node.elements.length - 1;
-			state.prereqList(
+			prereqs.pushList(
 				addIterableToArrayBuilder(
-					state,
+					prereqs,
 					spreadExp,
 					ptr.value,
 					lengthId,
@@ -63,16 +68,17 @@ export function transformArrayLiteralExpression(state: TransformState, node: ts.
 				),
 			);
 		} else {
-			const [expression, prereqs] = state.capture(() => transformExpression(state, element));
-			if (luau.isArray(ptr.value) && !luau.list.isEmpty(prereqs)) {
-				disableArrayInline(state, ptr);
+			const expressionPrereqs = new Prereqs();
+			const expression = transformExpression(state, expressionPrereqs, element);
+			if (luau.isArray(ptr.value) && !luau.list.isEmpty(expressionPrereqs.statements)) {
+				disableArrayInline(prereqs, ptr);
 				updateLengthId();
 			}
 			if (luau.isArray(ptr.value)) {
 				luau.list.push(ptr.value.members, expression);
 			} else {
-				state.prereqList(prereqs);
-				state.prereq(
+				prereqs.pushList(expressionPrereqs.statements);
+				prereqs.push(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 							expression: ptr.value,

--- a/src/TSTransformer/nodes/expressions/transformArrayLiteralExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformArrayLiteralExpression.ts
@@ -19,28 +19,16 @@ export function transformArrayLiteralExpression(
 
 	const ptr = createArrayPointer("array");
 	const lengthId = luau.tempId("length");
-	let lengthInitialized = false;
 	let amtElementsSinceUpdate = 0;
 
-	function updateLengthId() {
-		const right = luau.unary("#", ptr.value);
-		if (lengthInitialized) {
-			prereqs.push(
-				luau.create(luau.SyntaxKind.Assignment, {
-					left: lengthId,
-					operator: "=",
-					right,
-				}),
-			);
-		} else {
-			prereqs.push(
-				luau.create(luau.SyntaxKind.VariableDeclaration, {
-					left: lengthId,
-					right,
-				}),
-			);
-			lengthInitialized = true;
-		}
+	// the array pointer becomes an identifier once, when inline construction ends
+	function initializeLengthId() {
+		prereqs.push(
+			luau.create(luau.SyntaxKind.VariableDeclaration, {
+				left: lengthId,
+				right: luau.unary("#", ptr.value),
+			}),
+		);
 		amtElementsSinceUpdate = 0;
 	}
 
@@ -49,7 +37,7 @@ export function transformArrayLiteralExpression(
 		if (ts.isSpreadElement(element)) {
 			if (luau.isArray(ptr.value)) {
 				disableArrayInline(prereqs, ptr);
-				updateLengthId();
+				initializeLengthId();
 			}
 			assert(luau.isAnyIdentifier(ptr.value));
 
@@ -72,7 +60,7 @@ export function transformArrayLiteralExpression(
 			const expression = transformExpression(state, expressionPrereqs, element);
 			if (luau.isArray(ptr.value) && !luau.list.isEmpty(expressionPrereqs.statements)) {
 				disableArrayInline(prereqs, ptr);
-				updateLengthId();
+				initializeLengthId();
 			}
 			if (luau.isArray(ptr.value)) {
 				luau.list.push(ptr.value.members, expression);

--- a/src/TSTransformer/nodes/expressions/transformAwaitExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformAwaitExpression.ts
@@ -1,9 +1,10 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { skipDownwards } from "TSTransformer/util/traversal";
 import ts from "typescript";
 
-export function transformAwaitExpression(state: TransformState, node: ts.AwaitExpression) {
-	return luau.call(state.TS(node, "await"), [transformExpression(state, skipDownwards(node.expression))]);
+export function transformAwaitExpression(state: TransformState, prereqs: Prereqs, node: ts.AwaitExpression) {
+	return luau.call(state.TS(node, "await"), [transformExpression(state, prereqs, skipDownwards(node.expression))]);
 }

--- a/src/TSTransformer/nodes/expressions/transformBinaryExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformBinaryExpression.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayAssignmentPattern } from "TSTransformer/nodes/binding/transformArrayAssignmentPattern";
 import { transformObjectAssignmentPattern } from "TSTransformer/nodes/binding/transformObjectAssignmentPattern";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
@@ -37,82 +38,80 @@ import ts from "typescript";
 
 function transformOptimizedArrayAssignmentPattern(
 	state: TransformState,
+	prereqs: Prereqs,
 	assignmentPattern: ts.ArrayLiteralExpression,
 	rhs: luau.Expression | luau.List<luau.Expression>,
 ) {
 	const variables = luau.list.make<luau.TemporaryIdentifier>();
 	const writes = luau.list.make<luau.WritableExpression>();
 	const writesPrereqs = luau.list.make<luau.Statement>();
-	const statements = state.capturePrereqs(() => {
-		for (let element of assignmentPattern.elements) {
-			if (ts.isOmittedExpression(element)) {
-				luau.list.push(writes, luau.tempId());
-			} else if (ts.isSpreadElement(element)) {
-				assert(false, "Cannot optimize-assign spread element");
-			} else {
-				let initializer: ts.Expression | undefined;
-				if (ts.isBinaryExpression(element)) {
-					initializer = skipDownwards(element.right);
-					element = skipDownwards(element.left);
-				}
+	const bindingPrereqs = new Prereqs();
+	for (let element of assignmentPattern.elements) {
+		if (ts.isOmittedExpression(element)) {
+			luau.list.push(writes, luau.tempId());
+		} else if (ts.isSpreadElement(element)) {
+			assert(false, "Cannot optimize-assign spread element");
+		} else {
+			let initializer: ts.Expression | undefined;
+			if (ts.isBinaryExpression(element)) {
+				initializer = skipDownwards(element.right);
+				element = skipDownwards(element.left);
+			}
 
-				if (
-					ts.isIdentifier(element) ||
-					ts.isElementAccessExpression(element) ||
-					ts.isPropertyAccessExpression(element)
-				) {
-					const [id, idPrereqs] = state.capture(() => transformWritableExpression(state, element, true));
-					luau.list.pushList(writesPrereqs, idPrereqs);
-					luau.list.push(writes, id);
-					if (initializer) {
-						state.prereq(transformInitializer(state, id, initializer));
-					}
-				} else if (ts.isArrayLiteralExpression(element)) {
-					const id = luau.tempId("binding");
-					luau.list.push(variables, id);
-					luau.list.push(writes, id);
-					if (initializer) {
-						state.prereq(transformInitializer(state, id, initializer));
-					}
-					transformArrayAssignmentPattern(state, element, id);
-				} else if (ts.isObjectLiteralExpression(element)) {
-					const id = luau.tempId("binding");
-					luau.list.push(variables, id);
-					luau.list.push(writes, id);
-					if (initializer) {
-						state.prereq(transformInitializer(state, id, initializer));
-					}
-					transformObjectAssignmentPattern(state, element, id);
-				} else {
-					assert(
-						false,
-						`transformOptimizedArrayAssignmentPattern invalid element: ${getKindName(element.kind)}`,
-					);
+			if (
+				ts.isIdentifier(element) ||
+				ts.isElementAccessExpression(element) ||
+				ts.isPropertyAccessExpression(element)
+			) {
+				const idPrereqs = new Prereqs();
+				const id = transformWritableExpression(state, idPrereqs, element, true);
+				luau.list.pushList(writesPrereqs, idPrereqs.statements);
+				luau.list.push(writes, id);
+				if (initializer) {
+					bindingPrereqs.push(transformInitializer(state, id, initializer));
 				}
+			} else if (ts.isArrayLiteralExpression(element)) {
+				const id = luau.tempId("binding");
+				luau.list.push(variables, id);
+				luau.list.push(writes, id);
+				if (initializer) {
+					bindingPrereqs.push(transformInitializer(state, id, initializer));
+				}
+				transformArrayAssignmentPattern(state, bindingPrereqs, element, id);
+			} else if (ts.isObjectLiteralExpression(element)) {
+				const id = luau.tempId("binding");
+				luau.list.push(variables, id);
+				luau.list.push(writes, id);
+				if (initializer) {
+					bindingPrereqs.push(transformInitializer(state, id, initializer));
+				}
+				transformObjectAssignmentPattern(state, bindingPrereqs, element, id);
+			} else {
+				assert(false, `transformOptimizedArrayAssignmentPattern invalid element: ${getKindName(element.kind)}`);
 			}
 		}
-	});
+	}
 	if (!luau.list.isEmpty(variables)) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.VariableDeclaration, {
 				left: variables,
 				right: undefined,
 			}),
 		);
 	}
-	state.prereqList(writesPrereqs);
+	prereqs.pushList(writesPrereqs);
 	assert(!luau.list.isEmpty(writes));
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: writes,
 			operator: "=",
 			right: rhs,
 		}),
 	);
-	state.prereqList(statements);
+	prereqs.pushList(bindingPrereqs.statements);
 }
 
-export function transformBinaryExpression(state: TransformState, node: ts.BinaryExpression) {
+export function transformBinaryExpression(state: TransformState, prereqs: Prereqs, node: ts.BinaryExpression) {
 	const operatorKind = node.operatorToken.kind;
 
 	validateNotAnyType(state, node.left);
@@ -133,17 +132,17 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 		operatorKind === ts.SyntaxKind.BarBarToken ||
 		operatorKind === ts.SyntaxKind.QuestionQuestionToken
 	) {
-		return transformLogical(state, node);
+		return transformLogical(state, prereqs, node);
 	}
 
 	if (ts.isLogicalOrCoalescingAssignmentExpression(node)) {
-		return transformLogicalOrCoalescingAssignmentExpression(state, node);
+		return transformLogicalOrCoalescingAssignmentExpression(state, prereqs, node);
 	}
 
 	if (ts.isAssignmentOperator(operatorKind)) {
 		// in destructuring, rhs must be executed first
 		if (ts.isArrayLiteralExpression(node.left)) {
-			const rightExp = transformExpression(state, node.right);
+			const rightExp = transformExpression(state, prereqs, node.right);
 
 			// optimize empty array destructure
 			if (node.left.elements.length === 0) {
@@ -158,7 +157,7 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 				isLuaTupleType(state)(state.getType(node.right)) &&
 				!arrayLikeExpressionContainsSpread(node.left)
 			) {
-				transformOptimizedArrayAssignmentPattern(state, node.left, rightExp);
+				transformOptimizedArrayAssignmentPattern(state, prereqs, node.left, rightExp);
 				if (!isUsedAsStatement(node)) {
 					DiagnosticService.addDiagnostic(errors.noLuaTupleDestructureAssignmentExpression(node));
 				}
@@ -171,15 +170,15 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 				isUsedAsStatement(node) &&
 				!arrayLikeExpressionContainsSpread(node.left)
 			) {
-				transformOptimizedArrayAssignmentPattern(state, node.left, rightExp.members);
+				transformOptimizedArrayAssignmentPattern(state, prereqs, node.left, rightExp.members);
 				return luau.none();
 			}
 
-			const parentId = state.pushToVar(rightExp, "binding");
-			transformArrayAssignmentPattern(state, node.left, parentId);
+			const parentId = prereqs.pushToVar(rightExp, "binding");
+			transformArrayAssignmentPattern(state, prereqs, node.left, parentId);
 			return parentId;
 		} else if (ts.isObjectLiteralExpression(node.left)) {
-			const rightExp = transformExpression(state, node.right);
+			const rightExp = transformExpression(state, prereqs, node.right);
 
 			// optimize empty object destructure
 			if (node.left.properties.length === 0) {
@@ -189,8 +188,8 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 				return rightExp;
 			}
 
-			const parentId = state.pushToVar(rightExp, "binding");
-			transformObjectAssignmentPattern(state, node.left, parentId);
+			const parentId = prereqs.pushToVar(rightExp, "binding");
+			transformObjectAssignmentPattern(state, prereqs, node.left, parentId);
 			return parentId;
 		}
 
@@ -199,6 +198,7 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 		const operator = getSimpleAssignmentOperator(writableType, operatorKind as ts.AssignmentOperator, valueType);
 		const { writable, readable, value } = transformWritableAssignment(
 			state,
+			prereqs,
 			node.left,
 			node.right,
 			true,
@@ -206,7 +206,7 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 		);
 		if (operator !== undefined) {
 			return createAssignmentExpression(
-				state,
+				prereqs,
 				writable,
 				operator,
 				getAssignableValue(operator, value, valueType),
@@ -214,8 +214,7 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 			);
 		} else {
 			return createCompoundAssignmentExpression(
-				state,
-				node,
+				prereqs,
 				writable,
 				writableType,
 				readable,
@@ -227,10 +226,10 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 	}
 
 	if (isBitwiseOperator(operatorKind)) {
-		return createBitwiseFromOperator(state, operatorKind, node);
+		return createBitwiseFromOperator(state, prereqs, operatorKind, node);
 	}
 
-	const [left, right] = ensureTransformOrder(state, [node.left, node.right]);
+	const [left, right] = ensureTransformOrder(state, prereqs, [node.left, node.right]);
 
 	if (operatorKind === ts.SyntaxKind.InKeyword) {
 		return luau.binary(
@@ -265,5 +264,5 @@ export function transformBinaryExpression(state: TransformState, node: ts.Binary
 		}
 	}
 
-	return createBinaryFromOperator(state, node, left, leftType, operatorKind, right, rightType);
+	return createBinaryFromOperator(prereqs, left, leftType, operatorKind, right, rightType);
 }

--- a/src/TSTransformer/nodes/expressions/transformBinaryExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformBinaryExpression.ts
@@ -22,7 +22,6 @@ import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexa
 import { createBinaryFromOperator } from "TSTransformer/util/createBinaryFromOperator";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { getAssignableValue } from "TSTransformer/util/getAssignableValue";
-import { getKindName } from "TSTransformer/util/getKindName";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import { skipDownwards } from "TSTransformer/util/traversal";
 import {
@@ -49,9 +48,9 @@ function transformOptimizedArrayAssignmentPattern(
 	for (let element of assignmentPattern.elements) {
 		if (ts.isOmittedExpression(element)) {
 			luau.list.push(writes, luau.tempId());
-		} else if (ts.isSpreadElement(element)) {
-			assert(false, "Cannot optimize-assign spread element");
 		} else {
+			// callers only select this optimization for patterns without spread elements
+			assert(!ts.isSpreadElement(element), "Cannot optimize-assign spread element");
 			let initializer: ts.Expression | undefined;
 			if (ts.isBinaryExpression(element)) {
 				initializer = skipDownwards(element.right);
@@ -78,7 +77,8 @@ function transformOptimizedArrayAssignmentPattern(
 					bindingPrereqs.push(transformInitializer(state, id, initializer));
 				}
 				transformArrayAssignmentPattern(state, bindingPrereqs, element, id);
-			} else if (ts.isObjectLiteralExpression(element)) {
+			} else {
+				assert(ts.isObjectLiteralExpression(element), "Expected object assignment pattern");
 				const id = luau.tempId("binding");
 				luau.list.push(variables, id);
 				luau.list.push(writes, id);
@@ -86,8 +86,6 @@ function transformOptimizedArrayAssignmentPattern(
 					bindingPrereqs.push(transformInitializer(state, id, initializer));
 				}
 				transformObjectAssignmentPattern(state, bindingPrereqs, element, id);
-			} else {
-				assert(false, `transformOptimizedArrayAssignmentPattern invalid element: ${getKindName(element.kind)}`);
 			}
 		}
 	}

--- a/src/TSTransformer/nodes/expressions/transformCallExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformCallExpression.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformImportExpression } from "TSTransformer/nodes/expressions/transformImportExpression";
 import { transformMacroCall } from "TSTransformer/nodes/transformMacroCall";
@@ -47,6 +48,7 @@ function fixVoidArgumentsForRobloxFunctions(
 
 export function transformCallExpressionInner(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.CallExpression,
 	expression: luau.Expression,
 	nodeArguments: ReadonlyArray<ts.Expression>,
@@ -61,7 +63,7 @@ export function transformCallExpressionInner(
 	if (ts.isSuperCall(node)) {
 		return luau.call(luau.property(convertToIndexableExpression(expression), "constructor"), [
 			luau.globals.self,
-			...ensureTransformOrder(state, node.arguments),
+			...ensureTransformOrder(state, prereqs, node.arguments),
 		]);
 	}
 
@@ -70,17 +72,18 @@ export function transformCallExpressionInner(
 	if (symbol) {
 		const macro = state.services.macroManager.getCallMacro(symbol);
 		if (macro) {
-			return transformMacroCall(macro, state, node, expression, nodeArguments);
+			return transformMacroCall(macro, state, prereqs, node, expression, nodeArguments);
 		}
 	}
 
-	const [args, prereqs] = state.capture(() => ensureTransformOrder(state, nodeArguments));
+	const argsPrereqs = new Prereqs();
+	const args = ensureTransformOrder(state, argsPrereqs, nodeArguments);
 	fixVoidArgumentsForRobloxFunctions(state, expType, args, nodeArguments);
 
-	if (!effectsCommute(getEffects(expression), getEffects(prereqs))) {
-		expression = state.pushToVar(expression, "fn");
+	if (!effectsCommute(getEffects(expression), getEffects(argsPrereqs.statements))) {
+		expression = prereqs.pushToVar(expression, "fn");
 	}
-	state.prereqList(prereqs);
+	prereqs.pushList(argsPrereqs.statements);
 
 	const exp = luau.call(convertToIndexableExpression(expression), args);
 
@@ -89,11 +92,12 @@ export function transformCallExpressionInner(
 
 function createOrderedPropertyCall(
 	state: TransformState,
+	prereqs: Prereqs,
 	source: ts.PropertyAccessExpression | ts.ElementAccessExpression,
 	base: luau.Expression,
 	key: string | luau.Expression,
 	args: Array<luau.Expression>,
-	prereqs: luau.List<luau.Statement>,
+	prereqStatements: luau.List<luau.Statement>,
 	method: boolean,
 ) {
 	const property = () => {
@@ -107,7 +111,7 @@ function createOrderedPropertyCall(
 		tryMarkBuiltinMember(state, source, expression);
 		return expression;
 	};
-	const prereqEffects = getEffects(prereqs);
+	const prereqEffects = getEffects(prereqStatements);
 	const name = typeof key === "string" ? key : luau.isStringLiteral(key) ? key.value : undefined;
 	const stableMethod = method && isStableBuiltinMember(state, source);
 	let callee: luau.IndexableExpression = property();
@@ -121,9 +125,9 @@ function createOrderedPropertyCall(
 	) {
 		// a stable method lookup can stay inline even when its receiver needs a snapshot
 		if (stableMethod && !effectsCommute(getEffects(base), prereqEffects)) {
-			base = state.pushToVar(base, "self");
+			base = prereqs.pushToVar(base, "self");
 		}
-		state.prereqList(prereqs);
+		prereqs.pushList(prereqStatements);
 		return luau.create(luau.SyntaxKind.MethodCallExpression, {
 			expression: convertToIndexableExpression(base),
 			name,
@@ -135,18 +139,19 @@ function createOrderedPropertyCall(
 		method &&
 		(!luau.isSimple(base) || !effectsCommute(getEffects(base), joinEffects(lookupEffects, prereqEffects)))
 	) {
-		base = state.pushToVar(base, "self");
+		base = prereqs.pushToVar(base, "self");
 		callee = property();
 	}
 	if (captureCallee) {
-		callee = state.pushToVar(callee, "fn");
+		callee = prereqs.pushToVar(callee, "fn");
 	}
-	state.prereqList(prereqs);
+	prereqs.pushList(prereqStatements);
 	return luau.call(callee, method ? [base, ...args] : args);
 }
 
 export function transformPropertyCallExpressionInner(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.CallExpression,
 	expression: ts.PropertyAccessExpression,
 	baseExpression: luau.Expression,
@@ -161,7 +166,7 @@ export function transformPropertyCallExpressionInner(
 	if (ts.isSuperProperty(expression)) {
 		return luau.call(luau.property(convertToIndexableExpression(baseExpression), expression.name.text), [
 			luau.globals.self,
-			...ensureTransformOrder(state, node.arguments),
+			...ensureTransformOrder(state, prereqs, node.arguments),
 		]);
 	}
 
@@ -170,20 +175,22 @@ export function transformPropertyCallExpressionInner(
 	if (symbol) {
 		const macro = state.services.macroManager.getPropertyCallMacro(symbol);
 		if (macro) {
-			return transformMacroCall(macro, state, node, baseExpression, nodeArguments);
+			return transformMacroCall(macro, state, prereqs, node, baseExpression, nodeArguments);
 		}
 	}
 
-	const [args, prereqs] = state.capture(() => ensureTransformOrder(state, nodeArguments));
+	const argsPrereqs = new Prereqs();
+	const args = ensureTransformOrder(state, argsPrereqs, nodeArguments);
 	fixVoidArgumentsForRobloxFunctions(state, expType, args, nodeArguments);
 
 	const exp = createOrderedPropertyCall(
 		state,
+		prereqs,
 		expression,
 		baseExpression,
 		name,
 		args,
-		prereqs,
+		argsPrereqs.statements,
 		isMethod(state, expression),
 	);
 	return wrapReturnIfLuaTuple(state, node, exp);
@@ -191,6 +198,7 @@ export function transformPropertyCallExpressionInner(
 
 export function transformElementCallExpressionInner(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.CallExpression,
 	expression: ts.ElementAccessExpression,
 	baseExpression: luau.Expression,
@@ -208,9 +216,9 @@ export function transformElementCallExpressionInner(
 		return luau.call(
 			luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 				expression: convertToIndexableExpression(baseExpression),
-				index: transformExpression(state, expression.argumentExpression),
+				index: transformExpression(state, prereqs, expression.argumentExpression),
 			}),
-			[luau.globals.self, ...ensureTransformOrder(state, node.arguments)],
+			[luau.globals.self, ...ensureTransformOrder(state, prereqs, node.arguments)],
 		);
 	}
 
@@ -219,21 +227,26 @@ export function transformElementCallExpressionInner(
 	if (symbol) {
 		const macro = state.services.macroManager.getPropertyCallMacro(symbol);
 		if (macro) {
-			return transformMacroCall(macro, state, node, baseExpression, nodeArguments);
+			return transformMacroCall(macro, state, prereqs, node, baseExpression, nodeArguments);
 		}
 	}
 
-	const [argumentExp, keyPrereqs] = state.capture(() => transformExpression(state, argumentExpression));
+	const keyPrereqs = new Prereqs();
+	const argumentExp = transformExpression(state, keyPrereqs, argumentExpression);
 	if (
 		!effectsCommute(
 			getEffects(baseExpression),
-			joinEffects(getEffects(keyPrereqs), isLateRead(baseExpression) ? getEffects(argumentExp) : NO_EFFECTS),
+			joinEffects(
+				getEffects(keyPrereqs.statements),
+				isLateRead(baseExpression) ? getEffects(argumentExp) : NO_EFFECTS,
+			),
 		)
 	) {
-		baseExpression = state.pushToVar(baseExpression, "exp");
+		baseExpression = prereqs.pushToVar(baseExpression, "exp");
 	}
-	state.prereqList(keyPrereqs);
-	const [args, prereqs] = state.capture(() => ensureTransformOrder(state, nodeArguments));
+	prereqs.pushList(keyPrereqs.statements);
+	const argsPrereqs = new Prereqs();
+	const args = ensureTransformOrder(state, argsPrereqs, nodeArguments);
 	fixVoidArgumentsForRobloxFunctions(state, expType, args, nodeArguments);
 	const key = addOneIfArrayType(
 		state,
@@ -242,16 +255,17 @@ export function transformElementCallExpressionInner(
 	);
 	const exp = createOrderedPropertyCall(
 		state,
+		prereqs,
 		expression,
 		baseExpression,
 		key,
 		args,
-		prereqs,
+		argsPrereqs.statements,
 		isMethod(state, expression),
 	);
 	return wrapReturnIfLuaTuple(state, node, exp);
 }
 
-export function transformCallExpression(state: TransformState, node: ts.CallExpression) {
-	return transformOptionalChain(state, node);
+export function transformCallExpression(state: TransformState, prereqs: Prereqs, node: ts.CallExpression) {
+	return transformOptionalChain(state, prereqs, node);
 }

--- a/src/TSTransformer/nodes/expressions/transformClassExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformClassExpression.ts
@@ -1,9 +1,10 @@
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformClassLikeDeclaration } from "TSTransformer/nodes/class/transformClassLikeDeclaration";
 import ts from "typescript";
 
-export function transformClassExpression(state: TransformState, node: ts.ClassExpression) {
+export function transformClassExpression(state: TransformState, prereqs: Prereqs, node: ts.ClassExpression) {
 	const { statements, name } = transformClassLikeDeclaration(state, node);
-	state.prereqList(statements);
+	prereqs.pushList(statements);
 	return name;
 }

--- a/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformConditionalExpression.ts
@@ -1,47 +1,53 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { createTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import { wrapExpressionStatement } from "TSTransformer/util/wrapExpressionStatement";
 import ts from "typescript";
 
-export function transformConditionalExpression(state: TransformState, node: ts.ConditionalExpression) {
-	const condition = transformExpression(state, node.condition);
-	const [whenTrue, whenTruePrereqs] = state.capture(() => transformExpression(state, node.whenTrue));
-	const [whenFalse, whenFalsePrereqs] = state.capture(() => transformExpression(state, node.whenFalse));
+export function transformConditionalExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.ConditionalExpression,
+) {
+	const condition = transformExpression(state, prereqs, node.condition);
+	const whenTruePrereqs = new Prereqs();
+	const whenTrue = transformExpression(state, whenTruePrereqs, node.whenTrue);
+	const whenFalsePrereqs = new Prereqs();
+	const whenFalse = transformExpression(state, whenFalsePrereqs, node.whenFalse);
 
 	if (isUsedAsStatement(node)) {
-		luau.list.pushList(whenTruePrereqs, wrapExpressionStatement(whenTrue));
-		luau.list.pushList(whenFalsePrereqs, wrapExpressionStatement(whenFalse));
-		state.prereq(
+		whenTruePrereqs.pushList(wrapExpressionStatement(whenTrue));
+		whenFalsePrereqs.pushList(wrapExpressionStatement(whenFalse));
+		prereqs.push(
 			luau.create(luau.SyntaxKind.IfStatement, {
-				condition: createTruthinessChecks(state, condition, node.condition),
-				statements: whenTruePrereqs,
-				elseBody: whenFalsePrereqs,
+				condition: createTruthinessChecks(state, prereqs, condition, node.condition),
+				statements: whenTruePrereqs.statements,
+				elseBody: whenFalsePrereqs.statements,
 			}),
 		);
 		return luau.none();
 	}
 
-	if (luau.list.isEmpty(whenTruePrereqs) && luau.list.isEmpty(whenFalsePrereqs)) {
+	if (luau.list.isEmpty(whenTruePrereqs.statements) && luau.list.isEmpty(whenFalsePrereqs.statements)) {
 		return luau.create(luau.SyntaxKind.IfExpression, {
-			condition: createTruthinessChecks(state, condition, node.condition),
+			condition: createTruthinessChecks(state, prereqs, condition, node.condition),
 			expression: whenTrue,
 			alternative: whenFalse,
 		});
 	}
 
 	const tempId = luau.tempId("result");
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.VariableDeclaration, {
 			left: tempId,
 			right: undefined,
 		}),
 	);
 
-	luau.list.push(
-		whenTruePrereqs,
+	whenTruePrereqs.push(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: tempId,
 			operator: "=",
@@ -49,8 +55,7 @@ export function transformConditionalExpression(state: TransformState, node: ts.C
 		}),
 	);
 
-	luau.list.push(
-		whenFalsePrereqs,
+	whenFalsePrereqs.push(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: tempId,
 			operator: "=",
@@ -58,11 +63,11 @@ export function transformConditionalExpression(state: TransformState, node: ts.C
 		}),
 	);
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.IfStatement, {
-			condition: createTruthinessChecks(state, condition, node.condition),
-			statements: whenTruePrereqs,
-			elseBody: whenFalsePrereqs,
+			condition: createTruthinessChecks(state, prereqs, condition, node.condition),
+			statements: whenTruePrereqs.statements,
+			elseBody: whenFalsePrereqs.statements,
 		}),
 	);
 

--- a/src/TSTransformer/nodes/expressions/transformDeleteExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformDeleteExpression.ts
@@ -1,11 +1,12 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import ts from "typescript";
 
-export function transformDeleteExpression(state: TransformState, node: ts.DeleteExpression) {
+export function transformDeleteExpression(state: TransformState, prereqs: Prereqs, node: ts.DeleteExpression) {
 	// we just want the prereqs, deleting is done in the index expression transforms
-	transformExpression(state, node.expression);
+	transformExpression(state, prereqs, node.expression);
 	return !isUsedAsStatement(node) ? luau.bool(true) : luau.none();
 }

--- a/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformElementAccessExpression.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformOptionalChain } from "TSTransformer/nodes/transformOptionalChain";
 import { addIndexDiagnostics } from "TSTransformer/util/addIndexDiagnostics";
@@ -16,6 +17,7 @@ import ts from "typescript";
 
 export function transformElementAccessExpressionInner(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.ElementAccessExpression,
 	expression: luau.Expression,
 	argumentExpression: ts.Expression,
@@ -28,12 +30,13 @@ export function transformElementAccessExpressionInner(
 	const expType = state.typeChecker.getNonOptionalType(state.getType(node.expression));
 	addIndexDiagnostics(state, node, expType);
 
-	const [index, prereqs] = state.capture(() => transformExpression(state, argumentExpression));
+	const indexPrereqs = new Prereqs();
+	const index = transformExpression(state, indexPrereqs, argumentExpression);
 
 	if (
 		!effectsCommute(
 			getEffects(expression),
-			joinEffects(getEffects(prereqs), isLateRead(expression) ? getEffects(index) : NO_EFFECTS),
+			joinEffects(getEffects(indexPrereqs.statements), isLateRead(expression) ? getEffects(index) : NO_EFFECTS),
 		)
 	) {
 		// hack because wrapReturnIfLuaTuple will not wrap this, but now we need to!
@@ -41,9 +44,9 @@ export function transformElementAccessExpressionInner(
 			expression = luau.array([expression]);
 		}
 
-		expression = state.pushToVar(expression, "exp");
+		expression = prereqs.pushToVar(expression, "exp");
 	}
-	state.prereqList(prereqs);
+	prereqs.pushList(indexPrereqs.statements);
 
 	// LuaTuple<T> checks
 	if (luau.isCall(expression) && isLuaTupleType(state)(expType)) {
@@ -56,7 +59,7 @@ export function transformElementAccessExpressionInner(
 	}
 
 	if (ts.isDeleteExpression(skipUpwards(node).parent)) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: convertToIndexableExpression(expression),
@@ -77,11 +80,15 @@ export function transformElementAccessExpressionInner(
 	return access;
 }
 
-export function transformElementAccessExpression(state: TransformState, node: ts.ElementAccessExpression) {
+export function transformElementAccessExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.ElementAccessExpression,
+) {
 	const constantValue = getConstantValueLiteral(state, node);
 	if (constantValue) {
 		return constantValue;
 	}
 
-	return transformOptionalChain(state, node);
+	return transformOptionalChain(state, prereqs, node);
 }

--- a/src/TSTransformer/nodes/expressions/transformExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformExpression.ts
@@ -4,6 +4,7 @@ import { assert } from "Shared/util/assert";
 import { getOrSetDefault } from "Shared/util/getOrSetDefault";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayLiteralExpression } from "TSTransformer/nodes/expressions/transformArrayLiteralExpression";
 import { transformAwaitExpression } from "TSTransformer/nodes/expressions/transformAwaitExpression";
 import { transformBinaryExpression } from "TSTransformer/nodes/expressions/transformBinaryExpression";
@@ -42,11 +43,12 @@ import { transformYieldExpression } from "TSTransformer/nodes/expressions/transf
 import { markPrimitiveValue } from "TSTransformer/util/evaluation/facts";
 import { getKindName } from "TSTransformer/util/getKindName";
 import { isBooleanType, isDefinitelyType, isNumberType, isStringType, isUndefinedType } from "TSTransformer/util/types";
+import { withoutPrereqs } from "TSTransformer/util/withoutPrereqs";
 import ts from "typescript";
 
 const NO_EMIT = () => luau.none();
 
-const DIAGNOSTIC = (factory: DiagnosticFactory) => (state: TransformState, node: ts.Expression) => {
+const DIAGNOSTIC = (factory: DiagnosticFactory) => (state: TransformState, prereqs: Prereqs, node: ts.Expression) => {
 	DiagnosticService.addDiagnostic(factory(node));
 	return NO_EMIT();
 };
@@ -54,8 +56,8 @@ const DIAGNOSTIC = (factory: DiagnosticFactory) => (state: TransformState, node:
 type Validate<T> = {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- typecheck only works with `any`
 	[k in keyof T]: T[k] extends [infer Kind, infer C extends (...args: any) => unknown]
-		? "kind" extends keyof Parameters<C>[1]
-			? Kind extends Parameters<C>[1]["kind"]
+		? "kind" extends keyof Parameters<C>[2]
+			? Kind extends Parameters<C>[2]["kind"]
 				? T[k]
 				: never
 			: T[k]
@@ -64,9 +66,14 @@ type Validate<T> = {
 
 function createTransformerMap<
 	T extends Array<
-		[ts.SyntaxKind, { bivariant(state: TransformState, exp: ts.Expression): luau.Expression }["bivariant"]]
+		[
+			ts.SyntaxKind,
+			{ bivariant(state: TransformState, prereqs: Prereqs, exp: ts.Expression): luau.Expression }["bivariant"],
+		]
 	>,
->(values: Validate<[...T]>): Map<ts.SyntaxKind, (state: TransformState, exp: ts.Expression) => luau.Expression> {
+>(
+	values: Validate<[...T]>,
+): Map<ts.SyntaxKind, (state: TransformState, prereqs: Prereqs, exp: ts.Expression) => luau.Expression> {
 	return new Map(values);
 }
 
@@ -83,7 +90,7 @@ const TRANSFORMER_BY_KIND = createTransformerMap([
 
 	// regular transforms
 	[ts.SyntaxKind.ArrayLiteralExpression, transformArrayLiteralExpression],
-	[ts.SyntaxKind.ArrowFunction, transformFunctionExpression],
+	[ts.SyntaxKind.ArrowFunction, withoutPrereqs(transformFunctionExpression)],
 	[ts.SyntaxKind.AsExpression, transformTypeExpression],
 	[ts.SyntaxKind.AwaitExpression, transformAwaitExpression],
 	[ts.SyntaxKind.BinaryExpression, transformBinaryExpression],
@@ -94,16 +101,16 @@ const TRANSFORMER_BY_KIND = createTransformerMap([
 	[ts.SyntaxKind.ElementAccessExpression, transformElementAccessExpression],
 	[ts.SyntaxKind.ExpressionWithTypeArguments, transformTypeExpression],
 	[ts.SyntaxKind.FalseKeyword, transformFalseKeyword],
-	[ts.SyntaxKind.FunctionExpression, transformFunctionExpression],
-	[ts.SyntaxKind.Identifier, transformIdentifier],
+	[ts.SyntaxKind.FunctionExpression, withoutPrereqs(transformFunctionExpression)],
+	[ts.SyntaxKind.Identifier, withoutPrereqs(transformIdentifier)],
 	[ts.SyntaxKind.JsxElement, transformJsxElement],
 	[ts.SyntaxKind.JsxExpression, transformJsxExpression],
 	[ts.SyntaxKind.JsxFragment, transformJsxFragment],
 	[ts.SyntaxKind.JsxSelfClosingElement, transformJsxSelfClosingElement],
 	[ts.SyntaxKind.NewExpression, transformNewExpression],
 	[ts.SyntaxKind.NonNullExpression, transformTypeExpression],
-	[ts.SyntaxKind.NoSubstitutionTemplateLiteral, transformNoSubstitutionTemplateLiteral],
-	[ts.SyntaxKind.NumericLiteral, transformNumericLiteral],
+	[ts.SyntaxKind.NoSubstitutionTemplateLiteral, withoutPrereqs(transformNoSubstitutionTemplateLiteral)],
+	[ts.SyntaxKind.NumericLiteral, withoutPrereqs(transformNumericLiteral)],
 	[ts.SyntaxKind.ObjectLiteralExpression, transformObjectLiteralExpression],
 	[ts.SyntaxKind.OmittedExpression, transformOmittedExpression],
 	[ts.SyntaxKind.ParenthesizedExpression, transformParenthesizedExpression],
@@ -112,21 +119,21 @@ const TRANSFORMER_BY_KIND = createTransformerMap([
 	[ts.SyntaxKind.PropertyAccessExpression, transformPropertyAccessExpression],
 	[ts.SyntaxKind.SatisfiesExpression, transformTypeExpression],
 	[ts.SyntaxKind.SpreadElement, transformSpreadElement],
-	[ts.SyntaxKind.StringLiteral, transformStringLiteral],
+	[ts.SyntaxKind.StringLiteral, withoutPrereqs(transformStringLiteral)],
 	[ts.SyntaxKind.SuperKeyword, transformSuperKeyword],
 	[ts.SyntaxKind.TaggedTemplateExpression, transformTaggedTemplateExpression],
 	[ts.SyntaxKind.TemplateExpression, transformTemplateExpression],
-	[ts.SyntaxKind.ThisKeyword, transformThisExpression],
+	[ts.SyntaxKind.ThisKeyword, withoutPrereqs(transformThisExpression)],
 	[ts.SyntaxKind.TrueKeyword, transformTrueKeyword],
 	[ts.SyntaxKind.TypeAssertionExpression, transformTypeExpression],
 	[ts.SyntaxKind.VoidExpression, transformVoidExpression],
 	[ts.SyntaxKind.YieldExpression, transformYieldExpression],
 ]);
 
-export function transformExpression(state: TransformState, node: ts.Expression): luau.Expression {
+export function transformExpression(state: TransformState, prereqs: Prereqs, node: ts.Expression): luau.Expression {
 	const transformer = TRANSFORMER_BY_KIND.get(node.kind);
 	if (transformer) {
-		const expression = transformer(state, node);
+		const expression = transformer(state, prereqs, node);
 		const type = state.getType(node);
 		if (
 			getOrSetDefault(state.multiTransformState.isPrimitiveTypeCache, type, () =>

--- a/src/TSTransformer/nodes/expressions/transformFunctionExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformFunctionExpression.ts
@@ -21,9 +21,7 @@ export function transformFunctionExpression(state: TransformState, node: ts.Func
 	if (ts.isFunctionBody(body)) {
 		luau.list.pushList(statements, transformStatementList(state, body, body.statements));
 	} else {
-		const [returnStatements, prereqs] = state.capture(() => transformReturnStatementInner(state, body));
-		luau.list.pushList(statements, prereqs);
-		luau.list.pushList(statements, returnStatements);
+		luau.list.pushList(statements, transformReturnStatementInner(state, body));
 	}
 
 	const isAsync = ts.hasSyntacticModifier(node, ts.ModifierFlags.Async);

--- a/src/TSTransformer/nodes/expressions/transformJsxElement.ts
+++ b/src/TSTransformer/nodes/expressions/transformJsxElement.ts
@@ -1,7 +1,15 @@
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformJsx } from "TSTransformer/nodes/jsx/transformJsx";
 import ts from "typescript";
 
-export function transformJsxElement(state: TransformState, node: ts.JsxElement) {
-	return transformJsx(state, node, node.openingElement.tagName, node.openingElement.attributes, node.children);
+export function transformJsxElement(state: TransformState, prereqs: Prereqs, node: ts.JsxElement) {
+	return transformJsx(
+		state,
+		prereqs,
+		node,
+		node.openingElement.tagName,
+		node.openingElement.attributes,
+		node.children,
+	);
 }

--- a/src/TSTransformer/nodes/expressions/transformJsxExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformJsxExpression.ts
@@ -1,11 +1,12 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import ts from "typescript";
 
-export function transformJsxExpression(state: TransformState, node: ts.JsxExpression) {
+export function transformJsxExpression(state: TransformState, prereqs: Prereqs, node: ts.JsxExpression) {
 	if (node.expression) {
-		const expression = transformExpression(state, node.expression);
+		const expression = transformExpression(state, prereqs, node.expression);
 		if (node.dotDotDotToken) {
 			return luau.call(luau.globals.unpack, [expression]);
 		}

--- a/src/TSTransformer/nodes/expressions/transformJsxFragment.ts
+++ b/src/TSTransformer/nodes/expressions/transformJsxFragment.ts
@@ -1,12 +1,13 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformJsxChildren } from "TSTransformer/nodes/jsx/transformJsxChildren";
 import { transformEntityName } from "TSTransformer/nodes/transformEntityName";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import ts from "typescript";
 
-export function transformJsxFragment(state: TransformState, node: ts.JsxFragment) {
+export function transformJsxFragment(state: TransformState, prereqs: Prereqs, node: ts.JsxFragment) {
 	const jsxFactoryEntity = state.resolver.getJsxFactoryEntity(node);
 	assert(jsxFactoryEntity, "Expected jsxFactoryEntity to be defined");
 
@@ -21,7 +22,7 @@ export function transformJsxFragment(state: TransformState, node: ts.JsxFragment
 
 	const args = [transformEntityName(state, jsxFragmentFactoryEntity)];
 
-	const transformedChildren = transformJsxChildren(state, node.children);
+	const transformedChildren = transformJsxChildren(state, prereqs, node.children);
 
 	// props parameter
 	if (transformedChildren.length > 0) {

--- a/src/TSTransformer/nodes/expressions/transformJsxSelfClosingElement.ts
+++ b/src/TSTransformer/nodes/expressions/transformJsxSelfClosingElement.ts
@@ -1,7 +1,12 @@
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformJsx } from "TSTransformer/nodes/jsx/transformJsx";
 import ts from "typescript";
 
-export function transformJsxSelfClosingElement(state: TransformState, node: ts.JsxSelfClosingElement) {
-	return transformJsx(state, node, node.tagName, node.attributes, []);
+export function transformJsxSelfClosingElement(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.JsxSelfClosingElement,
+) {
+	return transformJsx(state, prereqs, node, node.tagName, node.attributes, []);
 }

--- a/src/TSTransformer/nodes/expressions/transformNewExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformNewExpression.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
@@ -7,18 +8,18 @@ import { getFirstConstructSymbol } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 import ts from "typescript";
 
-export function transformNewExpression(state: TransformState, node: ts.NewExpression) {
+export function transformNewExpression(state: TransformState, prereqs: Prereqs, node: ts.NewExpression) {
 	validateNotAnyType(state, node.expression);
 
 	const symbol = getFirstConstructSymbol(state, node.expression);
 	if (symbol) {
 		const macro = state.services.macroManager.getConstructorMacro(symbol);
 		if (macro) {
-			return macro(state, node);
+			return macro(state, prereqs, node);
 		}
 	}
 
-	const expression = convertToIndexableExpression(transformExpression(state, node.expression));
-	const args = node.arguments ? ensureTransformOrder(state, node.arguments) : [];
+	const expression = convertToIndexableExpression(transformExpression(state, prereqs, node.expression));
+	const args = node.arguments ? ensureTransformOrder(state, prereqs, node.arguments) : [];
 	return luau.call(luau.property(expression, "new"), args);
 }

--- a/src/TSTransformer/nodes/expressions/transformObjectLiteralExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformObjectLiteralExpression.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformMethodDeclaration } from "TSTransformer/nodes/transformMethodDeclaration";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
@@ -13,25 +14,33 @@ import ts from "typescript";
 
 function transformPropertyAssignment(
 	state: TransformState,
+	prereqs: Prereqs,
 	ptr: MapPointer,
 	name: ts.PropertyName,
 	initializer: ts.Expression,
 ) {
-	let [left, leftPrereqs] = state.capture(() => transformPropertyName(state, name));
-	const [right, rightPrereqs] = state.capture(() => transformExpression(state, initializer));
+	const leftPrereqs = new Prereqs();
+	let left = transformPropertyName(state, leftPrereqs, name);
+	const rightPrereqs = new Prereqs();
+	const right = transformExpression(state, rightPrereqs, initializer);
 
-	if (!luau.list.isEmpty(leftPrereqs) || !luau.list.isEmpty(rightPrereqs)) {
-		disableMapInline(state, ptr);
-		state.prereqList(leftPrereqs);
-		left = state.pushToVar(left, "left");
+	if (!luau.list.isEmpty(leftPrereqs.statements) || !luau.list.isEmpty(rightPrereqs.statements)) {
+		disableMapInline(prereqs, ptr);
+		prereqs.pushList(leftPrereqs.statements);
+		left = prereqs.pushToVar(left, "left");
 	}
 
-	state.prereqList(rightPrereqs);
+	prereqs.pushList(rightPrereqs.statements);
 
-	assignToMapPointer(state, ptr, left, right);
+	assignToMapPointer(prereqs, ptr, left, right);
 }
 
-function transformSpreadAssignment(state: TransformState, ptr: MapPointer, property: ts.SpreadAssignment) {
+function transformSpreadAssignment(
+	state: TransformState,
+	prereqs: Prereqs,
+	ptr: MapPointer,
+	property: ts.SpreadAssignment,
+) {
 	const expType = state.typeChecker.getNonOptionalType(state.getType(property.expression));
 	const symbol = getFirstDefinedSymbol(state, expType);
 	if (symbol && state.services.macroManager.isMacroOnlyClass(symbol)) {
@@ -42,11 +51,11 @@ function transformSpreadAssignment(state: TransformState, ptr: MapPointer, prope
 	const definitelyObject = isDefinitelyType(type, isObjectType);
 
 	if (definitelyObject && luau.isMap(ptr.value) && luau.list.isEmpty(ptr.value.fields)) {
-		ptr.value = state.pushToVar(
-			luau.call(luau.globals.table.clone, [transformExpression(state, property.expression)]),
+		ptr.value = prereqs.pushToVar(
+			luau.call(luau.globals.table.clone, [transformExpression(state, prereqs, property.expression)]),
 			ptr.name,
 		);
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				// Explicitly remove metatable because things like classes can be spread
 				expression: luau.call(luau.globals.setmetatable, [ptr.value, luau.nil()]),
@@ -55,10 +64,10 @@ function transformSpreadAssignment(state: TransformState, ptr: MapPointer, prope
 		return;
 	}
 
-	disableMapInline(state, ptr);
-	let spreadExp = transformExpression(state, property.expression);
+	disableMapInline(prereqs, ptr);
+	let spreadExp = transformExpression(state, prereqs, property.expression);
 	if (!definitelyObject) {
-		spreadExp = state.pushToVarIfComplex(spreadExp, "spread");
+		spreadExp = prereqs.pushToVarIfComplex(spreadExp, "spread");
 	}
 
 	const keyId = luau.tempId("k");
@@ -80,16 +89,20 @@ function transformSpreadAssignment(state: TransformState, ptr: MapPointer, prope
 
 	if (!definitelyObject) {
 		statement = luau.create(luau.SyntaxKind.IfStatement, {
-			condition: createTruthinessChecks(state, spreadExp, property.expression),
+			condition: createTruthinessChecks(state, prereqs, spreadExp, property.expression),
 			statements: luau.list.make(statement),
 			elseBody: luau.list.make(),
 		});
 	}
 
-	state.prereq(statement);
+	prereqs.push(statement);
 }
 
-export function transformObjectLiteralExpression(state: TransformState, node: ts.ObjectLiteralExpression) {
+export function transformObjectLiteralExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.ObjectLiteralExpression,
+) {
 	// starts as luau.Map, becomes luau.TemporaryIdentifier when `disableInline` is called
 	const ptr = createMapPointer("object");
 	for (const property of node.properties) {
@@ -99,13 +112,13 @@ export function transformObjectLiteralExpression(state: TransformState, node: ts
 				DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(property.name));
 				continue;
 			}
-			transformPropertyAssignment(state, ptr, property.name, property.initializer);
+			transformPropertyAssignment(state, prereqs, ptr, property.name, property.initializer);
 		} else if (ts.isShorthandPropertyAssignment(property)) {
-			transformPropertyAssignment(state, ptr, property.name, property.name);
+			transformPropertyAssignment(state, prereqs, ptr, property.name, property.name);
 		} else if (ts.isSpreadAssignment(property)) {
-			transformSpreadAssignment(state, ptr, property);
+			transformSpreadAssignment(state, prereqs, ptr, property);
 		} else if (ts.isMethodDeclaration(property)) {
-			state.prereqList(transformMethodDeclaration(state, property, ptr));
+			prereqs.pushList(transformMethodDeclaration(state, prereqs, property, ptr));
 		} else {
 			// must be ts.AccessorDeclaration, which is banned
 			DiagnosticService.addDiagnostic(errors.noGetterSetter(property));

--- a/src/TSTransformer/nodes/expressions/transformParenthesizedExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformParenthesizedExpression.ts
@@ -1,11 +1,16 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { skipDownwards } from "TSTransformer/util/traversal";
 import ts from "typescript";
 
-export function transformParenthesizedExpression(state: TransformState, node: ts.ParenthesizedExpression) {
-	const expression = transformExpression(state, skipDownwards(node.expression));
+export function transformParenthesizedExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.ParenthesizedExpression,
+) {
+	const expression = transformExpression(state, prereqs, skipDownwards(node.expression));
 	if (luau.isSimple(expression)) {
 		return expression;
 	} else {

--- a/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformPropertyAccessExpression.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformOptionalChain } from "TSTransformer/nodes/transformOptionalChain";
 import { addIndexDiagnostics } from "TSTransformer/util/addIndexDiagnostics";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
@@ -11,6 +12,7 @@ import ts from "typescript";
 
 export function transformPropertyAccessExpressionInner(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.PropertyAccessExpression,
 	expression: luau.Expression,
 	name: string,
@@ -21,7 +23,7 @@ export function transformPropertyAccessExpressionInner(
 	addIndexDiagnostics(state, node, state.typeChecker.getNonOptionalType(state.getType(node)));
 
 	if (ts.isDeleteExpression(skipUpwards(node).parent)) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.property(convertToIndexableExpression(expression), name),
 				operator: "=",
@@ -36,11 +38,15 @@ export function transformPropertyAccessExpressionInner(
 	return property;
 }
 
-export function transformPropertyAccessExpression(state: TransformState, node: ts.PropertyAccessExpression) {
+export function transformPropertyAccessExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.PropertyAccessExpression,
+) {
 	const constantValue = getConstantValueLiteral(state, node);
 	if (constantValue) {
 		return constantValue;
 	}
 
-	return transformOptionalChain(state, node);
+	return transformOptionalChain(state, prereqs, node);
 }

--- a/src/TSTransformer/nodes/expressions/transformSpreadElement.ts
+++ b/src/TSTransformer/nodes/expressions/transformSpreadElement.ts
@@ -3,13 +3,14 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { getAddIterableToArrayBuilder } from "TSTransformer/util/getAddIterableToArrayBuilder";
 import { isArrayType, isDefinitelyType } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 import ts from "typescript";
 
-export function transformSpreadElement(state: TransformState, node: ts.SpreadElement) {
+export function transformSpreadElement(state: TransformState, prereqs: Prereqs, node: ts.SpreadElement) {
 	validateNotAnyType(state, node.expression);
 
 	// array literal is caught and handled separately in transformArrayLiteralExpression.ts
@@ -18,16 +19,16 @@ export function transformSpreadElement(state: TransformState, node: ts.SpreadEle
 		DiagnosticService.addDiagnostic(errors.noPrecedingSpreadElement(node));
 	}
 
-	const expression = transformExpression(state, node.expression);
+	const expression = transformExpression(state, prereqs, node.expression);
 
 	const type = state.getType(node.expression);
 	if (isDefinitelyType(type, isArrayType(state))) {
 		return luau.call(luau.globals.unpack, [expression]);
 	} else {
 		const addIterableToArrayBuilder = getAddIterableToArrayBuilder(state, node.expression, type);
-		const arrayId = state.pushToVar(luau.array(), "array");
-		const lengthId = state.pushToVar(luau.number(0), "length");
-		state.prereqList(addIterableToArrayBuilder(state, expression, arrayId, lengthId, 0, false));
+		const arrayId = prereqs.pushToVar(luau.array(), "array");
+		const lengthId = prereqs.pushToVar(luau.number(0), "length");
+		prereqs.pushList(addIterableToArrayBuilder(prereqs, expression, arrayId, lengthId, 0, false));
 		return luau.call(luau.globals.unpack, [arrayId]);
 	}
 }

--- a/src/TSTransformer/nodes/expressions/transformTaggedTemplateExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformTaggedTemplateExpression.ts
@@ -1,12 +1,17 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import ts from "typescript";
 
-export function transformTaggedTemplateExpression(state: TransformState, node: ts.TaggedTemplateExpression) {
-	const tagExp = transformExpression(state, node.tag);
+export function transformTaggedTemplateExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.TaggedTemplateExpression,
+) {
+	const tagExp = transformExpression(state, prereqs, node.tag);
 
 	if (ts.isTemplateExpression(node.template)) {
 		const strings = new Array<luau.Expression>();
@@ -17,6 +22,7 @@ export function transformTaggedTemplateExpression(state: TransformState, node: t
 
 		const expressions = ensureTransformOrder(
 			state,
+			prereqs,
 			node.template.templateSpans.map(templateSpan => templateSpan.expression),
 		);
 

--- a/src/TSTransformer/nodes/expressions/transformTemplateExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformTemplateExpression.ts
@@ -1,10 +1,11 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformInterpolatedStringPart } from "TSTransformer/nodes/transformInterpolatedStringPart";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import ts from "typescript";
 
-export function transformTemplateExpression(state: TransformState, node: ts.TemplateExpression) {
+export function transformTemplateExpression(state: TransformState, prereqs: Prereqs, node: ts.TemplateExpression) {
 	const parts = luau.list.make<luau.InterpolatedStringPart | luau.Expression>();
 
 	if (node.head.text.length > 0) {
@@ -13,6 +14,7 @@ export function transformTemplateExpression(state: TransformState, node: ts.Temp
 
 	const orderedExpressions = ensureTransformOrder(
 		state,
+		prereqs,
 		node.templateSpans.map(templateSpan => templateSpan.expression),
 	);
 

--- a/src/TSTransformer/nodes/expressions/transformTypeExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformTypeExpression.ts
@@ -1,9 +1,11 @@
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import ts from "typescript";
 
 export function transformTypeExpression(
 	state: TransformState,
+	prereqs: Prereqs,
 	node:
 		| ts.AsExpression
 		| ts.NonNullExpression
@@ -11,5 +13,5 @@ export function transformTypeExpression(
 		| ts.TypeAssertion
 		| ts.ExpressionWithTypeArguments,
 ) {
-	return transformExpression(state, node.expression);
+	return transformExpression(state, prereqs, node.expression);
 }

--- a/src/TSTransformer/nodes/expressions/transformUnaryExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformUnaryExpression.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformWritableExpression } from "TSTransformer/nodes/transformWritable";
 import { assertNever } from "TSTransformer/util/assertNever";
@@ -10,20 +11,24 @@ import { isDefinitelyType, isNumberType } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 import ts from "typescript";
 
-export function transformPostfixUnaryExpression(state: TransformState, node: ts.PostfixUnaryExpression) {
+export function transformPostfixUnaryExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.PostfixUnaryExpression,
+) {
 	validateNotAnyType(state, node.operand);
 
-	const writable = transformWritableExpression(state, node.operand, true);
+	const writable = transformWritableExpression(state, prereqs, node.operand, true);
 	const origValue = luau.tempId("original");
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.VariableDeclaration, {
 			left: origValue,
 			right: writable,
 		}),
 	);
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: writable,
 			operator:
@@ -39,13 +44,17 @@ export function transformPostfixUnaryExpression(state: TransformState, node: ts.
 	return origValue;
 }
 
-export function transformPrefixUnaryExpression(state: TransformState, node: ts.PrefixUnaryExpression) {
+export function transformPrefixUnaryExpression(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.PrefixUnaryExpression,
+) {
 	validateNotAnyType(state, node.operand);
 
 	if (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) {
-		const writable = transformWritableExpression(state, node.operand, true);
+		const writable = transformWritableExpression(state, prereqs, node.operand, true);
 		const operator: luau.AssignmentOperator = node.operator === ts.SyntaxKind.PlusPlusToken ? "+=" : "-=";
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: writable,
 				operator,
@@ -55,17 +64,24 @@ export function transformPrefixUnaryExpression(state: TransformState, node: ts.P
 		return writable;
 	} else if (node.operator === ts.SyntaxKind.PlusToken) {
 		DiagnosticService.addDiagnostic(errors.noUnaryPlus(node));
-		return transformExpression(state, node.operand);
+		return transformExpression(state, prereqs, node.operand);
 	} else if (node.operator === ts.SyntaxKind.MinusToken) {
 		if (!isDefinitelyType(state.getType(node.operand), isNumberType)) {
 			DiagnosticService.addDiagnostic(errors.noNonNumberUnaryMinus(node));
 		}
-		return luau.unary("-", transformExpression(state, node.operand));
+		return luau.unary("-", transformExpression(state, prereqs, node.operand));
 	} else if (node.operator === ts.SyntaxKind.ExclamationToken) {
-		const checks = createTruthinessChecks(state, transformExpression(state, node.operand), node.operand);
+		const checks = createTruthinessChecks(
+			state,
+			prereqs,
+			transformExpression(state, prereqs, node.operand),
+			node.operand,
+		);
 		return luau.unary("not", checks);
 	} else if (node.operator === ts.SyntaxKind.TildeToken) {
-		return luau.call(luau.property(luau.globals.bit32, "bnot"), [transformExpression(state, node.operand)]);
+		return luau.call(luau.property(luau.globals.bit32, "bnot"), [
+			transformExpression(state, prereqs, node.operand),
+		]);
 	}
 	return assertNever(node.operator, "transformPrefixUnaryExpression");
 }

--- a/src/TSTransformer/nodes/expressions/transformVoidExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformVoidExpression.ts
@@ -1,10 +1,11 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpressionStatementInner } from "TSTransformer/nodes/statements/transformExpressionStatement";
 import { skipDownwards } from "TSTransformer/util/traversal";
 import ts from "typescript";
 
-export function transformVoidExpression(state: TransformState, node: ts.VoidExpression) {
-	state.prereqList(transformExpressionStatementInner(state, skipDownwards(node.expression)));
+export function transformVoidExpression(state: TransformState, prereqs: Prereqs, node: ts.VoidExpression) {
+	prereqs.pushList(transformExpressionStatementInner(state, skipDownwards(node.expression)));
 	return luau.create(luau.SyntaxKind.NilLiteral, {});
 }

--- a/src/TSTransformer/nodes/expressions/transformYieldExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformYieldExpression.ts
@@ -1,16 +1,17 @@
 import luau from "@roblox-ts/luau-ast";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
 import ts from "typescript";
 
-export function transformYieldExpression(state: TransformState, node: ts.YieldExpression) {
+export function transformYieldExpression(state: TransformState, prereqs: Prereqs, node: ts.YieldExpression) {
 	if (!node.expression) {
 		return luau.call(luau.globals.coroutine.yield, []);
 	}
 
-	const expression = transformExpression(state, node.expression);
+	const expression = transformExpression(state, prereqs, node.expression);
 	if (node.asteriskToken) {
 		const loopId = luau.tempId("result");
 
@@ -18,7 +19,7 @@ export function transformYieldExpression(state: TransformState, node: ts.YieldEx
 		let evaluated: luau.Expression = luau.none();
 
 		if (!isUsedAsStatement(node)) {
-			const returnValue = state.pushToVar(undefined, "returnValue");
+			const returnValue = prereqs.pushToVar(undefined, "returnValue");
 			luau.list.unshift(
 				finalizer,
 				luau.create(luau.SyntaxKind.Assignment, {
@@ -30,7 +31,7 @@ export function transformYieldExpression(state: TransformState, node: ts.YieldEx
 			evaluated = returnValue;
 		}
 
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.ForStatement, {
 				ids: luau.list.make(loopId),
 				expression: luau.property(convertToIndexableExpression(expression), "next"),

--- a/src/TSTransformer/nodes/jsx/transformJsx.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsx.ts
@@ -1,6 +1,7 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformJsxAttributes } from "TSTransformer/nodes/jsx/transformJsxAttributes";
 import { transformJsxChildren } from "TSTransformer/nodes/jsx/transformJsxChildren";
 import { transformJsxTagName } from "TSTransformer/nodes/jsx/transformJsxTagName";
@@ -11,6 +12,7 @@ import ts from "typescript";
 
 export function transformJsx(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.JsxElement | ts.JsxSelfClosingElement,
 	tagName: ts.JsxTagNameExpression,
 	attributes: ts.JsxAttributes,
@@ -22,15 +24,15 @@ export function transformJsx(
 
 	const createElementExpression = convertToIndexableExpression(transformEntityName(state, jsxFactoryEntity));
 
-	const tagNameExp = transformJsxTagName(state, tagName);
+	const tagNameExp = transformJsxTagName(state, prereqs, tagName);
 
 	let attributesPtr: MapPointer | undefined;
 	if (attributes.properties.length > 0) {
 		attributesPtr = createMapPointer("attributes");
-		transformJsxAttributes(state, attributes, attributesPtr);
+		transformJsxAttributes(state, prereqs, attributes, attributesPtr);
 	}
 
-	const transformedChildren = transformJsxChildren(state, children);
+	const transformedChildren = transformJsxChildren(state, prereqs, children);
 
 	const args = [tagNameExp];
 

--- a/src/TSTransformer/nodes/jsx/transformJsx.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsx.ts
@@ -24,7 +24,7 @@ export function transformJsx(
 
 	const createElementExpression = convertToIndexableExpression(transformEntityName(state, jsxFactoryEntity));
 
-	const tagNameExp = transformJsxTagName(state, prereqs, tagName);
+	const tagNameExp = transformJsxTagName(state, tagName);
 
 	let attributesPtr: MapPointer | undefined;
 	if (attributes.properties.length > 0) {

--- a/src/TSTransformer/nodes/jsx/transformJsxAttributes.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxAttributes.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { createTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
 import { assignToMapPointer, disableMapInline, MapPointer } from "TSTransformer/util/pointer";
@@ -10,13 +11,14 @@ import ts from "typescript";
 
 function createJsxAttributeLoop(
 	state: TransformState,
+	prereqs: Prereqs,
 	attributesPtrValue: luau.AnyIdentifier,
 	expression: luau.Expression,
 	tsExpression: ts.Expression,
 ) {
 	const definitelyObject = isDefinitelyType(state.getType(tsExpression), isObjectType);
 	if (!definitelyObject) {
-		expression = state.pushToVarIfComplex(expression, "attribute");
+		expression = prereqs.pushToVarIfComplex(expression, "attribute");
 	}
 
 	const keyId = luau.tempId("k");
@@ -38,7 +40,7 @@ function createJsxAttributeLoop(
 
 	if (!definitelyObject) {
 		statement = luau.create(luau.SyntaxKind.IfStatement, {
-			condition: createTruthinessChecks(state, expression, tsExpression),
+			condition: createTruthinessChecks(state, prereqs, expression, tsExpression),
 			statements: luau.list.make(statement),
 			elseBody: luau.list.make(),
 		});
@@ -47,30 +49,39 @@ function createJsxAttributeLoop(
 	return statement;
 }
 
-function transformJsxAttribute(state: TransformState, attribute: ts.JsxAttribute, attributesPtr: MapPointer) {
+function transformJsxAttribute(
+	state: TransformState,
+	prereqs: Prereqs,
+	attribute: ts.JsxAttribute,
+	attributesPtr: MapPointer,
+) {
 	let initializer: ts.Expression | undefined = attribute.initializer;
 	if (initializer && ts.isJsxExpression(initializer)) {
 		initializer = initializer.expression;
 	}
 
-	const [init, initPrereqs] = initializer
-		? state.capture(() => transformExpression(state, initializer!))
-		: [luau.bool(true), luau.list.make<luau.Statement>()];
+	const initPrereqs = new Prereqs();
+	const init = initializer ? transformExpression(state, initPrereqs, initializer) : luau.bool(true);
 
-	if (!luau.list.isEmpty(initPrereqs)) {
-		disableMapInline(state, attributesPtr);
-		state.prereqList(initPrereqs);
+	if (!luau.list.isEmpty(initPrereqs.statements)) {
+		disableMapInline(prereqs, attributesPtr);
+		prereqs.pushList(initPrereqs.statements);
 	}
 
 	const text = ts.isIdentifier(attribute.name) ? attribute.name.text : ts.getTextOfJsxNamespacedName(attribute.name);
 	const name = luau.string(text);
-	assignToMapPointer(state, attributesPtr, name, init);
+	assignToMapPointer(prereqs, attributesPtr, name, init);
 }
 
-export function transformJsxAttributes(state: TransformState, attributes: ts.JsxAttributes, attributesPtr: MapPointer) {
+export function transformJsxAttributes(
+	state: TransformState,
+	prereqs: Prereqs,
+	attributes: ts.JsxAttributes,
+	attributesPtr: MapPointer,
+) {
 	for (const attribute of attributes.properties) {
 		if (ts.isJsxAttribute(attribute)) {
-			transformJsxAttribute(state, attribute, attributesPtr);
+			transformJsxAttribute(state, prereqs, attribute, attributesPtr);
 		} else {
 			// spread attributes: `<frame { ...x }/>`
 
@@ -80,14 +91,14 @@ export function transformJsxAttributes(state: TransformState, attributes: ts.Jsx
 				DiagnosticService.addDiagnostic(errors.noMacroObjectSpread(attribute));
 			}
 
-			const expression = transformExpression(state, attribute.expression);
+			const expression = transformExpression(state, prereqs, attribute.expression);
 
 			if (attribute === attributes.properties[0] && isDefinitelyType(expType, isObjectType)) {
-				attributesPtr.value = state.pushToVar(
+				attributesPtr.value = prereqs.pushToVar(
 					luau.call(luau.globals.table.clone, [expression]),
 					attributesPtr.name,
 				);
-				state.prereq(
+				prereqs.push(
 					luau.create(luau.SyntaxKind.CallStatement, {
 						// Explicitly remove metatable because things like classes can be spread
 						expression: luau.call(luau.globals.setmetatable, [attributesPtr.value, luau.nil()]),
@@ -96,8 +107,8 @@ export function transformJsxAttributes(state: TransformState, attributes: ts.Jsx
 				continue;
 			}
 
-			disableMapInline(state, attributesPtr);
-			state.prereq(createJsxAttributeLoop(state, attributesPtr.value, expression, attribute.expression));
+			disableMapInline(prereqs, attributesPtr);
+			prereqs.push(createJsxAttributeLoop(state, prereqs, attributesPtr.value, expression, attribute.expression));
 		}
 	}
 }

--- a/src/TSTransformer/nodes/jsx/transformJsxChildren.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxChildren.ts
@@ -2,13 +2,14 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { findLastIndex } from "Shared/util/findLastIndex";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { fixupWhitespaceAndDecodeEntities } from "TSTransformer/util/fixupWhitespaceAndDecodeEntities";
 import ts from "typescript";
 
-export function transformJsxChildren(state: TransformState, children: ReadonlyArray<ts.JsxChild>) {
+export function transformJsxChildren(state: TransformState, prereqs: Prereqs, children: ReadonlyArray<ts.JsxChild>) {
 	const lastJsxChildIndex = findLastIndex(
 		children,
 		child => !ts.isJsxText(child) || !child.containsOnlyTriviaWhiteSpaces,
@@ -23,17 +24,18 @@ export function transformJsxChildren(state: TransformState, children: ReadonlyAr
 
 	return ensureTransformOrder(
 		state,
+		prereqs,
 		children
 			// ignore jsx text that only contains whitespace
 			.filter(v => !ts.isJsxText(v) || !v.containsOnlyTriviaWhiteSpaces)
 			// ignore empty jsx expressions, i.e. `{}`
 			.filter(v => !ts.isJsxExpression(v) || v.expression !== undefined),
-		(state, node) => {
+		(state, prereqs, node) => {
 			if (ts.isJsxText(node)) {
 				const text = fixupWhitespaceAndDecodeEntities(node.text) ?? "";
 				return luau.string(text.replace(/\\/g, "\\\\"));
 			}
-			return transformExpression(state, node);
+			return transformExpression(state, prereqs, node);
 		},
 	);
 }

--- a/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
+import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { Prereqs } from "TSTransformer/classes/Prereqs";
@@ -31,13 +32,10 @@ function transformJsxTagNameExpression(state: TransformState, prereqs: Prereqs, 
 	}
 }
 
-export function transformJsxTagName(state: TransformState, prereqs: Prereqs, tagName: ts.JsxTagNameExpression) {
+export function transformJsxTagName(state: TransformState, tagName: ts.JsxTagNameExpression) {
 	const expressionPrereqs = new Prereqs();
 	const expression = transformJsxTagNameExpression(state, expressionPrereqs, tagName);
-	let tagNameExp = expression;
-	if (!luau.list.isEmpty(expressionPrereqs.statements)) {
-		prereqs.pushList(expressionPrereqs.statements);
-		tagNameExp = prereqs.pushToVarIfComplex(tagNameExp, "tagName");
-	}
-	return tagNameExp;
+	// JSX tag names only allow identifiers, this, dotted names, and namespaced names
+	assert(luau.list.isEmpty(expressionPrereqs.statements));
+	return expression;
 }

--- a/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxTagName.ts
@@ -2,11 +2,12 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import ts from "typescript";
 
-function transformJsxTagNameExpression(state: TransformState, node: ts.JsxTagNameExpression) {
+function transformJsxTagNameExpression(state: TransformState, prereqs: Prereqs, node: ts.JsxTagNameExpression) {
 	// host component
 	if (ts.isIdentifier(node)) {
 		const firstChar = node.text[0];
@@ -19,20 +20,24 @@ function transformJsxTagNameExpression(state: TransformState, node: ts.JsxTagNam
 		if (ts.isPrivateIdentifier(node.name)) {
 			DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(node.name));
 		}
-		return luau.property(convertToIndexableExpression(transformExpression(state, node.expression)), node.name.text);
+		return luau.property(
+			convertToIndexableExpression(transformExpression(state, prereqs, node.expression)),
+			node.name.text,
+		);
 	} else if (ts.isJsxNamespacedName(node)) {
 		return luau.string(ts.getTextOfJsxNamespacedName(node));
 	} else {
-		return transformExpression(state, node);
+		return transformExpression(state, prereqs, node);
 	}
 }
 
-export function transformJsxTagName(state: TransformState, tagName: ts.JsxTagNameExpression) {
-	const [expression, prereqs] = state.capture(() => transformJsxTagNameExpression(state, tagName));
+export function transformJsxTagName(state: TransformState, prereqs: Prereqs, tagName: ts.JsxTagNameExpression) {
+	const expressionPrereqs = new Prereqs();
+	const expression = transformJsxTagNameExpression(state, expressionPrereqs, tagName);
 	let tagNameExp = expression;
-	if (!luau.list.isEmpty(prereqs)) {
-		state.prereqList(prereqs);
-		tagNameExp = state.pushToVarIfComplex(tagNameExp, "tagName");
+	if (!luau.list.isEmpty(expressionPrereqs.statements)) {
+		prereqs.pushList(expressionPrereqs.statements);
+		tagNameExp = prereqs.pushToVarIfComplex(tagNameExp, "tagName");
 	}
 	return tagNameExp;
 }

--- a/src/TSTransformer/nodes/statements/transformDoStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformDoStatement.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformStatementList } from "TSTransformer/nodes/transformStatementList";
 import { createTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
@@ -15,8 +16,12 @@ export function transformDoStatement(state: TransformState, { expression, statem
 		conditionIsInvertedInLuau = false;
 	}
 
-	const [condition, conditionPrereqs] = state.capture(() =>
-		createTruthinessChecks(state, transformExpression(state, expression), expression),
+	const conditionPrereqs = new Prereqs();
+	const condition = createTruthinessChecks(
+		state,
+		conditionPrereqs,
+		transformExpression(state, conditionPrereqs, expression),
+		expression,
 	);
 
 	const repeatStatements = luau.list.make<luau.Statement>();
@@ -26,7 +31,7 @@ export function transformDoStatement(state: TransformState, { expression, statem
 			statements,
 		}),
 	);
-	luau.list.pushList(repeatStatements, conditionPrereqs);
+	luau.list.pushList(repeatStatements, conditionPrereqs.statements);
 
 	return luau.list.make(
 		luau.create(luau.SyntaxKind.RepeatStatement, {

--- a/src/TSTransformer/nodes/statements/transformEnumDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformEnumDeclaration.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
@@ -37,92 +38,105 @@ export function transformEnumDeclaration(state: TransformState, node: ts.EnumDec
 		return luau.list.make<luau.Statement>();
 	}
 
-	validateIdentifier(state, node.name);
+	validateIdentifier(node.name);
 
 	const left = transformIdentifierDefined(state, node.name);
 	const isHoisted = symbol !== undefined && state.isHoisted.get(symbol) === true;
+	const statements = luau.list.make<luau.Statement>();
 
 	if (node.members.every(member => !needsInverseEntry(state, member))) {
+		const prereqs = new Prereqs();
 		const right = luau.map(
 			node.members.map(member => [
-				state.pushToVarIfComplex(transformPropertyName(state, member.name)),
+				prereqs.pushToVarIfComplex(transformPropertyName(state, prereqs, member.name)),
 				luau.string(state.typeChecker.getConstantValue(member) as string),
 			]),
 		);
-		return luau.list.make<luau.Statement>(
+		luau.list.pushList(statements, prereqs.statements);
+		luau.list.push(
+			statements,
 			isHoisted
 				? luau.create(luau.SyntaxKind.Assignment, { left, operator: "=", right })
 				: luau.create(luau.SyntaxKind.VariableDeclaration, { left, right }),
 		);
+		return statements;
 	}
 
-	const statements = state.capturePrereqs(() => {
-		const inverseId = state.pushToVar(luau.map(), "inverse");
-		state.prereq(
+	const enumStatements = luau.list.make<luau.Statement>();
+	const inverseId = luau.tempId("inverse");
+	luau.list.push(
+		enumStatements,
+		luau.create(luau.SyntaxKind.VariableDeclaration, { left: inverseId, right: luau.map() }),
+	);
+	luau.list.push(
+		enumStatements,
+		luau.create(luau.SyntaxKind.Assignment, {
+			left,
+			operator: "=",
+			right: luau.call(luau.globals.setmetatable, [luau.map(), luau.map([[luau.strings.__index, inverseId]])]),
+		}),
+	);
+
+	for (const member of node.members) {
+		const memberPrereqs = new Prereqs();
+		const name = transformPropertyName(state, memberPrereqs, member.name);
+		const index = expressionMightMutate(
+			state,
+			name,
+			ts.isComputedPropertyName(member.name) ? member.name.expression : member.name,
+		)
+			? // note: we don't use pushToVarIfComplex here
+				// because identifier also needs to be pushed
+				// since the value calculation might reassign the variable
+				memberPrereqs.pushToVar(name)
+			: name;
+
+		const value = state.typeChecker.getConstantValue(member);
+		let valueExp: luau.Expression;
+		if (typeof value === "string") {
+			valueExp = luau.string(value);
+		} else if (typeof value === "number") {
+			valueExp = luau.number(value);
+		} else {
+			// constantValue is always number without initializer, so assert is safe
+			assert(member.initializer);
+			valueExp = memberPrereqs.pushToVarIfComplex(
+				transformExpression(state, memberPrereqs, member.initializer),
+				"value",
+			);
+		}
+
+		luau.list.pushList(enumStatements, memberPrereqs.statements);
+		luau.list.push(
+			enumStatements,
 			luau.create(luau.SyntaxKind.Assignment, {
-				left,
+				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+					expression: left,
+					index,
+				}),
 				operator: "=",
-				right: luau.call(luau.globals.setmetatable, [
-					luau.map(),
-					luau.map([[luau.strings.__index, inverseId]]),
-				]),
+				right: valueExp,
 			}),
 		);
 
-		for (const member of node.members) {
-			const name = transformPropertyName(state, member.name);
-			const index = expressionMightMutate(
-				state,
-				name,
-				ts.isComputedPropertyName(member.name) ? member.name.expression : member.name,
-			)
-				? // note: we don't use pushToVarIfComplex here
-					// because identifier also needs to be pushed
-					// since the value calculation might reassign the variable
-					state.pushToVar(name)
-				: name;
-
-			const value = state.typeChecker.getConstantValue(member);
-			let valueExp: luau.Expression;
-			if (typeof value === "string") {
-				valueExp = luau.string(value);
-			} else if (typeof value === "number") {
-				valueExp = luau.number(value);
-			} else {
-				// constantValue is always number without initializer, so assert is safe
-				assert(member.initializer);
-				valueExp = state.pushToVarIfComplex(transformExpression(state, member.initializer), "value");
-			}
-
-			state.prereq(
+		if (needsInverseEntry(state, member)) {
+			luau.list.push(
+				enumStatements,
 				luau.create(luau.SyntaxKind.Assignment, {
 					left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-						expression: left,
-						index,
+						expression: inverseId,
+						index: valueExp,
 					}),
 					operator: "=",
-					right: valueExp,
+					right: index,
 				}),
 			);
-
-			if (needsInverseEntry(state, member)) {
-				state.prereq(
-					luau.create(luau.SyntaxKind.Assignment, {
-						left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-							expression: inverseId,
-							index: valueExp,
-						}),
-						operator: "=",
-						right: index,
-					}),
-				);
-			}
 		}
-	});
-
-	const list = luau.list.make<luau.Statement>(luau.create(luau.SyntaxKind.DoStatement, { statements }));
-	if (!isHoisted) {
-		luau.list.unshift(list, luau.create(luau.SyntaxKind.VariableDeclaration, { left, right: undefined }));
 	}
-	return list;
+
+	luau.list.push(statements, luau.create(luau.SyntaxKind.DoStatement, { statements: enumStatements }));
+	if (!isHoisted) {
+		luau.list.unshift(statements, luau.create(luau.SyntaxKind.VariableDeclaration, { left, right: undefined }));
+	}
+	return statements;
 }

--- a/src/TSTransformer/nodes/statements/transformExportAssignment.ts
+++ b/src/TSTransformer/nodes/statements/transformExportAssignment.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { isSymbolMutable } from "TSTransformer/util/isSymbolMutable";
 import { isSymbolOfValue } from "TSTransformer/util/isSymbolOfValue";
@@ -10,27 +11,34 @@ import ts from "typescript";
 function transformExportEquals(state: TransformState, node: ts.ExportAssignment) {
 	state.hasExportEquals = true;
 
+	const statements = luau.list.make<luau.Statement>();
+	const prereqs = new Prereqs();
+	let statement: luau.Statement;
+
 	const sourceFile = node.getSourceFile();
 	const finalStatement = sourceFile.statements[sourceFile.statements.length - 1];
 	if (finalStatement === node) {
-		return luau.list.make<luau.Statement>(
-			luau.create(luau.SyntaxKind.ReturnStatement, { expression: transformExpression(state, node.expression) }),
-		);
+		statement = luau.create(luau.SyntaxKind.ReturnStatement, {
+			expression: transformExpression(state, prereqs, node.expression),
+		});
 	} else {
-		return luau.list.make<luau.Statement>(
-			luau.create(luau.SyntaxKind.VariableDeclaration, {
-				left: state.getModuleIdFromNode(node),
-				right: transformExpression(state, node.expression),
-			}),
-		);
+		statement = luau.create(luau.SyntaxKind.VariableDeclaration, {
+			left: state.getModuleIdFromNode(node),
+			right: transformExpression(state, prereqs, node.expression),
+		});
 	}
+
+	luau.list.pushList(statements, prereqs.statements);
+	luau.list.push(statements, statement);
+	return statements;
 }
 
 function transformExportDefault(state: TransformState, node: ts.ExportAssignment) {
 	const statements = luau.list.make<luau.Statement>();
 
-	const [expression, prereqs] = state.capture(() => transformExpression(state, node.expression));
-	luau.list.pushList(statements, prereqs);
+	const expressionPrereqs = new Prereqs();
+	const expression = transformExpression(state, expressionPrereqs, node.expression);
+	luau.list.pushList(statements, expressionPrereqs.statements);
 	luau.list.push(
 		statements,
 		luau.create(luau.SyntaxKind.VariableDeclaration, {

--- a/src/TSTransformer/nodes/statements/transformExportDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformExportDeclaration.ts
@@ -1,6 +1,7 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
 import { cleanModuleName } from "TSTransformer/util/cleanModuleName";
 import { createImportExpression } from "TSTransformer/util/createImportExpression";
@@ -72,17 +73,21 @@ function transformExportFrom(state: TransformState, node: ts.ExportDeclaration) 
 			// export { a, b, c } from "./module";
 			for (const element of exportClause.elements) {
 				if (isExportSpecifierValue(state, element)) {
+					const namePrereqs = new Prereqs();
+					const exportName = transformPropertyName(state, namePrereqs, element.name);
+					const importName = transformPropertyName(state, namePrereqs, element.propertyName ?? element.name);
+					luau.list.pushList(statements, namePrereqs.statements);
 					luau.list.push(
 						statements,
 						luau.create(luau.SyntaxKind.Assignment, {
 							left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 								expression: moduleId,
-								index: transformPropertyName(state, element.name),
+								index: exportName,
 							}),
 							operator: "=",
 							right: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 								expression: importExp,
-								index: transformPropertyName(state, element.propertyName ?? element.name),
+								index: importName,
 							}),
 						}),
 					);
@@ -90,12 +95,15 @@ function transformExportFrom(state: TransformState, node: ts.ExportDeclaration) 
 			}
 		} else {
 			// export * as foo from "./module";
+			const namePrereqs = new Prereqs();
+			const name = transformPropertyName(state, namePrereqs, exportClause.name);
+			luau.list.pushList(statements, namePrereqs.statements);
 			luau.list.push(
 				statements,
 				luau.create(luau.SyntaxKind.Assignment, {
 					left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 						expression: moduleId,
-						index: transformPropertyName(state, exportClause.name),
+						index: name,
 					}),
 					operator: "=",
 					right: importExp,
@@ -133,7 +141,9 @@ function transformExportFrom(state: TransformState, node: ts.ExportDeclaration) 
 }
 
 export function transformExportDeclaration(state: TransformState, node: ts.ExportDeclaration) {
-	if (node.isTypeOnly) return luau.list.make<luau.Statement>();
+	if (node.isTypeOnly) {
+		return luau.list.make<luau.Statement>();
+	}
 
 	if (node.moduleSpecifier) {
 		return transformExportFrom(state, node);

--- a/src/TSTransformer/nodes/statements/transformExpressionStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformExpressionStatement.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformLogicalOrCoalescingAssignmentExpressionStatement } from "TSTransformer/nodes/transformLogicalOrCoalescingAssignmentExpression";
 import { transformWritableAssignment, transformWritableExpression } from "TSTransformer/nodes/transformWritable";
@@ -16,9 +17,10 @@ import ts from "typescript";
 
 function transformUnaryExpressionStatement(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.PrefixUnaryExpression | ts.PostfixUnaryExpression,
 ) {
-	const writable = transformWritableExpression(state, node.operand, false);
+	const writable = transformWritableExpression(state, prereqs, node.operand, false);
 	const operator: luau.AssignmentOperator = node.operator === ts.SyntaxKind.PlusPlusToken ? "+=" : "-=";
 	return luau.create(luau.SyntaxKind.Assignment, {
 		left: writable,
@@ -31,6 +33,9 @@ export function transformExpressionStatementInner(
 	state: TransformState,
 	expression: ts.Expression,
 ): luau.List<luau.Statement> {
+	const statements = luau.list.make<luau.Statement>();
+	const prereqs = new Prereqs();
+
 	if (ts.isBinaryExpression(expression)) {
 		const operatorKind = expression.operatorToken.kind;
 		if (ts.isLogicalOrCoalescingAssignmentExpression(expression)) {
@@ -49,43 +54,51 @@ export function transformExpressionStatementInner(
 			);
 			const { writable, readable, value } = transformWritableAssignment(
 				state,
+				prereqs,
 				expression.left,
 				expression.right,
 				operator === undefined,
 				operator !== "=",
 			);
+
+			let assignment: luau.Assignment;
 			if (operator !== undefined) {
-				return luau.list.make(
-					createAssignmentStatement(
-						writable,
-						operator,
-						getAssignableValue(operator, value, valueType),
-						readable,
-					),
+				assignment = createAssignmentStatement(
+					writable,
+					operator,
+					getAssignableValue(operator, value, valueType),
+					readable,
 				);
 			} else {
-				return luau.list.make(
-					createCompoundAssignmentStatement(
-						state,
-						expression,
-						writable,
-						writableType,
-						readable,
-						operatorKind,
-						value,
-						valueType,
-					),
+				assignment = createCompoundAssignmentStatement(
+					prereqs,
+					writable,
+					writableType,
+					readable,
+					operatorKind,
+					value,
+					valueType,
 				);
 			}
+
+			luau.list.pushList(statements, prereqs.statements);
+			luau.list.push(statements, assignment);
+			return statements;
 		}
 	} else if (
 		(ts.isPrefixUnaryExpression(expression) || ts.isPostfixUnaryExpression(expression)) &&
 		isUnaryAssignmentOperator(expression.operator)
 	) {
-		return luau.list.make(transformUnaryExpressionStatement(state, expression));
+		const assignment = transformUnaryExpressionStatement(state, prereqs, expression);
+		luau.list.pushList(statements, prereqs.statements);
+		luau.list.push(statements, assignment);
+		return statements;
 	}
 
-	return wrapExpressionStatement(transformExpression(state, expression));
+	const expressionStatements = wrapExpressionStatement(transformExpression(state, prereqs, expression));
+	luau.list.pushList(statements, prereqs.statements);
+	luau.list.pushList(statements, expressionStatements);
+	return statements;
 }
 
 export function transformExpressionStatement(state: TransformState, node: ts.ExpressionStatement) {

--- a/src/TSTransformer/nodes/statements/transformForOfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForOfStatement.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { SYMBOL_NAMES, TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayAssignmentPattern } from "TSTransformer/nodes/binding/transformArrayAssignmentPattern";
 import { transformBindingName } from "TSTransformer/nodes/binding/transformBindingName";
 import { transformObjectAssignmentPattern } from "TSTransformer/nodes/binding/transformObjectAssignmentPattern";
@@ -35,6 +36,7 @@ import ts from "typescript";
 
 type LoopBuilder = (
 	state: TransformState,
+	prereqs: Prereqs,
 	statements: luau.List<luau.Statement>,
 	initializer: ts.ForInitializer,
 	exp: luau.Expression,
@@ -43,16 +45,17 @@ type LoopBuilder = (
 function makeForLoopBuilder(
 	callback: (
 		state: TransformState,
+		prereqs: Prereqs,
 		initializer: ts.ForInitializer,
 		exp: luau.Expression,
 		ids: luau.List<luau.AnyIdentifier>,
 		initializers: luau.List<luau.Statement>,
 	) => luau.Expression,
 ): LoopBuilder {
-	return (state, statements, name, exp) => {
+	return (state, prereqs, statements, name, exp) => {
 		const ids = luau.list.make<luau.AnyIdentifier>();
 		const initializers = luau.list.make<luau.Statement>();
-		const expression = callback(state, name, exp, ids, initializers);
+		const expression = callback(state, prereqs, name, exp, ids, initializers);
 		luau.list.unshiftList(statements, initializers);
 		return luau.list.make(luau.create(luau.SyntaxKind.ForStatement, { ids, expression, statements }));
 	};
@@ -60,28 +63,25 @@ function makeForLoopBuilder(
 
 function transformForInitializerExpressionDirect(
 	state: TransformState,
+	prereqs: Prereqs,
 	initializer: ts.Expression,
 	initializers: luau.List<luau.Statement>,
 	value: luau.Expression,
 ) {
 	if (ts.isArrayLiteralExpression(initializer)) {
-		const [parentId, prereqs] = state.capture(() => {
-			const parentId = state.pushToVar(value, "binding");
-			transformArrayAssignmentPattern(state, initializer, parentId);
-			return parentId;
-		});
-		luau.list.pushList(initializers, prereqs);
+		const bindingPrereqs = new Prereqs();
+		const parentId = bindingPrereqs.pushToVar(value, "binding");
+		transformArrayAssignmentPattern(state, bindingPrereqs, initializer, parentId);
+		luau.list.pushList(initializers, bindingPrereqs.statements);
 		return parentId;
 	} else if (ts.isObjectLiteralExpression(initializer)) {
-		const [parentId, prereqs] = state.capture(() => {
-			const parentId = state.pushToVar(value, "binding");
-			transformObjectAssignmentPattern(state, initializer, parentId);
-			return parentId;
-		});
-		luau.list.pushList(initializers, prereqs);
+		const bindingPrereqs = new Prereqs();
+		const parentId = bindingPrereqs.pushToVar(value, "binding");
+		transformObjectAssignmentPattern(state, bindingPrereqs, initializer, parentId);
+		luau.list.pushList(initializers, bindingPrereqs.statements);
 		return parentId;
 	} else {
-		const expression = transformWritableExpression(state, initializer, false);
+		const expression = transformWritableExpression(state, prereqs, initializer, false);
 		luau.list.push(
 			initializers,
 			luau.create(luau.SyntaxKind.Assignment, {
@@ -95,6 +95,7 @@ function transformForInitializerExpressionDirect(
 
 function transformForInitializer(
 	state: TransformState,
+	prereqs: Prereqs,
 	initializer: ts.ForInitializer,
 	initializers: luau.List<luau.Statement>,
 ) {
@@ -102,21 +103,19 @@ function transformForInitializer(
 		return transformBindingName(state, initializer.declarations[0].name, initializers);
 	} else if (ts.isArrayLiteralExpression(initializer)) {
 		const parentId = luau.tempId("binding");
-		luau.list.pushList(
-			initializers,
-			state.capturePrereqs(() => transformArrayAssignmentPattern(state, initializer, parentId)),
-		);
+		const bindingPrereqs = new Prereqs();
+		transformArrayAssignmentPattern(state, bindingPrereqs, initializer, parentId);
+		luau.list.pushList(initializers, bindingPrereqs.statements);
 		return parentId;
 	} else if (ts.isObjectLiteralExpression(initializer)) {
 		const parentId = luau.tempId("binding");
-		luau.list.pushList(
-			initializers,
-			state.capturePrereqs(() => transformObjectAssignmentPattern(state, initializer, parentId)),
-		);
+		const bindingPrereqs = new Prereqs();
+		transformObjectAssignmentPattern(state, bindingPrereqs, initializer, parentId);
+		luau.list.pushList(initializers, bindingPrereqs.statements);
 		return parentId;
 	} else {
 		const valueId = luau.tempId("v");
-		const expression = transformWritableExpression(state, initializer, false);
+		const expression = transformWritableExpression(state, prereqs, initializer, false);
 		luau.list.push(
 			initializers,
 			luau.create(luau.SyntaxKind.Assignment, {
@@ -129,14 +128,14 @@ function transformForInitializer(
 	}
 }
 
-const buildArrayLoop: LoopBuilder = makeForLoopBuilder((state, initializer, exp, ids, initializers) => {
+const buildArrayLoop: LoopBuilder = makeForLoopBuilder((state, prereqs, initializer, exp, ids, initializers) => {
 	luau.list.push(ids, luau.tempId());
-	luau.list.push(ids, transformForInitializer(state, initializer, initializers));
+	luau.list.push(ids, transformForInitializer(state, prereqs, initializer, initializers));
 	return exp;
 });
 
-const buildSetLoop: LoopBuilder = makeForLoopBuilder((state, initializer, exp, ids, initializers) => {
-	luau.list.push(ids, transformForInitializer(state, initializer, initializers));
+const buildSetLoop: LoopBuilder = makeForLoopBuilder((state, prereqs, initializer, exp, ids, initializers) => {
+	luau.list.push(ids, transformForInitializer(state, prereqs, initializer, initializers));
 	return exp;
 });
 
@@ -165,61 +164,55 @@ function transformInLineArrayAssignmentPattern(
 	ids: luau.List<luau.AnyIdentifier>,
 	initializers: luau.List<luau.Statement>,
 ) {
-	luau.list.pushList(
-		initializers,
-		state.capturePrereqs(() => {
-			for (let element of assignmentPattern.elements) {
-				if (ts.isOmittedExpression(element)) {
-					luau.list.push(ids, luau.tempId());
-				} else {
-					let initializer: ts.Expression | undefined;
-					if (ts.isBinaryExpression(element)) {
-						initializer = skipDownwards(element.right);
-						element = skipDownwards(element.left);
-					}
-
-					const valueId = luau.tempId("binding");
-					if (
-						ts.isIdentifier(element) ||
-						ts.isElementAccessExpression(element) ||
-						ts.isPropertyAccessExpression(element)
-					) {
-						const id = transformWritableExpression(state, element, initializer !== undefined);
-						state.prereq(
-							luau.create(luau.SyntaxKind.Assignment, {
-								left: id,
-								operator: "=",
-								right: valueId,
-							}),
-						);
-						if (initializer) {
-							state.prereq(transformInitializer(state, id, initializer));
-						}
-					} else if (ts.isArrayLiteralExpression(element)) {
-						if (initializer) {
-							state.prereq(transformInitializer(state, valueId, initializer));
-						}
-						transformArrayAssignmentPattern(state, element, valueId);
-					} else if (ts.isObjectLiteralExpression(element)) {
-						if (initializer) {
-							state.prereq(transformInitializer(state, valueId, initializer));
-						}
-						transformObjectAssignmentPattern(state, element, valueId);
-					} else {
-						assert(
-							false,
-							`transformInLineArrayAssignmentPattern invalid element: ${getKindName(element.kind)}`,
-						);
-					}
-
-					luau.list.push(ids, valueId);
-				}
+	const bindingPrereqs = new Prereqs();
+	for (let element of assignmentPattern.elements) {
+		if (ts.isOmittedExpression(element)) {
+			luau.list.push(ids, luau.tempId());
+		} else {
+			let initializer: ts.Expression | undefined;
+			if (ts.isBinaryExpression(element)) {
+				initializer = skipDownwards(element.right);
+				element = skipDownwards(element.left);
 			}
-		}),
-	);
+
+			const valueId = luau.tempId("binding");
+			if (
+				ts.isIdentifier(element) ||
+				ts.isElementAccessExpression(element) ||
+				ts.isPropertyAccessExpression(element)
+			) {
+				const id = transformWritableExpression(state, bindingPrereqs, element, initializer !== undefined);
+				bindingPrereqs.push(
+					luau.create(luau.SyntaxKind.Assignment, {
+						left: id,
+						operator: "=",
+						right: valueId,
+					}),
+				);
+				if (initializer) {
+					bindingPrereqs.push(transformInitializer(state, id, initializer));
+				}
+			} else if (ts.isArrayLiteralExpression(element)) {
+				if (initializer) {
+					bindingPrereqs.push(transformInitializer(state, valueId, initializer));
+				}
+				transformArrayAssignmentPattern(state, bindingPrereqs, element, valueId);
+			} else if (ts.isObjectLiteralExpression(element)) {
+				if (initializer) {
+					bindingPrereqs.push(transformInitializer(state, valueId, initializer));
+				}
+				transformObjectAssignmentPattern(state, bindingPrereqs, element, valueId);
+			} else {
+				assert(false, `transformInLineArrayAssignmentPattern invalid element: ${getKindName(element.kind)}`);
+			}
+
+			luau.list.push(ids, valueId);
+		}
+	}
+	luau.list.pushList(initializers, bindingPrereqs.statements);
 }
 
-const buildMapLoop: LoopBuilder = makeForLoopBuilder((state, initializer, exp, ids, initializers) => {
+const buildMapLoop: LoopBuilder = makeForLoopBuilder((state, prereqs, initializer, exp, ids, initializers) => {
 	// TEST
 	if (ts.isVariableDeclarationList(initializer)) {
 		const name = initializer.declarations[0].name;
@@ -242,27 +235,35 @@ const buildMapLoop: LoopBuilder = makeForLoopBuilder((state, initializer, exp, i
 		luau.list.push(
 			initializers,
 			luau.create(luau.SyntaxKind.VariableDeclaration, {
-				left: transformForInitializer(state, initializer, bindingList),
+				left: transformForInitializer(state, prereqs, initializer, bindingList),
 				right: luau.array([keyId, valueId]),
 			}),
 		);
 		luau.list.pushList(initializers, bindingList);
 	} else {
-		transformForInitializerExpressionDirect(state, initializer, initializers, luau.array([keyId, valueId]));
+		transformForInitializerExpressionDirect(
+			state,
+			prereqs,
+			initializer,
+			initializers,
+			luau.array([keyId, valueId]),
+		);
 	}
 
 	return exp;
 });
 
-const buildStringLoop: LoopBuilder = makeForLoopBuilder((state, initializer, exp, ids, initializers) => {
-	luau.list.push(ids, transformForInitializer(state, initializer, initializers));
+const buildStringLoop: LoopBuilder = makeForLoopBuilder((state, prereqs, initializer, exp, ids, initializers) => {
+	luau.list.push(ids, transformForInitializer(state, prereqs, initializer, initializers));
 	return luau.call(luau.globals.string.gmatch, [exp, luau.globals.utf8.charpattern]);
 });
 
-const buildIterableFunctionLoop: LoopBuilder = makeForLoopBuilder((state, initializer, exp, ids, initializers) => {
-	luau.list.push(ids, transformForInitializer(state, initializer, initializers));
-	return exp;
-});
+const buildIterableFunctionLoop: LoopBuilder = makeForLoopBuilder(
+	(state, prereqs, initializer, exp, ids, initializers) => {
+		luau.list.push(ids, transformForInitializer(state, prereqs, initializer, initializers));
+		return exp;
+	},
+);
 
 function makeIterableFunctionLuaTupleShorthand(
 	state: TransformState,
@@ -282,7 +283,7 @@ function makeIterableFunctionLuaTupleShorthand(
 }
 
 const buildIterableFunctionLuaTupleLoop: (type: ts.Type) => LoopBuilder =
-	type => (state, statements, initializer, exp) => {
+	type => (state, prereqs, statements, initializer, exp) => {
 		if (ts.isVariableDeclarationList(initializer)) {
 			// for (const [a, b] of iter())
 			const name = initializer.declarations[0].name;
@@ -324,11 +325,11 @@ const buildIterableFunctionLuaTupleLoop: (type: ts.Type) => LoopBuilder =
 				iteratorReturnIds.push(luau.tempId(name));
 			}
 		} else {
-			const iterFuncId = state.pushToVar(exp, valueToIdStr(exp) || "iterFunc");
+			const iterFuncId = prereqs.pushToVar(exp, valueToIdStr(exp) || "iterFunc");
 			const loopStatements = luau.list.make<luau.Statement>();
 
 			const initializerStatements = luau.list.make<luau.Statement>();
-			const valueId = transformForInitializer(state, initializer, initializerStatements);
+			const valueId = transformForInitializer(state, prereqs, initializer, initializerStatements);
 
 			luau.list.push(
 				loopStatements,
@@ -359,9 +360,9 @@ const buildIterableFunctionLuaTupleLoop: (type: ts.Type) => LoopBuilder =
 			);
 		}
 
-		const tupleId = transformForInitializer(state, initializer, statements);
+		const tupleId = transformForInitializer(state, prereqs, initializer, statements);
 
-		const builder = makeForLoopBuilder((state, initializer, exp, ids, initializers) => {
+		const builder = makeForLoopBuilder((state, prereqs, initializer, exp, ids, initializers) => {
 			for (const id of iteratorReturnIds) {
 				luau.list.push(ids, id);
 			}
@@ -376,10 +377,10 @@ const buildIterableFunctionLuaTupleLoop: (type: ts.Type) => LoopBuilder =
 			return exp;
 		});
 
-		return builder(state, statements, initializer, exp);
+		return builder(state, prereqs, statements, initializer, exp);
 	};
 
-const buildGeneratorLoop: LoopBuilder = makeForLoopBuilder((state, initializer, exp, ids, initializers) => {
+const buildGeneratorLoop: LoopBuilder = makeForLoopBuilder((state, prereqs, initializer, exp, ids, initializers) => {
 	const loopId = luau.tempId("result");
 	luau.list.push(ids, loopId);
 
@@ -397,13 +398,19 @@ const buildGeneratorLoop: LoopBuilder = makeForLoopBuilder((state, initializer, 
 		luau.list.push(
 			initializers,
 			luau.create(luau.SyntaxKind.VariableDeclaration, {
-				left: transformForInitializer(state, initializer, bindingList),
+				left: transformForInitializer(state, prereqs, initializer, bindingList),
 				right: luau.property(loopId, "value"),
 			}),
 		);
 		luau.list.pushList(initializers, bindingList);
 	} else {
-		transformForInitializerExpressionDirect(state, initializer, initializers, luau.property(loopId, "value"));
+		transformForInitializerExpressionDirect(
+			state,
+			prereqs,
+			initializer,
+			initializers,
+			luau.property(loopId, "value"),
+		);
 	}
 
 	return luau.property(convertToIndexableExpression(exp), "next");
@@ -453,10 +460,13 @@ export function transformForOfRangeMacro(
 	const result = luau.list.make<luau.Statement>();
 
 	const statements = luau.list.make<luau.Statement>();
-	const id = transformForInitializer(state, node.initializer, statements);
+	const initializerPrereqs = new Prereqs();
+	const id = transformForInitializer(state, initializerPrereqs, node.initializer, statements);
+	luau.list.pushList(result, initializerPrereqs.statements);
 
-	const [[start, end, step], prereqs] = state.capture(() => ensureTransformOrder(state, macroCall.arguments));
-	luau.list.pushList(result, prereqs);
+	const rangePrereqs = new Prereqs();
+	const [start, end, step] = ensureTransformOrder(state, rangePrereqs, macroCall.arguments);
+	luau.list.pushList(result, rangePrereqs.statements);
 
 	luau.list.pushList(statements, transformStatementList(state, node.statement, getStatements(node.statement)));
 
@@ -487,7 +497,7 @@ export function transformForOfStatement(state: TransformState, node: ts.ForOfSta
 	if (ts.isVariableDeclarationList(node.initializer)) {
 		const name = node.initializer.declarations[0].name;
 		if (ts.isIdentifier(name)) {
-			validateIdentifier(state, name);
+			validateIdentifier(name);
 		}
 	}
 
@@ -496,16 +506,20 @@ export function transformForOfStatement(state: TransformState, node: ts.ForOfSta
 		return transformForOfRangeMacro(state, node, rangeMacroCall);
 	}
 
-	const result = luau.list.make<luau.Statement>();
-
-	const [exp, expPrereqs] = state.capture(() => transformExpression(state, node.expression));
-	luau.list.pushList(result, expPrereqs);
+	const expPrereqs = new Prereqs();
+	const exp = transformExpression(state, expPrereqs, node.expression);
 
 	const expType = state.getType(node.expression);
 	const statements = transformStatementList(state, node.statement, getStatements(node.statement));
 
 	const loopBuilder = getLoopBuilder(state, node.expression, expType);
-	luau.list.pushList(result, loopBuilder(state, statements, node.initializer, exp));
+	const loopPrereqs = new Prereqs();
+	const loopStatements = loopBuilder(state, loopPrereqs, statements, node.initializer, exp);
+
+	const result = luau.list.make<luau.Statement>();
+	luau.list.pushList(result, loopPrereqs.statements);
+	luau.list.pushList(result, expPrereqs.statements);
+	luau.list.pushList(result, loopStatements);
 
 	return result;
 }

--- a/src/TSTransformer/nodes/statements/transformForOfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForOfStatement.ts
@@ -13,7 +13,6 @@ import { transformStatementList } from "TSTransformer/nodes/transformStatementLi
 import { transformWritableExpression } from "TSTransformer/nodes/transformWritable";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
-import { getKindName } from "TSTransformer/util/getKindName";
 import { getLiteralNumberValue } from "TSTransformer/util/getLiteralNumberValue";
 import { getStatements } from "TSTransformer/util/getStatements";
 import { skipDownwards } from "TSTransformer/util/traversal";
@@ -197,13 +196,12 @@ function transformInLineArrayAssignmentPattern(
 					bindingPrereqs.push(transformInitializer(state, valueId, initializer));
 				}
 				transformArrayAssignmentPattern(state, bindingPrereqs, element, valueId);
-			} else if (ts.isObjectLiteralExpression(element)) {
+			} else {
+				assert(ts.isObjectLiteralExpression(element), "Expected object assignment pattern");
 				if (initializer) {
 					bindingPrereqs.push(transformInitializer(state, valueId, initializer));
 				}
 				transformObjectAssignmentPattern(state, bindingPrereqs, element, valueId);
-			} else {
-				assert(false, `transformInLineArrayAssignmentPattern invalid element: ${getKindName(element.kind)}`);
 			}
 
 			luau.list.push(ids, valueId);

--- a/src/TSTransformer/nodes/statements/transformForStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForStatement.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
 import { transformExpressionStatementInner } from "TSTransformer/nodes/statements/transformExpressionStatement";
@@ -141,11 +142,7 @@ function transformForStatementFallback(state: TransformState, node: ts.ForStatem
 			}
 
 			for (const declaration of initializer.declarations) {
-				const [decStatements, decPrereqs] = state.capture(() =>
-					transformVariableDeclaration(state, declaration),
-				);
-				luau.list.pushList(result, decPrereqs);
-				luau.list.pushList(result, decStatements);
+				luau.list.pushList(result, transformVariableDeclaration(state, declaration));
 			}
 
 			for (const id of variables) {
@@ -194,9 +191,7 @@ function transformForStatementFallback(state: TransformState, node: ts.ForStatem
 				}
 			}
 		} else {
-			const [statements, prereqs] = state.capture(() => transformExpressionStatementInner(state, initializer));
-			luau.list.pushList(result, prereqs);
-			luau.list.pushList(result, statements);
+			luau.list.pushList(result, transformExpressionStatementInner(state, initializer));
 		}
 	}
 
@@ -212,10 +207,7 @@ function transformForStatementFallback(state: TransformState, node: ts.ForStatem
 			}),
 		);
 
-		const incrementorStatements = luau.list.make<luau.Statement>();
-		const [statements, prereqs] = state.capture(() => transformExpressionStatementInner(state, incrementor));
-		luau.list.pushList(incrementorStatements, prereqs);
-		luau.list.pushList(incrementorStatements, statements);
+		const incrementorStatements = transformExpressionStatementInner(state, incrementor);
 
 		// if _shouldIncrement then
 		// 	[incrementorStatements]
@@ -238,15 +230,17 @@ function transformForStatementFallback(state: TransformState, node: ts.ForStatem
 		);
 	}
 
-	let [conditionExp, conditionPrereqs] = state.capture(() => {
-		if (condition) {
-			return createTruthinessChecks(state, transformExpression(state, condition), condition);
-		} else {
-			return luau.bool(true);
-		}
-	});
+	const conditionPrereqs = new Prereqs();
+	let conditionExp = condition
+		? createTruthinessChecks(
+				state,
+				conditionPrereqs,
+				transformExpression(state, conditionPrereqs, condition),
+				condition,
+			)
+		: luau.bool(true);
 
-	luau.list.pushList(whileStatements, conditionPrereqs);
+	luau.list.pushList(whileStatements, conditionPrereqs.statements);
 
 	if (!luau.list.isEmpty(whileStatements)) {
 		if (condition) {
@@ -429,8 +423,12 @@ function transformForStatementOptimized(state: TransformState, node: ts.ForState
 
 	const id = transformIdentifierDefined(state, decName);
 
-	const start = state.noPrereqs(() => transformExpression(state, decInit));
-	let end = state.noPrereqs(() => transformExpression(state, condition.right));
+	const startPrereqs = new Prereqs();
+	const start = transformExpression(state, startPrereqs, decInit);
+	assert(luau.list.isEmpty(startPrereqs.statements));
+	const endPrereqs = new Prereqs();
+	let end = transformExpression(state, endPrereqs, condition.right);
+	assert(luau.list.isEmpty(endPrereqs.statements));
 
 	const step = luau.number(stepValue);
 	const statements = transformStatementList(state, statement, getStatements(statement));

--- a/src/TSTransformer/nodes/statements/transformFunctionDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformFunctionDeclaration.ts
@@ -21,7 +21,7 @@ export function transformFunctionDeclaration(state: TransformState, node: ts.Fun
 	assert(node.name || isExportDefault);
 
 	if (node.name) {
-		validateIdentifier(state, node.name);
+		validateIdentifier(node.name);
 	}
 
 	const name = node.name ? transformIdentifierDefined(state, node.name) : luau.id("default");

--- a/src/TSTransformer/nodes/statements/transformIfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformIfStatement.ts
@@ -1,13 +1,23 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformStatementList } from "TSTransformer/nodes/transformStatementList";
 import { createTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
 import { getStatements } from "TSTransformer/util/getStatements";
 import ts from "typescript";
 
-export function transformIfStatementInner(state: TransformState, node: ts.IfStatement): luau.IfStatement {
-	const condition = createTruthinessChecks(state, transformExpression(state, node.expression), node.expression);
+export function transformIfStatementInner(
+	state: TransformState,
+	prereqs: Prereqs,
+	node: ts.IfStatement,
+): luau.IfStatement {
+	const condition = createTruthinessChecks(
+		state,
+		prereqs,
+		transformExpression(state, prereqs, node.expression),
+		node.expression,
+	);
 
 	const statements = transformStatementList(state, node.thenStatement, getStatements(node.thenStatement));
 
@@ -17,12 +27,13 @@ export function transformIfStatementInner(state: TransformState, node: ts.IfStat
 	if (elseStatement === undefined) {
 		elseBody = luau.list.make<luau.Statement>();
 	} else if (ts.isIfStatement(elseStatement)) {
-		const [elseIf, elseIfPrereqs] = state.capture(() => transformIfStatementInner(state, elseStatement));
-		if (luau.list.isEmpty(elseIfPrereqs)) {
+		const elseIfPrereqs = new Prereqs();
+		const elseIf = transformIfStatementInner(state, elseIfPrereqs, elseStatement);
+		if (luau.list.isEmpty(elseIfPrereqs.statements)) {
 			elseBody = elseIf;
 		} else {
 			const elseIfStatements = luau.list.make<luau.Statement>();
-			luau.list.pushList(elseIfStatements, elseIfPrereqs);
+			luau.list.pushList(elseIfStatements, elseIfPrereqs.statements);
 			luau.list.push(elseIfStatements, elseIf);
 			elseBody = elseIfStatements;
 		}
@@ -38,5 +49,10 @@ export function transformIfStatementInner(state: TransformState, node: ts.IfStat
 }
 
 export function transformIfStatement(state: TransformState, node: ts.IfStatement) {
-	return luau.list.make(transformIfStatementInner(state, node));
+	const statements = luau.list.make<luau.Statement>();
+	const prereqs = new Prereqs();
+	const statement = transformIfStatementInner(state, prereqs, node);
+	luau.list.pushList(statements, prereqs.statements);
+	luau.list.push(statements, statement);
+	return statements;
 }

--- a/src/TSTransformer/nodes/statements/transformImportDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformImportDeclaration.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { Lazy } from "Shared/classes/Lazy";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformVariable } from "TSTransformer/nodes/statements/transformVariableStatement";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
 import { cleanModuleName } from "TSTransformer/util/cleanModuleName";
@@ -67,6 +68,8 @@ export function transformImportDeclaration(state: TransformState, node: ts.Impor
 			importExp.set(id);
 		}
 
+		const bindingPrereqs = new Prereqs();
+
 		// default import logic
 		const importClauseName = importClause.name;
 		if (importClauseName) {
@@ -75,17 +78,14 @@ export function transformImportDeclaration(state: TransformState, node: ts.Impor
 				const moduleFile = getSourceFileFromModuleSpecifier(state, node.moduleSpecifier);
 				const moduleSymbol = moduleFile && state.typeChecker.getSymbolAtLocation(moduleFile);
 				if (moduleSymbol && state.getModuleExports(moduleSymbol).some(v => v.name === "default")) {
-					luau.list.pushList(
-						statements,
-						state.capturePrereqs(() =>
-							transformVariable(state, importClauseName, luau.property(importExp.get(), "default")),
-						),
+					transformVariable(
+						state,
+						bindingPrereqs,
+						importClauseName,
+						luau.property(importExp.get(), "default"),
 					);
 				} else {
-					luau.list.pushList(
-						statements,
-						state.capturePrereqs(() => transformVariable(state, importClauseName, importExp.get())),
-					);
+					transformVariable(state, bindingPrereqs, importClauseName, importExp.get());
 				}
 			}
 		}
@@ -94,35 +94,32 @@ export function transformImportDeclaration(state: TransformState, node: ts.Impor
 		if (importClauseNamedBindings) {
 			// namespace import logic
 			if (ts.isNamespaceImport(importClauseNamedBindings)) {
-				luau.list.pushList(
-					statements,
-					state.capturePrereqs(() =>
-						transformVariable(state, importClauseNamedBindings.name, importExp.get()),
-					),
-				);
+				transformVariable(state, bindingPrereqs, importClauseNamedBindings.name, importExp.get());
 			} else {
 				// named elements import logic
 				for (const element of importClauseNamedBindings.elements) {
 					const symbol = getOriginalSymbolOfNode(state.typeChecker, element.name);
 					// check that import is referenced and has a value at runtime
 					if (state.resolver.isReferencedAliasDeclaration(element) && (!symbol || isSymbolOfValue(symbol))) {
-						luau.list.pushList(
-							statements,
-							state.capturePrereqs(() =>
-								transformVariable(
+						transformVariable(
+							state,
+							bindingPrereqs,
+							element.name,
+							luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+								expression: importExp.get(),
+								index: transformPropertyName(
 									state,
-									element.name,
-									luau.create(luau.SyntaxKind.ComputedIndexExpression, {
-										expression: importExp.get(),
-										index: transformPropertyName(state, element.propertyName ?? element.name),
-									}),
+									bindingPrereqs,
+									element.propertyName ?? element.name,
 								),
-							),
+							}),
 						);
 					}
 				}
 			}
 		}
+
+		luau.list.pushList(statements, bindingPrereqs.statements);
 	}
 
 	// ensure we emit something

--- a/src/TSTransformer/nodes/statements/transformImportEqualsDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformImportEqualsDeclaration.ts
@@ -1,6 +1,7 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformVariable } from "TSTransformer/nodes/statements/transformVariableStatement";
 import { transformEntityName } from "TSTransformer/nodes/transformEntityName";
 import { createImportExpression } from "TSTransformer/util/createImportExpression";
@@ -10,18 +11,16 @@ import ts from "typescript";
 export function transformImportEqualsDeclaration(state: TransformState, node: ts.ImportEqualsDeclaration) {
 	const { moduleReference } = node;
 	if (ts.isExternalModuleReference(moduleReference)) {
+		const statements = luau.list.make<luau.Statement>();
 		assert(ts.isStringLiteral(moduleReference.expression));
 		const importExp = createImportExpression(state, node.getSourceFile(), moduleReference.expression);
-
-		const statements = luau.list.make<luau.Statement>();
 
 		const aliasSymbol = state.typeChecker.getSymbolAtLocation(node.name);
 		assert(aliasSymbol);
 		if (isSymbolOfValue(ts.skipAlias(aliasSymbol, state.typeChecker))) {
-			luau.list.pushList(
-				statements,
-				state.capturePrereqs(() => transformVariable(state, node.name, importExp)),
-			);
+			const importPrereqs = new Prereqs();
+			transformVariable(state, importPrereqs, node.name, importExp);
+			luau.list.pushList(statements, importPrereqs.statements);
 		}
 
 		// ensure we emit something
@@ -37,8 +36,8 @@ export function transformImportEqualsDeclaration(state: TransformState, node: ts
 	} else {
 		// Identifier | QualifiedName
 		// see: https://github.com/roblox-ts/roblox-ts/issues/1895
-		return state.capturePrereqs(() =>
-			transformVariable(state, node.name, transformEntityName(state, moduleReference)),
-		);
+		const importPrereqs = new Prereqs();
+		transformVariable(state, importPrereqs, node.name, transformEntityName(state, moduleReference));
+		return importPrereqs.statements;
 	}
 }

--- a/src/TSTransformer/nodes/statements/transformModuleDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformModuleDeclaration.ts
@@ -47,7 +47,7 @@ function transformNamespace(state: TransformState, name: ts.Identifier, body: ts
 	const symbol = state.typeChecker.getSymbolAtLocation(name);
 	assert(symbol);
 
-	validateIdentifier(state, name);
+	validateIdentifier(name);
 
 	const nameExp = transformIdentifierDefined(state, name);
 

--- a/src/TSTransformer/nodes/statements/transformReturnStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformReturnStatement.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { SYMBOL_NAMES, TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { isReturnBlockedByTryStatement } from "TSTransformer/util/isBlockedByTryStatement";
@@ -30,16 +31,16 @@ export function transformReturnStatementInner(
 	returnExp: ts.Expression,
 ): luau.List<luau.Statement> {
 	const result = luau.list.make<luau.Statement>();
+	const prereqs = new Prereqs();
 
 	let expression: luau.Expression | luau.List<luau.Expression>;
 
 	const innerReturnExp = skipDownwards(returnExp);
 	if (ts.isCallExpression(innerReturnExp) && isTupleMacro(state, innerReturnExp)) {
-		const [args, prereqs] = state.capture(() => ensureTransformOrder(state, innerReturnExp.arguments));
-		luau.list.pushList(result, prereqs);
+		const args = ensureTransformOrder(state, prereqs, innerReturnExp.arguments);
 		expression = luau.list.make(...args);
 	} else {
-		expression = transformExpression(state, innerReturnExp);
+		expression = transformExpression(state, prereqs, innerReturnExp);
 		if (isLuaTupleType(state)(state.getType(returnExp)) && !isTupleReturningCall(state, returnExp, expression)) {
 			if (luau.isArray(expression)) {
 				expression = expression.members;
@@ -48,6 +49,8 @@ export function transformReturnStatementInner(
 			}
 		}
 	}
+
+	luau.list.pushList(result, prereqs.statements);
 
 	if (isReturnBlockedByTryStatement(returnExp)) {
 		state.markTryUses("usesReturn");

--- a/src/TSTransformer/nodes/statements/transformStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformStatement.ts
@@ -50,7 +50,9 @@ function createTransformerMap<
 	T extends Array<
 		[
 			ts.SyntaxKind,
-			{ bivariant(state: TransformState, statement: ts.Statement): luau.List<luau.Statement> }["bivariant"],
+			{
+				bivariant(state: TransformState, statement: ts.Statement): luau.List<luau.Statement>;
+			}["bivariant"],
 		]
 	>,
 >(
@@ -103,8 +105,10 @@ const TRANSFORMER_BY_KIND = createTransformerMap([
 export function transformStatement(state: TransformState, node: ts.Statement): luau.List<luau.Statement> {
 	// if any modifiers of the node include the `declare` keyword we do not transform
 	// `declare` tells us that the identifier of the node is defined somewhere else and we should trust it
-	const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
-	if (modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword)) return NO_EMIT();
+	if (ts.canHaveModifiers(node) && ts.getModifiers(node)?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword)) {
+		return NO_EMIT();
+	}
+
 	const transformer = TRANSFORMER_BY_KIND.get(node.kind);
 	if (transformer) {
 		return transformer(state, node);

--- a/src/TSTransformer/nodes/statements/transformSwitchStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformSwitchStatement.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformStatementList } from "TSTransformer/nodes/transformStatementList";
 import { createHoistDeclaration } from "TSTransformer/util/createHoistDeclaration";
@@ -14,7 +15,10 @@ function transformCaseClauseExpression(
 	canFallThroughTo: boolean,
 ) {
 	const caseValueId = luau.tempId("caseValue");
-	let [expression, prereqStatements] = state.capture(() => transformExpression(state, caseClauseExpression));
+	const casePrereqs = new Prereqs();
+	const expression = transformExpression(state, casePrereqs, caseClauseExpression);
+	let prereqStatements = luau.list.make<luau.Statement>();
+	luau.list.pushList(prereqStatements, casePrereqs.statements);
 	const caseValueMightMutate = expressionMightMutate(state, expression, caseClauseExpression);
 
 	if (caseValueMightMutate) {
@@ -125,10 +129,13 @@ function transformCaseClause(
 }
 
 export function transformSwitchStatement(state: TransformState, node: ts.SwitchStatement) {
-	const switchExpression = transformExpression(state, node.expression);
+	const result = luau.list.make<luau.Statement>();
+	const prereqs = new Prereqs();
+	const switchExpression = transformExpression(state, prereqs, node.expression);
 	const expression = expressionMightMutate(state, switchExpression, node.expression)
-		? state.pushToVar(switchExpression, "exp")
-		: state.pushToVarIfComplex(switchExpression, "exp");
+		? prereqs.pushToVar(switchExpression, "exp")
+		: prereqs.pushToVarIfComplex(switchExpression, "exp");
+	luau.list.pushList(result, prereqs.statements);
 	const fallThroughFlagId = luau.tempId("fallthrough");
 
 	let isFallThroughFlagNeeded = false;
@@ -141,7 +148,11 @@ export function transformSwitchStatement(state: TransformState, node: ts.SwitchS
 		if (ts.isCaseClause(caseClauseNode)) {
 			const shouldUpdateFallThroughFlag =
 				i < node.caseBlock.clauses.length - 1 && ts.isCaseClause(node.caseBlock.clauses[i + 1]);
-			const { canFallThroughFrom, prereqs, clauseStatements } = transformCaseClause(
+			const {
+				canFallThroughFrom,
+				prereqs: prereqStatements,
+				clauseStatements,
+			} = transformCaseClause(
 				state,
 				caseClauseNode,
 				expression,
@@ -150,7 +161,7 @@ export function transformSwitchStatement(state: TransformState, node: ts.SwitchS
 				shouldUpdateFallThroughFlag,
 			);
 
-			luau.list.pushList(statements, prereqs);
+			luau.list.pushList(statements, prereqStatements);
 			luau.list.pushList(statements, clauseStatements);
 
 			canFallThroughTo = canFallThroughFrom;
@@ -174,10 +185,12 @@ export function transformSwitchStatement(state: TransformState, node: ts.SwitchS
 		);
 	}
 
-	return luau.list.make<luau.Statement>(
+	luau.list.push(
+		result,
 		luau.create(luau.SyntaxKind.RepeatStatement, {
 			condition: luau.bool(true),
 			statements,
 		}),
 	);
+	return result;
 }

--- a/src/TSTransformer/nodes/statements/transformThrowStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformThrowStatement.ts
@@ -1,16 +1,22 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import ts from "typescript";
 
 export function transformThrowStatement(state: TransformState, node: ts.ThrowStatement) {
+	const statements = luau.list.make<luau.Statement>();
+	const prereqs = new Prereqs();
 	const args = new Array<luau.Expression>();
 	if (node.expression !== undefined) {
-		args.push(transformExpression(state, node.expression));
+		args.push(transformExpression(state, prereqs, node.expression));
 	}
-	return luau.list.make(
+	luau.list.pushList(statements, prereqs.statements);
+	luau.list.push(
+		statements,
 		luau.create(luau.SyntaxKind.CallStatement, {
 			expression: luau.call(luau.globals.error, args),
 		}),
 	);
+	return statements;
 }

--- a/src/TSTransformer/nodes/statements/transformVariableStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformVariableStatement.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayBindingPattern } from "TSTransformer/nodes/binding/transformArrayBindingPattern";
 import { transformObjectBindingPattern } from "TSTransformer/nodes/binding/transformObjectBindingPattern";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
@@ -19,8 +20,13 @@ import { validateIdentifier } from "TSTransformer/util/validateIdentifier";
 import { wrapExpressionStatement } from "TSTransformer/util/wrapExpressionStatement";
 import ts from "typescript";
 
-export function transformVariable(state: TransformState, identifier: ts.Identifier, right?: luau.Expression) {
-	validateIdentifier(state, identifier);
+export function transformVariable(
+	state: TransformState,
+	prereqs: Prereqs,
+	identifier: ts.Identifier,
+	right?: luau.Expression,
+) {
+	validateIdentifier(identifier);
 
 	const symbol = state.typeChecker.getSymbolAtLocation(identifier);
 	assert(symbol);
@@ -30,7 +36,7 @@ export function transformVariable(state: TransformState, identifier: ts.Identifi
 		const exportAccess = state.getModuleIdPropertyAccess(symbol);
 		if (exportAccess) {
 			if (right) {
-				state.prereq(
+				prereqs.push(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: exportAccess,
 						operator: "=",
@@ -55,10 +61,10 @@ export function transformVariable(state: TransformState, identifier: ts.Identifi
 	if (state.isHoisted.get(symbol) === true) {
 		// no need to do `x = nil` if the variable is already created
 		if (right) {
-			state.prereq(luau.create(luau.SyntaxKind.Assignment, { left, operator: "=", right }));
+			prereqs.push(luau.create(luau.SyntaxKind.Assignment, { left, operator: "=", right }));
 		}
 	} else {
-		state.prereq(luau.create(luau.SyntaxKind.VariableDeclaration, { left, right }));
+		prereqs.push(luau.create(luau.SyntaxKind.VariableDeclaration, { left, right }));
 	}
 
 	return left;
@@ -69,39 +75,43 @@ function transformOptimizedArrayBindingPattern(
 	bindingPattern: ts.ArrayBindingPattern,
 	rhs: luau.Expression | luau.List<luau.Expression>,
 ) {
-	return state.capturePrereqs(() => {
-		const ids = luau.list.make<luau.AnyIdentifier>();
-		const statements = state.capturePrereqs(() => {
-			for (const element of bindingPattern.elements) {
-				if (ts.isOmittedExpression(element)) {
-					luau.list.push(ids, luau.tempId());
-				} else {
-					if (ts.isIdentifier(element.name)) {
-						validateIdentifier(state, element.name);
-						const id = transformIdentifierDefined(state, element.name);
-						luau.list.push(ids, id);
-						if (element.initializer) {
-							state.prereq(transformInitializer(state, id, element.initializer));
-						}
-					} else {
-						const id = luau.tempId("binding");
-						luau.list.push(ids, id);
-						if (element.initializer) {
-							state.prereq(transformInitializer(state, id, element.initializer));
-						}
-						if (ts.isArrayBindingPattern(element.name)) {
-							transformArrayBindingPattern(state, element.name, id);
-						} else {
-							transformObjectBindingPattern(state, element.name, id);
-						}
-					}
+	const ids = luau.list.make<luau.AnyIdentifier>();
+	const bindingStatements = luau.list.make<luau.Statement>();
+	for (const element of bindingPattern.elements) {
+		if (ts.isOmittedExpression(element)) {
+			luau.list.push(ids, luau.tempId());
+		} else {
+			if (ts.isIdentifier(element.name)) {
+				validateIdentifier(element.name);
+				const id = transformIdentifierDefined(state, element.name);
+				luau.list.push(ids, id);
+				if (element.initializer) {
+					luau.list.push(bindingStatements, transformInitializer(state, id, element.initializer));
 				}
+			} else {
+				const id = luau.tempId("binding");
+				luau.list.push(ids, id);
+				if (element.initializer) {
+					luau.list.push(bindingStatements, transformInitializer(state, id, element.initializer));
+				}
+
+				const bindingPrereqs = new Prereqs();
+				if (ts.isArrayBindingPattern(element.name)) {
+					transformArrayBindingPattern(state, bindingPrereqs, element.name, id);
+				} else {
+					transformObjectBindingPattern(state, bindingPrereqs, element.name, id);
+				}
+				luau.list.pushList(bindingStatements, bindingPrereqs.statements);
 			}
-		});
-		assert(!luau.list.isEmpty(ids));
-		state.prereq(luau.create(luau.SyntaxKind.VariableDeclaration, { left: ids, right: rhs }));
-		state.prereqList(statements);
-	});
+		}
+	}
+
+	assert(!luau.list.isEmpty(ids));
+	const statements = luau.list.make<luau.Statement>(
+		luau.create(luau.SyntaxKind.VariableDeclaration, { left: ids, right: rhs }),
+	);
+	luau.list.pushList(statements, bindingStatements);
+	return statements;
 }
 
 export function transformVariableDeclaration(
@@ -112,19 +122,16 @@ export function transformVariableDeclaration(
 	let value: luau.Expression | undefined;
 	if (node.initializer) {
 		// must transform right _before_ checking isHoisted, that way references inside of value can be hoisted
-		luau.list.pushList(
-			statements,
-			// non-null assertion on node.initializer because inside callback
-			state.capturePrereqs(() => (value = transformExpression(state, node.initializer!))),
-		);
+		const initializerPrereqs = new Prereqs();
+		value = transformExpression(state, initializerPrereqs, node.initializer);
+		luau.list.pushList(statements, initializerPrereqs.statements);
 	}
 
 	const name = node.name;
 	if (ts.isIdentifier(name)) {
-		luau.list.pushList(
-			statements,
-			state.capturePrereqs(() => transformVariable(state, name, value)),
-		);
+		const variablePrereqs = new Prereqs();
+		transformVariable(state, variablePrereqs, name, value);
+		luau.list.pushList(statements, variablePrereqs.statements);
 	} else {
 		// in destructuring, rhs must be executed first
 		assert(node.initializer && value);
@@ -154,20 +161,16 @@ export function transformVariableDeclaration(
 			) {
 				luau.list.pushList(statements, transformOptimizedArrayBindingPattern(state, name, value.members));
 			} else {
-				luau.list.pushList(
-					statements,
-					state.capturePrereqs(() =>
-						transformArrayBindingPattern(state, name, getTargetIdForBindingPattern(state, name, value!)),
-					),
-				);
+				const bindingPrereqs = new Prereqs();
+				const target = getTargetIdForBindingPattern(bindingPrereqs, name, value);
+				transformArrayBindingPattern(state, bindingPrereqs, name, target);
+				luau.list.pushList(statements, bindingPrereqs.statements);
 			}
 		} else {
-			luau.list.pushList(
-				statements,
-				state.capturePrereqs(() =>
-					transformObjectBindingPattern(state, name, getTargetIdForBindingPattern(state, name, value!)),
-				),
-			);
+			const bindingPrereqs = new Prereqs();
+			const target = getTargetIdForBindingPattern(bindingPrereqs, name, value);
+			transformObjectBindingPattern(state, bindingPrereqs, name, target);
+			luau.list.pushList(statements, bindingPrereqs.statements);
 		}
 	}
 
@@ -188,9 +191,7 @@ export function transformVariableDeclarationList(
 
 	const statements = luau.list.make<luau.Statement>();
 	for (const declaration of node.declarations) {
-		const [variableStatements, prereqs] = state.capture(() => transformVariableDeclaration(state, declaration));
-		luau.list.pushList(statements, prereqs);
-		luau.list.pushList(statements, variableStatements);
+		luau.list.pushList(statements, transformVariableDeclaration(state, declaration));
 	}
 
 	return statements;

--- a/src/TSTransformer/nodes/transformEntityName.ts
+++ b/src/TSTransformer/nodes/transformEntityName.ts
@@ -7,7 +7,7 @@ import ts from "typescript";
 
 export function transformEntityName(state: TransformState, node: ts.EntityName) {
 	if (ts.isIdentifier(node)) {
-		validateIdentifier(state, node);
+		validateIdentifier(node);
 		return transformIdentifier(state, node);
 	} else {
 		return transformQualifiedName(state, node);

--- a/src/TSTransformer/nodes/transformInitializer.ts
+++ b/src/TSTransformer/nodes/transformInitializer.ts
@@ -1,20 +1,26 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import ts from "typescript";
 
 export function transformInitializer(state: TransformState, id: luau.WritableExpression, initializer: ts.Expression) {
+	const statements = luau.list.make<luau.Statement>();
+	const initializerPrereqs = new Prereqs();
+	const value = transformExpression(state, initializerPrereqs, initializer);
+	luau.list.pushList(statements, initializerPrereqs.statements);
+	luau.list.push(
+		statements,
+		luau.create(luau.SyntaxKind.Assignment, {
+			left: id,
+			operator: "=",
+			right: value,
+		}),
+	);
+
 	return luau.create(luau.SyntaxKind.IfStatement, {
 		condition: luau.binary(id, "==", luau.nil()),
 		elseBody: luau.list.make(),
-		statements: state.capturePrereqs(() => {
-			state.prereq(
-				luau.create(luau.SyntaxKind.Assignment, {
-					left: id,
-					operator: "=",
-					right: transformExpression(state, initializer),
-				}),
-			);
-		}),
+		statements,
 	});
 }

--- a/src/TSTransformer/nodes/transformLogical.ts
+++ b/src/TSTransformer/nodes/transformLogical.ts
@@ -1,6 +1,7 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { createTruthinessChecks, willCreateTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
 import { binaryExpressionChain } from "TSTransformer/util/expressionChain";
@@ -42,13 +43,14 @@ function getLogicalChain(
 ): Array<LogicalChainItem> {
 	return flattenByOperator(binaryExp, binaryOperatorKind).map((node, index, array) => {
 		const type = state.getType(node);
-		const [expression, statements] = state.capture(() => transformExpression(state, node));
+		const expressionPrereqs = new Prereqs();
+		const expression = transformExpression(state, expressionPrereqs, node);
 		let inline = false;
 		if (enableInlining) {
 			const willWrap = index < array.length - 1 && willCreateTruthinessChecks(type);
-			inline = luau.list.isEmpty(statements) && !willWrap;
+			inline = luau.list.isEmpty(expressionPrereqs.statements) && !willWrap;
 		}
-		return { node, type, expression, statements, inline };
+		return { node, type, expression, statements: expressionPrereqs.statements, inline };
 	});
 }
 
@@ -57,22 +59,23 @@ function getLogicalChain(
  */
 function buildLogicalChainPrereqs(
 	state: TransformState,
+	prereqs: Prereqs,
 	chain: Array<LogicalChainItem>,
 	conditionId: luau.TemporaryIdentifier,
-	buildCondition: (conditionId: luau.TemporaryIdentifier, node: ts.Expression) => luau.Expression,
+	buildCondition: (prereqs: Prereqs, conditionId: luau.TemporaryIdentifier, node: ts.Expression) => luau.Expression,
 	index = 0,
 ) {
 	const expInfo = chain[index];
-	state.prereqList(expInfo.statements);
+	prereqs.pushList(expInfo.statements);
 	if (index === 0) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.VariableDeclaration, {
 				left: conditionId,
 				right: expInfo.expression,
 			}),
 		);
 	} else {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: conditionId,
 				operator: "=",
@@ -81,12 +84,13 @@ function buildLogicalChainPrereqs(
 		);
 	}
 	if (index + 1 < chain.length) {
-		state.prereq(
+		const condition = buildCondition(prereqs, conditionId, expInfo.node);
+		const branchPrereqs = new Prereqs();
+		buildLogicalChainPrereqs(state, branchPrereqs, chain, conditionId, buildCondition, index + 1);
+		prereqs.push(
 			luau.create(luau.SyntaxKind.IfStatement, {
-				condition: buildCondition(conditionId, expInfo.node),
-				statements: state.capturePrereqs(() =>
-					buildLogicalChainPrereqs(state, chain, conditionId, buildCondition, index + 1),
-				),
+				condition,
+				statements: branchPrereqs.statements,
 				elseBody: luau.list.make(),
 			}),
 		);
@@ -125,10 +129,11 @@ function mergeInlineExpressions(chain: Array<LogicalChainItem>, binaryOperator: 
  */
 function buildInlineConditionExpression(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.BinaryExpression,
 	tsBinaryOperator: ts.SyntaxKind,
 	luaBinaryOperator: luau.BinaryOperator,
-	buildCondition: (conditionId: luau.TemporaryIdentifier, node: ts.Expression) => luau.Expression,
+	buildCondition: (prereqs: Prereqs, conditionId: luau.TemporaryIdentifier, node: ts.Expression) => luau.Expression,
 ) {
 	const chain = getLogicalChain(state, node, tsBinaryOperator, true);
 
@@ -140,27 +145,46 @@ function buildInlineConditionExpression(
 	}
 
 	const conditionId = luau.tempId("condition");
-	buildLogicalChainPrereqs(state, chain, conditionId, buildCondition);
+	buildLogicalChainPrereqs(state, prereqs, chain, conditionId, buildCondition);
 	return conditionId;
 }
 
-export function transformLogical(state: TransformState, node: ts.BinaryExpression): luau.Expression {
+export function transformLogical(state: TransformState, prereqs: Prereqs, node: ts.BinaryExpression): luau.Expression {
 	if (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
-		return buildInlineConditionExpression(state, node, node.operatorToken.kind, "and", (conditionId, node) =>
-			createTruthinessChecks(state, conditionId, node),
+		return buildInlineConditionExpression(
+			state,
+			prereqs,
+			node,
+			node.operatorToken.kind,
+			"and",
+			(prereqs, conditionId, node) => createTruthinessChecks(state, prereqs, conditionId, node),
 		);
 	} else if (node.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
-		return buildInlineConditionExpression(state, node, node.operatorToken.kind, "or", (conditionId, node) =>
-			luau.unary("not", createTruthinessChecks(state, conditionId, node)),
+		return buildInlineConditionExpression(
+			state,
+			prereqs,
+			node,
+			node.operatorToken.kind,
+			"or",
+			(prereqs, conditionId, node) =>
+				luau.unary("not", createTruthinessChecks(state, prereqs, conditionId, node)),
 		);
 	} else if (node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
-		const conditionBuilder = (conditionId: luau.TemporaryIdentifier) => luau.binary(conditionId, "==", luau.nil());
+		const conditionBuilder = (prereqs: Prereqs, conditionId: luau.TemporaryIdentifier) =>
+			luau.binary(conditionId, "==", luau.nil());
 		if (!isPossiblyType(state.getType(node), isBooleanLiteralType(state, false))) {
-			return buildInlineConditionExpression(state, node, node.operatorToken.kind, "or", conditionBuilder);
+			return buildInlineConditionExpression(
+				state,
+				prereqs,
+				node,
+				node.operatorToken.kind,
+				"or",
+				conditionBuilder,
+			);
 		}
 		const chain = getLogicalChain(state, node, ts.SyntaxKind.QuestionQuestionToken, false);
 		const conditionId = luau.tempId("condition");
-		buildLogicalChainPrereqs(state, chain, conditionId, conditionBuilder);
+		buildLogicalChainPrereqs(state, prereqs, chain, conditionId, conditionBuilder);
 		return conditionId;
 	}
 	assert(false, `Operator not implemented: ${getKindName(node.operatorToken.kind)}`);

--- a/src/TSTransformer/nodes/transformLogicalOrCoalescingAssignmentExpression.ts
+++ b/src/TSTransformer/nodes/transformLogicalOrCoalescingAssignmentExpression.ts
@@ -1,4 +1,5 @@
 import luau from "@roblox-ts/luau-ast";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformWritableExpression } from "TSTransformer/nodes/transformWritable";
@@ -7,14 +8,16 @@ import ts from "typescript";
 
 function transformCoalescingAssignmentExpression(
 	state: TransformState,
+	prereqs: Prereqs,
 	left: ts.LeftHandSideExpression,
 	right: ts.Expression,
 ) {
-	const writable = transformWritableExpression(state, left, true);
-	const [value, valuePreqreqs] = state.capture(() => transformExpression(state, right));
+	const writable = transformWritableExpression(state, prereqs, left, true);
+	const valuePrereqs = new Prereqs();
+	const value = transformExpression(state, valuePrereqs, right);
 
 	const ifStatements = luau.list.make<luau.Statement>();
-	luau.list.pushList(ifStatements, valuePreqreqs);
+	luau.list.pushList(ifStatements, valuePrereqs.statements);
 	luau.list.push(
 		ifStatements,
 		luau.create(luau.SyntaxKind.Assignment, {
@@ -24,7 +27,7 @@ function transformCoalescingAssignmentExpression(
 		}),
 	);
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.IfStatement, {
 			condition: luau.binary(writable, "==", luau.nil()),
 			statements: ifStatements,
@@ -37,16 +40,18 @@ function transformCoalescingAssignmentExpression(
 
 function transformLogicalAndAssignmentExpression(
 	state: TransformState,
+	prereqs: Prereqs,
 	left: ts.LeftHandSideExpression,
 	right: ts.Expression,
 ) {
-	const writable = transformWritableExpression(state, left, true);
-	const [value, valuePreqreqs] = state.capture(() => transformExpression(state, right));
+	const writable = transformWritableExpression(state, prereqs, left, true);
+	const valuePrereqs = new Prereqs();
+	const value = transformExpression(state, valuePrereqs, right);
 
-	const conditionId = state.pushToVar(writable, "condition");
+	const conditionId = prereqs.pushToVar(writable, "condition");
 
 	const ifStatements = luau.list.make<luau.Statement>();
-	luau.list.pushList(ifStatements, valuePreqreqs);
+	luau.list.pushList(ifStatements, valuePrereqs.statements);
 	luau.list.push(
 		ifStatements,
 		luau.create(luau.SyntaxKind.Assignment, {
@@ -56,15 +61,15 @@ function transformLogicalAndAssignmentExpression(
 		}),
 	);
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.IfStatement, {
-			condition: createTruthinessChecks(state, writable, left),
+			condition: createTruthinessChecks(state, prereqs, writable, left),
 			statements: ifStatements,
 			elseBody: luau.list.make(),
 		}),
 	);
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: writable,
 			operator: "=",
@@ -77,16 +82,18 @@ function transformLogicalAndAssignmentExpression(
 
 function transformLogicalOrAssignmentExpression(
 	state: TransformState,
+	prereqs: Prereqs,
 	left: ts.LeftHandSideExpression,
 	right: ts.Expression,
 ) {
-	const writable = transformWritableExpression(state, left, true);
-	const [value, valuePreqreqs] = state.capture(() => transformExpression(state, right));
+	const writable = transformWritableExpression(state, prereqs, left, true);
+	const valuePrereqs = new Prereqs();
+	const value = transformExpression(state, valuePrereqs, right);
 
-	const conditionId = state.pushToVar(writable, "condition");
+	const conditionId = prereqs.pushToVar(writable, "condition");
 
 	const ifStatements = luau.list.make<luau.Statement>();
-	luau.list.pushList(ifStatements, valuePreqreqs);
+	luau.list.pushList(ifStatements, valuePrereqs.statements);
 	luau.list.push(
 		ifStatements,
 		luau.create(luau.SyntaxKind.Assignment, {
@@ -96,15 +103,15 @@ function transformLogicalOrAssignmentExpression(
 		}),
 	);
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.IfStatement, {
-			condition: luau.unary("not", createTruthinessChecks(state, writable, left)),
+			condition: luau.unary("not", createTruthinessChecks(state, prereqs, writable, left)),
 			statements: ifStatements,
 			elseBody: luau.list.make(),
 		}),
 	);
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: writable,
 			operator: "=",
@@ -117,15 +124,16 @@ function transformLogicalOrAssignmentExpression(
 
 export function transformLogicalOrCoalescingAssignmentExpression(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.AssignmentExpression<ts.Token<ts.LogicalOrCoalescingAssignmentOperator>>,
 ): luau.WritableExpression {
 	const operator = node.operatorToken.kind;
 	if (operator === ts.SyntaxKind.QuestionQuestionEqualsToken) {
-		return transformCoalescingAssignmentExpression(state, node.left, node.right);
+		return transformCoalescingAssignmentExpression(state, prereqs, node.left, node.right);
 	} else if (operator === ts.SyntaxKind.AmpersandAmpersandEqualsToken) {
-		return transformLogicalAndAssignmentExpression(state, node.left, node.right);
+		return transformLogicalAndAssignmentExpression(state, prereqs, node.left, node.right);
 	} else {
-		return transformLogicalOrAssignmentExpression(state, node.left, node.right);
+		return transformLogicalOrAssignmentExpression(state, prereqs, node.left, node.right);
 	}
 }
 
@@ -133,5 +141,7 @@ export function transformLogicalOrCoalescingAssignmentExpressionStatement(
 	state: TransformState,
 	node: ts.AssignmentExpression<ts.Token<ts.LogicalOrCoalescingAssignmentOperator>>,
 ): luau.List<luau.Statement> {
-	return state.capturePrereqs(() => transformLogicalOrCoalescingAssignmentExpression(state, node));
+	const prereqs = new Prereqs();
+	transformLogicalOrCoalescingAssignmentExpression(state, prereqs, node);
+	return prereqs.statements;
 }

--- a/src/TSTransformer/nodes/transformMacroCall.ts
+++ b/src/TSTransformer/nodes/transformMacroCall.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { CallMacro, PropertyCallMacro } from "TSTransformer/macros/types";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { EvaluationOperand, planEvaluation } from "TSTransformer/util/evaluation/plan";
@@ -13,19 +14,21 @@ import ts from "typescript";
 export function transformMacroCall(
 	macro: CallMacro | PropertyCallMacro,
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.CallExpression,
 	expression: luau.Expression,
 	nodeArguments: ReadonlyArray<ts.Expression>,
 ): luau.Expression {
 	const operands: Array<EvaluationOperand> = [{ expression, prereqs: luau.list.make() }];
 	for (const argument of nodeArguments) {
-		let [value, prereqs] = state.capture(() => transformExpression(state, argument));
+		const valuePrereqs = new Prereqs();
+		let value = transformExpression(state, valuePrereqs, argument);
 		if (!ts.isSpreadElement(argument)) {
 			// scalar arguments must supply one nil even when an inlined call returns no values
 			if (luau.isCall(value) && isPossiblyType(state.getType(argument), isUndefinedType)) {
 				value = luau.create(luau.SyntaxKind.ParenthesizedExpression, { expression: value });
 			}
-			operands.push({ expression: value, prereqs });
+			operands.push({ expression: value, prereqs: valuePrereqs.statements });
 			continue;
 		}
 		const signature = state.typeChecker.getResolvedSignature(node);
@@ -41,23 +44,22 @@ export function transformMacroCall(
 		const ids = Array.from({ length: count }, (_, i) => luau.tempId(`spread${i}`));
 		if (ids.length === 0) {
 			// an empty spread may still have effects
-			luau.list.push(
-				prereqs,
-				luau.create(luau.SyntaxKind.VariableDeclaration, { left: luau.tempId(), right: value }),
-			);
-			operands.push({ expression: luau.none(), prereqs });
+			valuePrereqs.push(luau.create(luau.SyntaxKind.VariableDeclaration, { left: luau.tempId(), right: value }));
+			operands.push({ expression: luau.none(), prereqs: valuePrereqs.statements });
 		} else {
-			luau.list.push(
-				prereqs,
+			valuePrereqs.push(
 				luau.create(luau.SyntaxKind.VariableDeclaration, { left: luau.list.make(...ids), right: value }),
 			);
-			ids.forEach((id, i) => operands.push({ expression: id, prereqs: i === 0 ? prereqs : luau.list.make() }));
+			ids.forEach((id, i) =>
+				operands.push({ expression: id, prereqs: i === 0 ? valuePrereqs.statements : luau.list.make() }),
+			);
 		}
 	}
-	const result = planEvaluation(state, operands, ([receiver, ...args]) =>
+	const result = planEvaluation(prereqs, operands, (expansionPrereqs, [receiver, ...args]) =>
 		macro(
 			state,
-			node as Parameters<PropertyCallMacro>[1],
+			expansionPrereqs,
+			node as Parameters<PropertyCallMacro>[2],
 			receiver,
 			args.filter(arg => !luau.isNone(arg)),
 		),

--- a/src/TSTransformer/nodes/transformMethodDeclaration.ts
+++ b/src/TSTransformer/nodes/transformMethodDeclaration.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformParameters } from "TSTransformer/nodes/transformParameters";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
 import { transformStatementList } from "TSTransformer/nodes/transformStatementList";
@@ -13,6 +14,7 @@ import ts from "typescript";
 
 export function transformMethodDeclaration(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.MethodDeclaration,
 	ptr: Pointer<luau.Map | luau.AnyIdentifier>,
 ) {
@@ -31,7 +33,7 @@ export function transformMethodDeclaration(
 	let { statements, parameters, hasDotDotDot } = transformParameters(state, node);
 	luau.list.pushList(statements, transformStatementList(state, node.body, node.body.statements));
 
-	let name = transformPropertyName(state, node.name);
+	let name = transformPropertyName(state, prereqs, node.name);
 
 	if (ts.hasDecorators(node) || node.parameters.some(parameter => ts.hasDecorators(parameter))) {
 		if (!luau.isSimplePrimitive(name)) {
@@ -97,10 +99,9 @@ export function transformMethodDeclaration(
 	}
 
 	// we have to use `class[name] = function()`
-	luau.list.pushList(
-		result,
-		state.capturePrereqs(() => assignToMapPointer(state, ptr, name, expression)),
-	);
+	const assignmentPrereqs = new Prereqs();
+	assignToMapPointer(assignmentPrereqs, ptr, name, expression);
+	luau.list.pushList(result, assignmentPrereqs.statements);
 
 	return result;
 }

--- a/src/TSTransformer/nodes/transformOptionalChain.ts
+++ b/src/TSTransformer/nodes/transformOptionalChain.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import {
 	transformCallExpressionInner,
 	transformElementCallExpressionInner,
@@ -149,16 +150,17 @@ export function flattenOptionalChain(expression: ts.Expression) {
 	return { chain, expression };
 }
 
-function transformChainItem(state: TransformState, baseExpression: luau.Expression, item: ChainItem) {
+function transformChainItem(state: TransformState, prereqs: Prereqs, baseExpression: luau.Expression, item: ChainItem) {
 	if (item.kind === OptionalChainItemKind.PropertyAccess) {
-		return transformPropertyAccessExpressionInner(state, item.node, baseExpression, item.name);
+		return transformPropertyAccessExpressionInner(state, prereqs, item.node, baseExpression, item.name);
 	} else if (item.kind === OptionalChainItemKind.ElementAccess) {
-		return transformElementAccessExpressionInner(state, item.node, baseExpression, item.expression);
+		return transformElementAccessExpressionInner(state, prereqs, item.node, baseExpression, item.expression);
 	} else if (item.kind === OptionalChainItemKind.Call) {
-		return transformCallExpressionInner(state, item.node, baseExpression, item.args);
+		return transformCallExpressionInner(state, prereqs, item.node, baseExpression, item.args);
 	} else if (item.kind === OptionalChainItemKind.PropertyCall) {
 		return transformPropertyCallExpressionInner(
 			state,
+			prereqs,
 			item.node,
 			item.expression,
 			baseExpression,
@@ -168,6 +170,7 @@ function transformChainItem(state: TransformState, baseExpression: luau.Expressi
 	} else {
 		return transformElementCallExpressionInner(
 			state,
+			prereqs,
 			item.node,
 			item.expression,
 			baseExpression,
@@ -178,13 +181,13 @@ function transformChainItem(state: TransformState, baseExpression: luau.Expressi
 }
 
 function createOrSetTempId(
-	state: TransformState,
+	prereqs: Prereqs,
 	tempId: luau.TemporaryIdentifier | undefined,
 	expression: luau.Expression,
 	node: ts.Node,
 ) {
 	if (tempId === undefined) {
-		tempId = state.pushToVar(
+		tempId = prereqs.pushToVar(
 			expression,
 			node.parent && ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)
 				? node.parent.name.text
@@ -192,7 +195,7 @@ function createOrSetTempId(
 		);
 	} else {
 		if (tempId !== expression) {
-			state.prereq(
+			prereqs.push(
 				luau.create(luau.SyntaxKind.Assignment, {
 					left: tempId,
 					operator: "=",
@@ -218,6 +221,7 @@ function isCompoundCall(item: ChainItem): item is PropertyCallItem | ElementCall
 
 function transformOptionalChainInner(
 	state: TransformState,
+	prereqs: Prereqs,
 	chain: Array<ChainItem>,
 	baseExpression: luau.Expression,
 	tempId: luau.TemporaryIdentifier | undefined = undefined,
@@ -235,12 +239,12 @@ function transformOptionalChainInner(
 			isSuperCall = ts.isSuperProperty(item.expression);
 
 			if (item.callOptional && isMethodCall && !isSuperCall) {
-				selfParam = state.pushToVar(baseExpression, "self");
+				selfParam = prereqs.pushToVar(baseExpression, "self");
 				baseExpression = selfParam;
 			}
 
 			if (item.optional) {
-				tempId = createOrSetTempId(state, tempId, baseExpression, chain[chain.length - 1].node);
+				tempId = createOrSetTempId(prereqs, tempId, baseExpression, chain[chain.length - 1].node);
 				baseExpression = tempId;
 			}
 
@@ -252,83 +256,78 @@ function transformOptionalChainInner(
 
 					baseExpression = luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 						expression: convertToIndexableExpression(baseExpression),
-						index: addOneIfArrayType(state, expType, transformExpression(state, item.argumentExpression)),
+						index: addOneIfArrayType(
+							state,
+							expType,
+							transformExpression(state, prereqs, item.argumentExpression),
+						),
 					});
 				}
 			}
 		}
 
-		// capture so we can wrap later if necessary
-		const [result, prereqStatements] = state.capture(() => {
-			tempId = createOrSetTempId(state, tempId, baseExpression, chain[chain.length - 1].node);
+		// receiver initialization may need its own nil check before the optional call
+		const receiverPrereqs = new Prereqs();
+		tempId = createOrSetTempId(receiverPrereqs, tempId, baseExpression, chain[chain.length - 1].node);
 
-			const [newValue, ifStatements] = state.capture(() => {
-				let newExpression: luau.Expression;
-				if (isCompoundCall(item) && item.callOptional) {
-					const expType = state.typeChecker.getNonOptionalType(state.getType(item.node.expression));
-					const symbol = getFirstDefinedSymbol(state, expType);
-					if (symbol) {
-						const macro = state.services.macroManager.getPropertyCallMacro(symbol);
-						if (macro) {
-							DiagnosticService.addDiagnostic(errors.noOptionalMacroCall(item.node));
-							return luau.none();
-						}
-					}
-
-					const args = ensureTransformOrder(state, item.args);
-					if (isMethodCall) {
-						if (isSuperCall) {
-							args.unshift(luau.globals.self);
-						} else {
-							args.unshift(selfParam!);
-						}
-					}
-					newExpression = wrapReturnIfLuaTuple(state, item.node, luau.call(tempId!, args));
-				} else {
-					newExpression = transformChainItem(state, tempId!, item);
-				}
-				return transformOptionalChainInner(state, chain, newExpression, tempId, index + 1);
-			});
-
-			const isUsed = !luau.isNone(newValue) && !isUsedAsStatement(item.node);
-
-			if (tempId !== newValue && isUsed) {
-				luau.list.push(
-					ifStatements,
-					luau.create(luau.SyntaxKind.Assignment, {
-						left: tempId,
-						operator: "=",
-						right: newValue,
-					}),
-				);
+		const branchPrereqs = new Prereqs();
+		let newExpression: luau.Expression | undefined;
+		if (isCompoundCall(item) && item.callOptional) {
+			const expType = state.typeChecker.getNonOptionalType(state.getType(item.node.expression));
+			const symbol = getFirstDefinedSymbol(state, expType);
+			const macro = symbol && state.services.macroManager.getPropertyCallMacro(symbol);
+			if (macro) {
+				DiagnosticService.addDiagnostic(errors.noOptionalMacroCall(item.node));
 			} else {
-				if (luau.isCall(newValue)) {
-					luau.list.push(
-						ifStatements,
-						luau.create(luau.SyntaxKind.CallStatement, {
-							expression: newValue,
-						}),
-					);
+				const args = ensureTransformOrder(state, branchPrereqs, item.args);
+				if (isMethodCall) {
+					if (isSuperCall) {
+						args.unshift(luau.globals.self);
+					} else {
+						args.unshift(selfParam!);
+					}
 				}
+				newExpression = wrapReturnIfLuaTuple(state, item.node, luau.call(tempId, args));
 			}
-
-			state.prereq(createNilCheck(tempId, ifStatements));
-
-			return isUsed ? tempId : luau.none();
-		});
-
-		if (isCompoundCall(item) && item.optional && item.callOptional) {
-			state.prereq(createNilCheck(tempId!, prereqStatements));
 		} else {
-			state.prereqList(prereqStatements);
+			newExpression = transformChainItem(state, branchPrereqs, tempId, item);
+		}
+		const newValue = newExpression
+			? transformOptionalChainInner(state, branchPrereqs, chain, newExpression, tempId, index + 1)
+			: luau.none();
+		const isUsed = !luau.isNone(newValue) && !isUsedAsStatement(item.node);
+
+		if (tempId !== newValue && isUsed) {
+			branchPrereqs.push(
+				luau.create(luau.SyntaxKind.Assignment, {
+					left: tempId,
+					operator: "=",
+					right: newValue,
+				}),
+			);
+		} else if (luau.isCall(newValue)) {
+			branchPrereqs.push(
+				luau.create(luau.SyntaxKind.CallStatement, {
+					expression: newValue,
+				}),
+			);
 		}
 
-		return result;
+		receiverPrereqs.push(createNilCheck(tempId, branchPrereqs.statements));
+
+		if (isCompoundCall(item) && item.optional && item.callOptional) {
+			prereqs.push(createNilCheck(tempId, receiverPrereqs.statements));
+		} else {
+			prereqs.pushList(receiverPrereqs.statements);
+		}
+
+		return isUsed ? tempId : luau.none();
 	} else {
 		return transformOptionalChainInner(
 			state,
+			prereqs,
 			chain,
-			transformChainItem(state, baseExpression, item),
+			transformChainItem(state, prereqs, baseExpression, item),
 			tempId,
 			index + 1,
 		);
@@ -337,8 +336,9 @@ function transformOptionalChainInner(
 
 export function transformOptionalChain(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.PropertyAccessExpression | ts.ElementAccessExpression | ts.CallExpression,
 ): luau.Expression {
 	const { chain, expression } = flattenOptionalChain(node);
-	return transformOptionalChainInner(state, chain, transformExpression(state, expression));
+	return transformOptionalChainInner(state, prereqs, chain, transformExpression(state, prereqs, expression));
 }

--- a/src/TSTransformer/nodes/transformParameters.ts
+++ b/src/TSTransformer/nodes/transformParameters.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformArrayBindingPattern } from "TSTransformer/nodes/binding/transformArrayBindingPattern";
 import { transformObjectBindingPattern } from "TSTransformer/nodes/binding/transformObjectBindingPattern";
 import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
@@ -14,6 +15,7 @@ import ts from "typescript";
  */
 function optimizeArraySpreadParameter(
 	state: TransformState,
+	prereqs: Prereqs,
 	parameters: luau.List<luau.AnyIdentifier>,
 	bindingPattern: ts.ArrayBindingPattern,
 ) {
@@ -24,21 +26,21 @@ function optimizeArraySpreadParameter(
 			const name = element.name;
 			if (ts.isIdentifier(name)) {
 				const paramId = transformIdentifierDefined(state, name);
-				validateIdentifier(state, name);
+				validateIdentifier(name);
 				luau.list.push(parameters, paramId);
 				if (element.initializer) {
-					state.prereq(transformInitializer(state, paramId, element.initializer));
+					prereqs.push(transformInitializer(state, paramId, element.initializer));
 				}
 			} else {
 				const paramId = luau.tempId("param");
 				luau.list.push(parameters, paramId);
 				if (element.initializer) {
-					state.prereq(transformInitializer(state, paramId, element.initializer));
+					prereqs.push(transformInitializer(state, paramId, element.initializer));
 				}
 				if (ts.isArrayBindingPattern(name)) {
-					transformArrayBindingPattern(state, name, paramId);
+					transformArrayBindingPattern(state, prereqs, name, paramId);
 				} else {
-					transformObjectBindingPattern(state, name, paramId);
+					transformObjectBindingPattern(state, prereqs, name, paramId);
 				}
 			}
 		}
@@ -64,17 +66,16 @@ export function transformParameters(state: TransformState, node: ts.SignatureDec
 			ts.isArrayBindingPattern(parameter.name) &&
 			!arrayLikeExpressionContainsSpread(parameter.name)
 		) {
-			const prereqs = state.capturePrereqs(() =>
-				optimizeArraySpreadParameter(state, parameters, parameter.name as ts.ArrayBindingPattern),
-			);
-			luau.list.pushList(statements, prereqs);
+			const parameterPrereqs = new Prereqs();
+			optimizeArraySpreadParameter(state, parameterPrereqs, parameters, parameter.name);
+			luau.list.pushList(statements, parameterPrereqs.statements);
 			continue;
 		}
 
 		let paramId: luau.Identifier | luau.TemporaryIdentifier;
 		if (ts.isIdentifier(parameter.name)) {
 			paramId = transformIdentifierDefined(state, parameter.name);
-			validateIdentifier(state, parameter.name);
+			validateIdentifier(parameter.name);
 		} else {
 			paramId = luau.tempId("param");
 		}
@@ -101,17 +102,13 @@ export function transformParameters(state: TransformState, node: ts.SignatureDec
 		// destructuring
 		if (!ts.isIdentifier(parameter.name)) {
 			const bindingPattern = parameter.name;
+			const bindingPrereqs = new Prereqs();
 			if (ts.isArrayBindingPattern(bindingPattern)) {
-				luau.list.pushList(
-					statements,
-					state.capturePrereqs(() => transformArrayBindingPattern(state, bindingPattern, paramId)),
-				);
+				transformArrayBindingPattern(state, bindingPrereqs, bindingPattern, paramId);
 			} else {
-				luau.list.pushList(
-					statements,
-					state.capturePrereqs(() => transformObjectBindingPattern(state, bindingPattern, paramId)),
-				);
+				transformObjectBindingPattern(state, bindingPrereqs, bindingPattern, paramId);
 			}
+			luau.list.pushList(statements, bindingPrereqs.statements);
 		}
 	}
 

--- a/src/TSTransformer/nodes/transformPropertyName.ts
+++ b/src/TSTransformer/nodes/transformPropertyName.ts
@@ -1,14 +1,15 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import ts from "typescript";
 
-export function transformPropertyName(state: TransformState, name: ts.PropertyName) {
+export function transformPropertyName(state: TransformState, prereqs: Prereqs, name: ts.PropertyName) {
 	// identifier directly is from `{ a: value }`, so key must be "a"
 	if (ts.isIdentifier(name)) {
 		return luau.string(name.text);
 	} else {
 		// `name.expression`, if identifier, is from `{ [a]: value }`
-		return transformExpression(state, ts.isComputedPropertyName(name) ? name.expression : name);
+		return transformExpression(state, prereqs, ts.isComputedPropertyName(name) ? name.expression : name);
 	}
 }

--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -3,6 +3,7 @@ import { RbxType } from "@roblox-ts/rojo-resolver";
 import { COMPILER_VERSION } from "Shared/constants";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformIdentifierDefined } from "TSTransformer/nodes/expressions/transformIdentifier";
 import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
 import { transformStatementList } from "TSTransformer/nodes/transformStatementList";
@@ -21,7 +22,10 @@ function getExportPair(
 		const exportName = declaration.propertyName ?? declaration.name;
 		// exportName is only a StringLiteral for re-exports, which are filtered out in handleExports
 		assert(ts.isIdentifier(exportName));
-		return [transformPropertyName(state, declaration.name), transformIdentifierDefined(state, exportName)];
+		const namePrereqs = new Prereqs();
+		const name = transformPropertyName(state, namePrereqs, declaration.name);
+		assert(luau.list.isEmpty(namePrereqs.statements));
+		return [name, transformIdentifierDefined(state, exportName)];
 	} else {
 		let name = exportSymbol.name;
 		if (

--- a/src/TSTransformer/nodes/transformStatementList.ts
+++ b/src/TSTransformer/nodes/transformStatementList.ts
@@ -37,9 +37,7 @@ export function transformStatementList(
 
 	// iterate through each statement in the `statements` array
 	for (const statement of statements) {
-		// capture prerequisite statements for the `ts.Statement`
-		// transform the statement into a luau.List<...>
-		const [transformedStatements, prereqStatements] = state.capture(() => transformStatement(state, statement));
+		const transformedStatements = transformStatement(state, statement);
 
 		// iterate through each of the leading comments of the statement
 		if (state.compilerOptions.removeComments !== true) {
@@ -53,7 +51,6 @@ export function transformStatementList(
 			luau.list.push(result, hoistDeclaration);
 		}
 
-		luau.list.pushList(result, prereqStatements);
 		luau.list.pushList(result, transformedStatements);
 
 		const lastStatement = transformedStatements.tail?.value;

--- a/src/TSTransformer/nodes/transformWritable.ts
+++ b/src/TSTransformer/nodes/transformWritable.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { addOneIfArrayType } from "TSTransformer/util/addOneIfArrayType";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
@@ -13,6 +14,7 @@ import ts from "typescript";
 
 export function transformWritableExpression(
 	state: TransformState,
+	prereqs: Prereqs,
 	node: ts.Expression,
 	readAfterWrite: boolean,
 ): luau.WritableExpression {
@@ -20,25 +22,25 @@ export function transformWritableExpression(
 		DiagnosticService.addDiagnostic(errors.noPrototype(node));
 	}
 	if (ts.isPropertyAccessExpression(node)) {
-		const expression = transformExpression(state, node.expression);
+		const expression = transformExpression(state, prereqs, node.expression);
 		return luau.property(
-			readAfterWrite ? state.pushToVarIfNonId(expression, "exp") : convertToIndexableExpression(expression),
+			readAfterWrite ? prereqs.pushToVarIfNonId(expression, "exp") : convertToIndexableExpression(expression),
 			node.name.text,
 		);
 	} else if (ts.isElementAccessExpression(node)) {
-		let [expression, index] = ensureTransformOrder(state, [node.expression, node.argumentExpression]);
+		let [expression, index] = ensureTransformOrder(state, prereqs, [node.expression, node.argumentExpression]);
 		if (isLateRead(expression) && !effectsCommute(getEffects(expression), getEffects(index))) {
-			expression = state.pushToVar(expression, "exp");
+			expression = prereqs.pushToVar(expression, "exp");
 		}
 		const indexExp = addOneIfArrayType(state, state.getType(node.expression), index);
 		return luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 			expression: readAfterWrite
-				? state.pushToVarIfNonId(expression, "exp")
+				? prereqs.pushToVarIfNonId(expression, "exp")
 				: convertToIndexableExpression(expression),
-			index: readAfterWrite ? state.pushToVarIfComplex(indexExp, "index") : indexExp,
+			index: readAfterWrite ? prereqs.pushToVarIfComplex(indexExp, "index") : indexExp,
 		});
 	} else {
-		const transformed = transformExpression(state, skipDownwards(node));
+		const transformed = transformExpression(state, prereqs, skipDownwards(node));
 		assert(luau.isWritableExpression(transformed));
 		return transformed;
 	}
@@ -46,14 +48,16 @@ export function transformWritableExpression(
 
 export function transformWritableAssignment(
 	state: TransformState,
+	prereqs: Prereqs,
 	writeNode: ts.Expression,
 	valueNode: ts.Expression,
 	readAfterWrite = false,
 	readBeforeWrite = false,
 ) {
-	let writable = transformWritableExpression(state, writeNode, readAfterWrite);
-	const [value, prereqs] = state.capture(() => transformExpression(state, valueNode));
-	const prereqEffects = getEffects(prereqs);
+	let writable = transformWritableExpression(state, prereqs, writeNode, readAfterWrite);
+	const valuePrereqs = new Prereqs();
+	const value = transformExpression(state, valuePrereqs, valueNode);
+	const prereqEffects = getEffects(valuePrereqs.statements);
 	const valueEffects = getEffects(value);
 	const effects = joinEffects(prereqEffects, valueEffects);
 	// Luau evaluates complex bases and keys before an inline RHS, but can read
@@ -66,11 +70,11 @@ export function transformWritableAssignment(
 		const index = luau.isComputedIndexExpression(writable) ? writable.index : undefined;
 		const captureIndex = index !== undefined && !effectsCommute(getEffects(index), intervening(index));
 		const baseEffects = captureIndex ? joinEffects(intervening(base), getEffects(index)) : intervening(base);
-		const stableBase = !effectsCommute(getEffects(base), baseEffects) ? state.pushToVar(base, "exp") : base;
+		const stableBase = !effectsCommute(getEffects(base), baseEffects) ? prereqs.pushToVar(base, "exp") : base;
 		if (luau.isComputedIndexExpression(writable)) {
 			writable = luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 				expression: stableBase,
-				index: captureIndex ? state.pushToVar(writable.index, "index") : writable.index,
+				index: captureIndex ? prereqs.pushToVar(writable.index, "index") : writable.index,
 			});
 		} else {
 			writable = luau.property(stableBase, writable.name);
@@ -78,9 +82,9 @@ export function transformWritableAssignment(
 	}
 	const readable =
 		readBeforeWrite && !effectsCommute(getEffects(writable), effects)
-			? state.pushToVar(writable, "readable")
+			? prereqs.pushToVar(writable, "readable")
 			: writable;
-	state.prereqList(prereqs);
+	prereqs.pushList(valuePrereqs.statements);
 
 	return { writable, readable, value };
 }

--- a/src/TSTransformer/util/assignment.ts
+++ b/src/TSTransformer/util/assignment.ts
@@ -1,5 +1,5 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { createBinaryFromOperator } from "TSTransformer/util/createBinaryFromOperator";
 import { isDefinitelyType, isStringType } from "TSTransformer/util/types";
 import ts from "typescript";
@@ -48,19 +48,18 @@ export function createAssignmentStatement(
 }
 
 export function createAssignmentExpression(
-	state: TransformState,
+	prereqs: Prereqs,
 	writable: luau.WritableExpression,
 	operator: luau.AssignmentOperator,
 	value: luau.Expression,
 	readable: luau.WritableExpression = writable,
 ) {
-	state.prereq(createAssignmentStatement(writable, operator, value, readable));
+	prereqs.push(createAssignmentStatement(writable, operator, value, readable));
 	return writable;
 }
 
 export function createCompoundAssignmentStatement(
-	state: TransformState,
-	node: ts.Node,
+	prereqs: Prereqs,
 	writable: luau.WritableExpression,
 	writableType: ts.Type,
 	readable: luau.WritableExpression,
@@ -71,13 +70,12 @@ export function createCompoundAssignmentStatement(
 	return luau.create(luau.SyntaxKind.Assignment, {
 		left: writable,
 		operator: "=",
-		right: createBinaryFromOperator(state, node, readable, writableType, operator, value, valueType),
+		right: createBinaryFromOperator(prereqs, readable, writableType, operator, value, valueType),
 	});
 }
 
 export function createCompoundAssignmentExpression(
-	state: TransformState,
-	node: ts.Node,
+	prereqs: Prereqs,
 	writable: luau.WritableExpression,
 	writableType: ts.Type,
 	readable: luau.WritableExpression,
@@ -86,9 +84,9 @@ export function createCompoundAssignmentExpression(
 	valueType: ts.Type,
 ) {
 	return createAssignmentExpression(
-		state,
+		prereqs,
 		writable,
 		"=",
-		createBinaryFromOperator(state, node, readable, writableType, operator, value, valueType),
+		createBinaryFromOperator(prereqs, readable, writableType, operator, value, valueType),
 	);
 }

--- a/src/TSTransformer/util/binding/getAccessorForBindingType.ts
+++ b/src/TSTransformer/util/binding/getAccessorForBindingType.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import {
 	isArrayType,
 	isDefinitelyType,
@@ -19,7 +20,7 @@ import {
 import ts from "typescript";
 
 type BindingAccessor = (
-	state: TransformState,
+	prereqs: Prereqs,
 	parentId: luau.AnyIdentifier,
 	index: number,
 	idStack: Array<luau.AnyIdentifier>,
@@ -30,17 +31,17 @@ function peek<T>(array: Array<T>): T | undefined {
 	return array[array.length - 1];
 }
 
-const arrayAccessor: BindingAccessor = (state, parentId, index) => {
+const arrayAccessor: BindingAccessor = (prereqs, parentId, index) => {
 	return luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 		expression: parentId,
 		index: luau.number(index + 1),
 	});
 };
 
-const stringAccessor: BindingAccessor = (state, parentId, index, idStack, isOmitted) => {
+const stringAccessor: BindingAccessor = (prereqs, parentId, index, idStack, isOmitted) => {
 	let id: luau.AnyIdentifier;
 	if (idStack.length === 0) {
-		id = state.pushToVar(
+		id = prereqs.pushToVar(
 			luau.call(luau.globals.string.gmatch, [parentId, luau.globals.utf8.charpattern]),
 			"matcher",
 		);
@@ -52,7 +53,7 @@ const stringAccessor: BindingAccessor = (state, parentId, index, idStack, isOmit
 	const callExp = luau.call(id);
 
 	if (isOmitted) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				expression: callExp,
 			}),
@@ -63,7 +64,7 @@ const stringAccessor: BindingAccessor = (state, parentId, index, idStack, isOmit
 	}
 };
 
-const setAccessor: BindingAccessor = (state, parentId, index, idStack, isOmitted) => {
+const setAccessor: BindingAccessor = (prereqs, parentId, index, idStack, isOmitted) => {
 	const args = [parentId];
 	const lastId = peek(idStack);
 	if (lastId) {
@@ -71,20 +72,20 @@ const setAccessor: BindingAccessor = (state, parentId, index, idStack, isOmitted
 	}
 	const callExp = luau.call(luau.globals.next, args);
 	if (isOmitted) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				expression: callExp,
 			}),
 		);
 		return luau.none();
 	} else {
-		const id = state.pushToVar(callExp, "value");
+		const id = prereqs.pushToVar(callExp, "value");
 		idStack.push(id);
 		return id;
 	}
 };
 
-const mapAccessor: BindingAccessor = (state, parentId, index, idStack) => {
+const mapAccessor: BindingAccessor = (prereqs, parentId, index, idStack) => {
 	const args = [parentId];
 	const lastId = peek(idStack);
 	if (lastId) {
@@ -93,7 +94,7 @@ const mapAccessor: BindingAccessor = (state, parentId, index, idStack) => {
 	const keyId = luau.tempId("k");
 	const valueId = luau.tempId("v");
 	const ids = luau.list.make(keyId, valueId);
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.VariableDeclaration, {
 			left: ids,
 			right: luau.call(luau.globals.next, args),
@@ -103,10 +104,10 @@ const mapAccessor: BindingAccessor = (state, parentId, index, idStack) => {
 	return luau.create(luau.SyntaxKind.Array, { members: ids });
 };
 
-const iterableFunctionLuaTupleAccessor: BindingAccessor = (state, parentId, index, idStack, isOmitted) => {
+const iterableFunctionLuaTupleAccessor: BindingAccessor = (prereqs, parentId, index, idStack, isOmitted) => {
 	const callExp = luau.call(parentId);
 	if (isOmitted) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				expression: callExp,
 			}),
@@ -117,10 +118,10 @@ const iterableFunctionLuaTupleAccessor: BindingAccessor = (state, parentId, inde
 	}
 };
 
-const iterableFunctionAccessor: BindingAccessor = (state, parentId, index, idStack, isOmitted) => {
+const iterableFunctionAccessor: BindingAccessor = (prereqs, parentId, index, idStack, isOmitted) => {
 	const callExp = luau.call(parentId);
 	if (isOmitted) {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.CallStatement, {
 				expression: callExp,
 			}),
@@ -131,10 +132,10 @@ const iterableFunctionAccessor: BindingAccessor = (state, parentId, index, idSta
 	}
 };
 
-const iterAccessor: BindingAccessor = (state, parentId, index, idStack, isOmitted) => {
+const iterAccessor: BindingAccessor = (prereqs, parentId, index, idStack, isOmitted) => {
 	const callExp = luau.call(luau.property(parentId, "next"));
 	if (isOmitted) {
-		state.prereq(luau.create(luau.SyntaxKind.CallStatement, { expression: callExp }));
+		prereqs.push(luau.create(luau.SyntaxKind.CallStatement, { expression: callExp }));
 		return luau.none();
 	} else {
 		return luau.property(callExp, "value");

--- a/src/TSTransformer/util/binding/getTargetIdForBindingPattern.ts
+++ b/src/TSTransformer/util/binding/getTargetIdForBindingPattern.ts
@@ -1,14 +1,14 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer/classes/TransformState";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import ts from "typescript";
 
 /**
  * Checks to see if the binding contains initializers and returns a new temporary identifier,
  * since they could mutate the binding variable.
  */
-export function getTargetIdForBindingPattern(state: TransformState, name: ts.BindingPattern, value: luau.Expression) {
+export function getTargetIdForBindingPattern(prereqs: Prereqs, name: ts.BindingPattern, value: luau.Expression) {
 	return luau.isAnyIdentifier(value) &&
 		name.elements.every(element => ts.isOmittedExpression(element) || !element.initializer)
 		? value
-		: state.pushToVar(value, "binding");
+		: prereqs.pushToVar(value, "binding");
 }

--- a/src/TSTransformer/util/binding/objectAccessor.ts
+++ b/src/TSTransformer/util/binding/objectAccessor.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { addIndexDiagnostics } from "TSTransformer/util/addIndexDiagnostics";
 import { addOneIfArrayType } from "TSTransformer/util/addOneIfArrayType";
@@ -11,6 +12,7 @@ import ts from "typescript";
 
 export const objectAccessor = (
 	state: TransformState,
+	prereqs: Prereqs,
 	parentId: luau.AnyIdentifier,
 	type: ts.Type,
 	name: ts.PropertyName,
@@ -26,12 +28,12 @@ export const objectAccessor = (
 	} else if (ts.isComputedPropertyName(name)) {
 		return luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 			expression: parentId,
-			index: addOneIfArrayType(state, type, transformExpression(state, name.expression)),
+			index: addOneIfArrayType(state, type, transformExpression(state, prereqs, name.expression)),
 		});
 	} else if (ts.isNumericLiteral(name) || ts.isStringLiteral(name) || ts.isBigIntLiteral(name)) {
 		return luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 			expression: parentId,
-			index: transformExpression(state, name),
+			index: transformExpression(state, prereqs, name),
 		});
 	} else if (ts.isPrivateIdentifier(name)) {
 		DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(name));

--- a/src/TSTransformer/util/bitwise.ts
+++ b/src/TSTransformer/util/bitwise.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { getKindName } from "TSTransformer/util/getKindName";
@@ -67,6 +68,7 @@ export function createBitwiseCall(
 
 export function createBitwiseFromOperator(
 	state: TransformState,
+	prereqs: Prereqs,
 	operatorKind: ts.BinaryOperator,
 	node: ts.BinaryExpression,
 ): luau.Expression {
@@ -79,5 +81,5 @@ export function createBitwiseFromOperator(
 		flattenedExpressions.push(node.left, node.right);
 	}
 
-	return createBitwiseCall(operatorKind, ensureTransformOrder(state, flattenedExpressions));
+	return createBitwiseCall(operatorKind, ensureTransformOrder(state, prereqs, flattenedExpressions));
 }

--- a/src/TSTransformer/util/createBinaryFromOperator.ts
+++ b/src/TSTransformer/util/createBinaryFromOperator.ts
@@ -1,6 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
-import { TransformState } from "TSTransformer/classes/TransformState";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { createBitwiseCall, isBitwiseOperator } from "TSTransformer/util/bitwise";
 import { effectsCommute, getEffects, isLateRead } from "TSTransformer/util/evaluation/effects";
 import { getKindName } from "TSTransformer/util/getKindName";
@@ -40,8 +40,7 @@ function createBinaryAdd(left: luau.Expression, leftType: ts.Type, right: luau.E
 }
 
 export function createBinaryFromOperator(
-	state: TransformState,
-	node: ts.Node,
+	prereqs: Prereqs,
 	left: luau.Expression,
 	leftType: ts.Type,
 	operatorKind: ts.BinaryOperator,
@@ -50,7 +49,7 @@ export function createBinaryFromOperator(
 ): luau.Expression {
 	// arithmetic and comparison instructions can read a local after the RHS call ran
 	if (isLateRead(left) && !effectsCommute(getEffects(left), getEffects(right))) {
-		left = state.pushToVar(left, "left");
+		left = prereqs.pushToVar(left, "left");
 	}
 
 	// simple
@@ -70,7 +69,7 @@ export function createBinaryFromOperator(
 	}
 
 	if (operatorKind === ts.SyntaxKind.CommaToken) {
-		state.prereqList(wrapExpressionStatement(left));
+		prereqs.pushList(wrapExpressionStatement(left));
 		return right;
 	}
 

--- a/src/TSTransformer/util/createHoistDeclaration.ts
+++ b/src/TSTransformer/util/createHoistDeclaration.ts
@@ -7,7 +7,7 @@ import ts from "typescript";
 export function createHoistDeclaration(state: TransformState, statement: ts.Statement | ts.CaseClause) {
 	const hoists = state.hoistsByStatement.get(statement);
 	if (hoists && hoists.length > 0) {
-		hoists.forEach(hoist => validateIdentifier(state, hoist));
+		hoists.forEach(validateIdentifier);
 		return luau.create(luau.SyntaxKind.VariableDeclaration, {
 			left: luau.list.make(...hoists.map(hoistId => transformIdentifierDefined(state, hoistId))),
 			right: undefined,

--- a/src/TSTransformer/util/createTruthinessChecks.ts
+++ b/src/TSTransformer/util/createTruthinessChecks.ts
@@ -2,6 +2,7 @@ import luau from "@roblox-ts/luau-ast";
 import { warnings } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { binaryExpressionChain } from "TSTransformer/util/expressionChain";
 import { isEmptyStringType, isNaNType, isNumberLiteralType, isPossiblyType } from "TSTransformer/util/types";
 import ts from "typescript";
@@ -14,14 +15,19 @@ export function willCreateTruthinessChecks(type: ts.Type) {
 	);
 }
 
-export function createTruthinessChecks(state: TransformState, exp: luau.Expression, node: ts.Expression) {
+export function createTruthinessChecks(
+	state: TransformState,
+	prereqs: Prereqs,
+	exp: luau.Expression,
+	node: ts.Expression,
+) {
 	const type = state.getType(node);
 	const isAssignableToZero = isPossiblyType(type, isNumberLiteralType(0));
 	const isAssignableToNaN = isPossiblyType(type, isNaNType);
 	const isAssignableToEmptyString = isPossiblyType(type, isEmptyStringType);
 
 	if (isAssignableToZero || isAssignableToNaN || isAssignableToEmptyString) {
-		exp = state.pushToVarIfComplex(exp, "value");
+		exp = prereqs.pushToVarIfComplex(exp, "value");
 	}
 
 	const checks = new Array<luau.Expression>();

--- a/src/TSTransformer/util/ensureTransformOrder.ts
+++ b/src/TSTransformer/util/ensureTransformOrder.ts
@@ -1,44 +1,56 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { effectsCommute, getEffects, joinEffects, NO_EFFECTS } from "TSTransformer/util/evaluation/effects";
 import ts from "typescript";
 
 export function ensureTransformOrder(
 	state: TransformState,
+	prereqs: Prereqs,
 	nodes: ReadonlyArray<ts.Expression>,
-	transformer?: (state: TransformState, node: ts.Expression) => luau.Expression,
+	transformer?: (state: TransformState, prereqs: Prereqs, node: ts.Expression) => luau.Expression,
 ): Array<luau.Expression>;
 export function ensureTransformOrder<T extends ts.Node>(
 	state: TransformState,
+	prereqs: Prereqs,
 	nodes: ReadonlyArray<T>,
-	transformer: (state: TransformState, node: T) => luau.Expression,
+	transformer: (state: TransformState, prereqs: Prereqs, node: T) => luau.Expression,
 ): Array<luau.Expression>;
 export function ensureTransformOrder(
 	state: TransformState,
+	prereqs: Prereqs,
 	nodes: ReadonlyArray<ts.Expression>,
-	transformer: (state: TransformState, node: ts.Expression) => luau.Expression = transformExpression,
+	transformer: (
+		state: TransformState,
+		prereqs: Prereqs,
+		node: ts.Expression,
+	) => luau.Expression = transformExpression,
 ) {
-	const expressionInfoList = nodes.map(node => state.capture(() => transformer(state, node)));
+	const expressionInfoList = nodes.map(node => {
+		const expressionPrereqs = new Prereqs();
+		const expression = transformer(state, expressionPrereqs, node);
+		return { expression, prereqStatements: expressionPrereqs.statements };
+	});
 	const captures = new Array<boolean>(nodes.length).fill(false);
 	// each capture becomes a prerequisite that earlier expressions must also cross
 	let suffix = NO_EFFECTS;
 	for (let i = expressionInfoList.length - 1; i >= 0; i--) {
-		const [expression, prereqs] = expressionInfoList[i];
+		const { expression, prereqStatements } = expressionInfoList[i];
 		const effects = getEffects(expression);
 		captures[i] = !effectsCommute(effects, suffix);
 		if (captures[i]) {
 			suffix = joinEffects(effects, suffix);
 		}
-		suffix = joinEffects(getEffects(prereqs), suffix);
+		suffix = joinEffects(getEffects(prereqStatements), suffix);
 	}
 	const result = new Array<luau.Expression>();
 	for (let i = 0; i < expressionInfoList.length; i++) {
-		const [expression, prereqs] = expressionInfoList[i];
-		state.prereqList(prereqs);
+		const { expression, prereqStatements } = expressionInfoList[i];
+		prereqs.pushList(prereqStatements);
 
 		if (captures[i]) {
-			result.push(state.pushToVar(expression, "exp"));
+			result.push(prereqs.pushToVar(expression, "exp"));
 		} else {
 			result.push(expression);
 		}

--- a/src/TSTransformer/util/evaluation/plan.ts
+++ b/src/TSTransformer/util/evaluation/plan.ts
@@ -1,5 +1,5 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import {
 	canDiscard,
@@ -54,9 +54,9 @@ function substitute<T extends luau.Node>(node: T, replacements: ReadonlyMap<numb
 // opaque references prevent macros from decomposing or duplicating an operand's
 // computation before we decide where its value must be captured
 export function planEvaluation(
-	state: TransformState,
+	prereqs: Prereqs,
 	operands: ReadonlyArray<EvaluationOperand>,
-	expand: (references: Array<luau.Expression>) => luau.Expression,
+	expand: (prereqs: Prereqs, references: Array<luau.Expression>) => luau.Expression,
 ) {
 	const effects = operands.map(operand => getEffects(operand.expression));
 	const slots = new Map<number, EvaluationReference>();
@@ -70,8 +70,9 @@ export function planEvaluation(
 		slots.set(reference.id, { operandIndex: index, expression, effects: effects[index] });
 		return reference;
 	});
-	const [result, statements] = state.capture(() => expand(references));
-	const events = getEvaluationEvents(statements, result, slots);
+	const expansionPrereqs = new Prereqs();
+	const result = expand(expansionPrereqs, references);
+	const events = getEvaluationEvents(expansionPrereqs.statements, result, slots);
 
 	const uses = operands.map(() => new Array<number>());
 	events.forEach((event, index) => {
@@ -110,13 +111,13 @@ export function planEvaluation(
 
 	const replacements = new Map<number, luau.Expression>();
 	for (let i = 0; i < operands.length; i++) {
-		state.prereqList(operands[i].prereqs);
+		prereqs.pushList(operands[i].prereqs);
 		let expression = operands[i].expression;
 		if (captures[i]) {
 			if (uses[i].length === 0) {
-				state.prereqList(wrapExpressionStatement(expression));
+				prereqs.pushList(wrapExpressionStatement(expression));
 			} else {
-				const captured = state.pushToVar(expression, i === 0 ? "exp" : `arg${i - 1}`);
+				const captured = prereqs.pushToVar(expression, i === 0 ? "exp" : `arg${i - 1}`);
 				// working temporaries may change value; only immutable captures inherit these facts
 				copyValueFacts(expression, captured);
 				expression = captured;
@@ -128,8 +129,10 @@ export function planEvaluation(
 		}
 	}
 
-	state.prereqList(
-		luau.list.make(...luau.list.toArray(statements).map(statement => substitute(statement, replacements))),
+	prereqs.pushList(
+		luau.list.make(
+			...luau.list.toArray(expansionPrereqs.statements).map(statement => substitute(statement, replacements)),
+		),
 	);
 	return substitute(result, replacements);
 }

--- a/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
+++ b/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
@@ -3,6 +3,7 @@ import { errors } from "Shared/diagnostics";
 import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import {
 	isArrayType,
@@ -20,7 +21,7 @@ import { valueToIdStr } from "TSTransformer/util/valueToIdStr";
 import ts from "typescript";
 
 type AddIterableToArrayBuilder = (
-	state: TransformState,
+	prereqs: Prereqs,
 	expression: luau.Expression,
 	arrayId: luau.AnyIdentifier,
 	lengthId: luau.AnyIdentifier,
@@ -29,7 +30,7 @@ type AddIterableToArrayBuilder = (
 ) => luau.List<luau.Statement>;
 
 const addArray: AddIterableToArrayBuilder = (
-	state,
+	prereqs,
 	expression,
 	arrayId,
 	lengthId,
@@ -38,10 +39,10 @@ const addArray: AddIterableToArrayBuilder = (
 ) => {
 	const result = luau.list.make<luau.Statement>();
 
-	const inputArray = state.pushToVarIfNonId(expression, "array");
+	const inputArray = prereqs.pushToVarIfNonId(expression, "array");
 	let inputLength: luau.Expression = luau.unary("#", inputArray);
 	if (shouldUpdateLengthId) {
-		inputLength = state.pushToVar(inputLength, valueToIdStr(inputArray) + "Length");
+		inputLength = prereqs.pushToVar(inputLength, valueToIdStr(inputArray) + "Length");
 	}
 
 	luau.list.push(
@@ -75,7 +76,7 @@ function createForLoopArrayBuilder(
 	valueName: string,
 	getLoopExpression: (expression: luau.Expression) => luau.Expression = expression => expression,
 ): AddIterableToArrayBuilder {
-	return (state, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
+	return (prereqs, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
 		const result = luau.list.make<luau.Statement>();
 
 		if (amtElementsSinceUpdate > 0) {
@@ -124,7 +125,7 @@ const addString = createForLoopArrayBuilder("char", expression =>
 const addSet = createForLoopArrayBuilder("v");
 const addIterableFunction = createForLoopArrayBuilder("result");
 
-const addMap: AddIterableToArrayBuilder = (state, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
+const addMap: AddIterableToArrayBuilder = (prereqs, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
 	const result = luau.list.make<luau.Statement>();
 
 	if (amtElementsSinceUpdate > 0) {
@@ -167,7 +168,7 @@ const addMap: AddIterableToArrayBuilder = (state, expression, arrayId, lengthId,
 };
 
 const addIterableFunctionLuaTuple: AddIterableToArrayBuilder = (
-	state,
+	prereqs,
 	expression,
 	arrayId,
 	lengthId,
@@ -186,7 +187,7 @@ const addIterableFunctionLuaTuple: AddIterableToArrayBuilder = (
 		);
 	}
 
-	const iterFuncId = state.pushToVar(expression, "iterFunc");
+	const iterFuncId = prereqs.pushToVar(expression, "iterFunc");
 	const valueId = luau.tempId("results");
 	luau.list.push(
 		result,
@@ -222,7 +223,7 @@ const addIterableFunctionLuaTuple: AddIterableToArrayBuilder = (
 	return result;
 };
 
-const addGenerator: AddIterableToArrayBuilder = (state, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
+const addGenerator: AddIterableToArrayBuilder = (prereqs, expression, arrayId, lengthId, amtElementsSinceUpdate) => {
 	const result = luau.list.make<luau.Statement>();
 
 	if (amtElementsSinceUpdate > 0) {

--- a/src/TSTransformer/util/pointer.ts
+++ b/src/TSTransformer/util/pointer.ts
@@ -1,5 +1,5 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 
 export interface Pointer<T> {
 	name: string;
@@ -18,7 +18,7 @@ export function createArrayPointer(name: string): ArrayPointer {
 }
 
 export function assignToMapPointer(
-	state: TransformState,
+	prereqs: Prereqs,
 	ptr: Pointer<luau.Map | luau.AnyIdentifier>,
 	left: luau.Expression,
 	right: luau.Expression,
@@ -32,7 +32,7 @@ export function assignToMapPointer(
 			}),
 		);
 	} else {
-		state.prereq(
+		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: luau.create(luau.SyntaxKind.ComputedIndexExpression, {
 					expression: ptr.value,
@@ -45,20 +45,17 @@ export function assignToMapPointer(
 	}
 }
 
-export function disableMapInline(
-	state: TransformState,
-	ptr: MapPointer,
-): asserts ptr is Pointer<luau.TemporaryIdentifier> {
+export function disableMapInline(prereqs: Prereqs, ptr: MapPointer): asserts ptr is Pointer<luau.TemporaryIdentifier> {
 	if (luau.isMap(ptr.value)) {
-		ptr.value = state.pushToVar(ptr.value, ptr.name);
+		ptr.value = prereqs.pushToVar(ptr.value, ptr.name);
 	}
 }
 
 export function disableArrayInline(
-	state: TransformState,
+	prereqs: Prereqs,
 	ptr: ArrayPointer,
 ): asserts ptr is Pointer<luau.TemporaryIdentifier> {
 	if (luau.isArray(ptr.value)) {
-		ptr.value = state.pushToVar(ptr.value, ptr.name);
+		ptr.value = prereqs.pushToVar(ptr.value, ptr.name);
 	}
 }

--- a/src/TSTransformer/util/spreadDestructuring/index.ts
+++ b/src/TSTransformer/util/spreadDestructuring/index.ts
@@ -1,5 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { spreadDestructureArray } from "TSTransformer/util/spreadDestructuring/spreadDestructureArray";
 import { spreadDestructureGenerator } from "TSTransformer/util/spreadDestructuring/spreadDestructureGenerator";
@@ -14,7 +15,7 @@ export * from "TSTransformer/util/spreadDestructuring/spreadDestructureObject";
 export * from "TSTransformer/util/spreadDestructuring/spreadDestructureSet";
 
 type SpreadDestructor = (
-	state: TransformState,
+	prereqs: Prereqs,
 	parentId: luau.AnyIdentifier,
 	index: number,
 	idStack: Array<luau.AnyIdentifier>,

--- a/src/TSTransformer/util/spreadDestructuring/spreadDestructureArray.ts
+++ b/src/TSTransformer/util/spreadDestructuring/spreadDestructureArray.ts
@@ -1,7 +1,7 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer/classes/TransformState";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 
-export function spreadDestructureArray(state: TransformState, parentId: luau.AnyIdentifier, index: number) {
+export function spreadDestructureArray(prereqs: Prereqs, parentId: luau.AnyIdentifier, index: number) {
 	return luau.call(luau.globals.table.move, [
 		parentId,
 		luau.number(index + 1),

--- a/src/TSTransformer/util/spreadDestructuring/spreadDestructureGenerator.ts
+++ b/src/TSTransformer/util/spreadDestructuring/spreadDestructureGenerator.ts
@@ -1,8 +1,8 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer/classes/TransformState";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 
-export function spreadDestructureGenerator(state: TransformState, parentId: luau.AnyIdentifier) {
-	const restId = state.pushToVar(luau.array(), "rest");
+export function spreadDestructureGenerator(prereqs: Prereqs, parentId: luau.AnyIdentifier) {
+	const restId = prereqs.pushToVar(luau.array(), "rest");
 
 	const valueId = luau.tempId("v");
 	const variable = luau.create(luau.SyntaxKind.VariableDeclaration, {
@@ -24,7 +24,7 @@ export function spreadDestructureGenerator(state: TransformState, parentId: luau
 		expression: luau.call(luau.globals.table.insert, [restId, luau.property(valueId, "value")]),
 	});
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.WhileStatement, {
 			condition: luau.create(luau.SyntaxKind.TrueLiteral, {}),
 			statements: luau.list.make<luau.Statement>(variable, doneCheck, pushToRest),

--- a/src/TSTransformer/util/spreadDestructuring/spreadDestructureMap.ts
+++ b/src/TSTransformer/util/spreadDestructuring/spreadDestructureMap.ts
@@ -1,19 +1,19 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer/classes/TransformState";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 
 export function spreadDestructureMap(
-	state: TransformState,
+	prereqs: Prereqs,
 	parentId: luau.AnyIdentifier,
 	index: number,
 	idStack: Array<luau.AnyIdentifier>,
 ) {
-	const extracted = state.pushToVar(luau.set(idStack), "extracted");
-	const rest = state.pushToVar(luau.array(), "rest");
+	const extracted = prereqs.pushToVar(luau.set(idStack), "extracted");
+	const rest = prereqs.pushToVar(luau.array(), "rest");
 
 	const keyId = luau.tempId("k");
 	const valueId = luau.tempId("v");
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.ForStatement, {
 			ids: luau.list.make(keyId, valueId),
 			expression: parentId,

--- a/src/TSTransformer/util/spreadDestructuring/spreadDestructureObject.ts
+++ b/src/TSTransformer/util/spreadDestructuring/spreadDestructureObject.ts
@@ -1,13 +1,13 @@
 import luau from "@roblox-ts/luau-ast";
 import { assert } from "Shared/util/assert";
-import { TransformState } from "TSTransformer/classes/TransformState";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 
 export function spreadDestructureObject(
-	state: TransformState,
+	prereqs: Prereqs,
 	parentId: luau.AnyIdentifier,
 	preSpreadNames: Array<luau.Expression>,
 ) {
-	const extracted = state.pushToVar(
+	const extracted = prereqs.pushToVar(
 		luau.set(
 			preSpreadNames.map(expression => {
 				if (luau.isPropertyAccessExpression(expression)) return luau.string(expression.name);
@@ -18,11 +18,11 @@ export function spreadDestructureObject(
 		),
 		"extracted",
 	);
-	const rest = state.pushToVar(luau.map(), "rest");
+	const rest = prereqs.pushToVar(luau.map(), "rest");
 	const keyId = luau.tempId("k");
 	const valueId = luau.tempId("v");
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.ForStatement, {
 			ids: luau.list.make(keyId, valueId),
 			expression: parentId,

--- a/src/TSTransformer/util/spreadDestructuring/spreadDestructureSet.ts
+++ b/src/TSTransformer/util/spreadDestructuring/spreadDestructureSet.ts
@@ -1,17 +1,17 @@
 import luau from "@roblox-ts/luau-ast";
-import { TransformState } from "TSTransformer/classes/TransformState";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
 
 export function spreadDestructureSet(
-	state: TransformState,
+	prereqs: Prereqs,
 	parentId: luau.AnyIdentifier,
 	index: number,
 	idStack: Array<luau.AnyIdentifier>,
 ) {
-	const extracted = state.pushToVar(luau.set(idStack), "extracted");
-	const rest = state.pushToVar(luau.array(), "rest");
+	const extracted = prereqs.pushToVar(luau.set(idStack), "extracted");
+	const rest = prereqs.pushToVar(luau.array(), "rest");
 	const keyId = luau.tempId("k");
 
-	state.prereq(
+	prereqs.push(
 		luau.create(luau.SyntaxKind.ForStatement, {
 			ids: luau.list.make(keyId),
 			expression: parentId,

--- a/src/TSTransformer/util/validateIdentifier.ts
+++ b/src/TSTransformer/util/validateIdentifier.ts
@@ -1,10 +1,9 @@
 import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
-import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import ts from "typescript";
 
-export function validateIdentifier(state: TransformState, node: ts.Identifier) {
+export function validateIdentifier(node: ts.Identifier) {
 	if (!luau.isValidIdentifier(node.text)) {
 		DiagnosticService.addDiagnostic(errors.noInvalidIdentifier(node));
 	} else if (luau.isReservedIdentifier(node.text)) {

--- a/src/TSTransformer/util/withoutPrereqs.ts
+++ b/src/TSTransformer/util/withoutPrereqs.ts
@@ -1,0 +1,9 @@
+import { Prereqs } from "TSTransformer/classes/Prereqs";
+import { TransformState } from "TSTransformer/classes/TransformState";
+import ts from "typescript";
+
+// adapt transforms that cannot emit caller prerequisites to the dispatch signature
+// while preserving their node types for syntax-kind validation
+export function withoutPrereqs<T extends ts.Node, U>(transform: (state: TransformState, node: T) => U) {
+	return (state: TransformState, prereqs: Prereqs, node: T) => transform(state, node);
+}

--- a/tests/compiler/__snapshots__/prereqs.test.ts.snap
+++ b/tests/compiler/__snapshots__/prereqs.test.ts.snap
@@ -1,0 +1,265 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`preserves prerequisites for class field and parameter initializers 1`] = `
+"local values = { 1, 2, 3 }
+local Example
+do
+	Example = setmetatable({}, {
+		__tostring = function()
+			return "Example"
+		end,
+	})
+	Example.__index = Example
+	function Example.new(...)
+		local self = setmetatable({}, Example)
+		return self:constructor(...) or self
+	end
+	function Example:constructor(other)
+		if other == nil then
+			-- ▼ Array.pop ▼
+			local _length = #values
+			local _result = values[_length]
+			values[_length] = nil
+			-- ▲ Array.pop ▲
+			other = _result
+		end
+		self.other = other
+		-- ▼ Array.pop ▼
+		local _length = #values
+		local _result = values[_length]
+		values[_length] = nil
+		-- ▲ Array.pop ▲
+		self.value = _result
+	end
+end
+print(Example.new(10), Example.new())
+return nil
+"
+`;
+
+exports[`preserves prerequisites for conditional macro expansion inside an optional call 1`] = `
+"local first = { 1, 2 }
+local second = { 3, 4 }
+local _result = values
+if _result ~= nil then
+	local _arg0 = function()
+		local _result_1
+		if enabled then
+			-- ▼ Array.pop ▼
+			local _length = #first
+			local _result_2 = first[_length]
+			first[_length] = nil
+			-- ▲ Array.pop ▲
+			_result_1 = _result_2
+		else
+			-- ▼ Array.pop ▼
+			local _length = #second
+			local _result_2 = second[_length]
+			second[_length] = nil
+			-- ▲ Array.pop ▲
+			_result_1 = _result_2
+		end
+		return _result_1
+	end
+	-- ▼ ReadonlyArray.map ▼
+	local _newValue = table.create(#_result)
+	for _k, _v in _result do
+		_newValue[_k] = _arg0(_v, _k - 1, _result)
+	end
+	-- ▲ ReadonlyArray.map ▲
+	_result = _newValue
+end
+local result = _result
+print(result)
+return nil
+"
+`;
+
+exports[`preserves prerequisites for destructuring defaults before object rest 1`] = `
+"local values = { 1, 2, 3 }
+local function read(_param)
+	local value = _param.value
+	if value == nil then
+		-- ▼ Array.pop ▼
+		local _length = #values
+		local _result = values[_length]
+		values[_length] = nil
+		-- ▲ Array.pop ▲
+		value = _result
+	end
+	local _extracted = {
+		["value"] = true,
+	}
+	local _rest = {}
+	for _k, _v in _param do
+		if not _extracted[_k] then
+			_rest[_k] = _v
+		end
+	end
+	local rest = _rest
+	return { value, rest.other }
+end
+print(read({
+	other = 4,
+}), read({
+	value = 5,
+	other = 6,
+}))
+return nil
+"
+`;
+
+exports[`preserves prerequisites for else-if condition prerequisites 1`] = `
+"local values = { 1, 2, 3 }
+local function read(enabled)
+	if enabled then
+		return 0
+	else
+		-- ▼ Array.pop ▼
+		local _length = #values
+		local _result = values[_length]
+		values[_length] = nil
+		-- ▲ Array.pop ▲
+		if _result == 3 then
+			-- ▼ Array.pop ▼
+			local _length_1 = #values
+			local _result_1 = values[_length_1]
+			values[_length_1] = nil
+			-- ▲ Array.pop ▲
+			return _result_1
+		end
+	end
+	-- ▼ Array.pop ▼
+	local _length = #values
+	local _result = values[_length]
+	values[_length] = nil
+	-- ▲ Array.pop ▲
+	return _result
+end
+print((read(true)), (read(false)))
+return nil
+"
+`;
+
+exports[`preserves prerequisites for loop condition and increment prerequisites with continue 1`] = `
+"local values = { 1, 2, 3 }
+local checks = 0
+local increments = 0
+do
+	local _shouldIncrement = false
+	while true do
+		if _shouldIncrement then
+			increments += 1
+		else
+			_shouldIncrement = true
+		end
+		checks += 1
+		local _condition = checks < 4
+		if _condition then
+			-- ▼ Array.pop ▼
+			local _length = #values
+			local _result = values[_length]
+			values[_length] = nil
+			-- ▲ Array.pop ▲
+			_condition = _result ~= nil
+		end
+		if not _condition then
+			break
+		end
+		if checks == 2 then
+			continue
+		end
+		print(checks)
+	end
+end
+print(checks, increments)
+return nil
+"
+`;
+
+exports[`preserves prerequisites for statement comments and hoisted declarations 1`] = `
+"local values = { 1, 2, 3 }
+-- keep this comment before the hoist and temporary
+local later
+-- ▼ Array.pop ▼
+local _length = #values
+local _result = values[_length]
+values[_length] = nil
+-- ▲ Array.pop ▲
+local read = { function()
+	return later
+end, _result }
+later = 4
+print(read, later)
+return nil
+"
+`;
+
+exports[`preserves prerequisites for statement prerequisites before namespace exports 1`] = `
+"local values = { 1, 2, 3 }
+local Example = {}
+do
+	local _container = Example
+	-- ▼ Array.pop ▼
+	local _length = #values
+	local _result = values[_length]
+	values[_length] = nil
+	-- ▲ Array.pop ▲
+	local value = _result
+	_container.value = value
+	local function read()
+		-- ▼ Array.pop ▼
+		local _length_1 = #values
+		local _result_1 = values[_length_1]
+		values[_length_1] = nil
+		-- ▲ Array.pop ▲
+		return _result_1
+	end
+	_container.read = read
+end
+print(Example.value, (Example.read()))
+return nil
+"
+`;
+
+exports[`preserves prerequisites for try return and throw prerequisites 1`] = `
+"local TS = _G[script]
+local values = { 1, 2, 3, 4 }
+local function read(enabled)
+	local _exitType, _returns = TS.try(function()
+		if enabled then
+			-- ▼ Array.pop ▼
+			local _length = #values
+			local _result = values[_length]
+			values[_length] = nil
+			-- ▲ Array.pop ▲
+			-- ▼ Array.pop ▼
+			local _length_1 = #values
+			local _result_1 = values[_length_1]
+			values[_length_1] = nil
+			-- ▲ Array.pop ▲
+			return TS.TRY_RETURN, { _result, _result_1 }
+		end
+		-- ▼ Array.pop ▼
+		local _length = #values
+		local _result = values[_length]
+		values[_length] = nil
+		-- ▲ Array.pop ▲
+		error(_result)
+	end, function(error)
+		-- ▼ Array.pop ▼
+		local _length = #values
+		local _result = values[_length]
+		values[_length] = nil
+		-- ▲ Array.pop ▲
+		return TS.TRY_RETURN, { error, _result }
+	end)
+	if _exitType then
+		return unpack(_returns)
+	end
+end
+print({ read(true) })
+print({ read(false) })
+return nil
+"
+`;

--- a/tests/compiler/prereqCollector.test.ts
+++ b/tests/compiler/prereqCollector.test.ts
@@ -1,0 +1,18 @@
+import luau from "@roblox-ts/luau-ast";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
+
+it("prepends prerequisite lists in order without affecting another collector", () => {
+	const prereqs = new Prereqs();
+	const otherPrereqs = new Prereqs();
+	const first = luau.create(luau.SyntaxKind.CallStatement, { expression: luau.call(luau.id("first")) });
+	const second = luau.create(luau.SyntaxKind.CallStatement, { expression: luau.call(luau.id("second")) });
+	const third = luau.create(luau.SyntaxKind.CallStatement, { expression: luau.call(luau.id("third")) });
+
+	otherPrereqs.push(third);
+	prereqs.push(third);
+	prereqs.unshiftList(luau.list.make(first, second));
+	prereqs.unshiftList(luau.list.make());
+
+	expect(luau.list.toArray(prereqs.statements)).toEqual([first, second, third]);
+	expect(luau.list.toArray(otherPrereqs.statements)).toEqual([third]);
+});

--- a/tests/compiler/prereqs.test.ts
+++ b/tests/compiler/prereqs.test.ts
@@ -1,0 +1,94 @@
+import { createTestProject } from "./createTestProject";
+
+// keep cases alphabetized to match Jest's snapshot ordering
+it.each([
+	[
+		"class field and parameter initializers",
+		`const values = [1, 2, 3];
+		class Example {
+			value = values.pop();
+			constructor(readonly other = values.pop()) {}
+		}
+		print(new Example(10), new Example());`,
+	],
+	[
+		"conditional macro expansion inside an optional call",
+		`declare const enabled: boolean;
+		declare const values: Array<number> | undefined;
+		const first = [1, 2];
+		const second = [3, 4];
+		const result = values?.map(() => enabled ? first.pop() : second.pop());
+		print(result);`,
+	],
+	[
+		"destructuring defaults before object rest",
+		`const values = [1, 2, 3];
+		function read({ value = values.pop(), ...rest }: { value?: number; other: number }) {
+			return [value, rest.other];
+		}
+		print(read({ other: 4 }), read({ value: 5, other: 6 }));`,
+	],
+	[
+		"else-if condition prerequisites",
+		`const values = [1, 2, 3];
+		function read(enabled: boolean) {
+			if (enabled) {
+				return 0;
+			} else if (values.pop() === 3) {
+				return values.pop();
+			}
+			return values.pop();
+		}
+		print(read(true), read(false));`,
+	],
+	[
+		"loop condition and increment prerequisites with continue",
+		`const values = [1, 2, 3];
+		let checks = 0;
+		let increments = 0;
+		for (; (checks += 1) < 4 && values.pop() !== undefined; increments += 1) {
+			if (checks === 2) { continue; }
+			print(checks);
+		}
+		print(checks, increments);`,
+	],
+	[
+		"statement comments and hoisted declarations",
+		`const values = [1, 2, 3];
+		// keep this comment before the hoist and temporary
+		const read = [() => later, values.pop()];
+		const later = 4;
+		print(read, later);`,
+	],
+	[
+		"statement prerequisites before namespace exports",
+		`const values = [1, 2, 3];
+		namespace Example {
+			export const value = values.pop();
+			export function read() { return values.pop(); }
+		}
+		print(Example.value, Example.read());`,
+	],
+	[
+		"try return and throw prerequisites",
+		`const values = [1, 2, 3, 4];
+		function read(enabled: boolean) {
+			try {
+				if (enabled) { return $tuple(values.pop(), values.pop()); }
+				throw values.pop();
+			} catch (error) {
+				return $tuple(error, values.pop());
+			}
+		}
+		print(read(true));
+		print(read(false));`,
+	],
+])("preserves prerequisites for %s", (name, source) => {
+	const outputs = [false, true].map(optimizedLoops => {
+		const project = createTestProject({ optimizedLoops });
+		return project.compileSource(source).replace(/^-- Compiled with.*\n/, "");
+	});
+
+	expect(outputs[0]).toBe(outputs[1]);
+	expect(outputs[0]).toMatchSnapshot();
+});

--- a/tests/src/helpers/util/prereqs/defaultValue.ts
+++ b/tests/src/helpers/util/prereqs/defaultValue.ts
@@ -1,0 +1,2 @@
+const values = [1, 2, 3];
+export default values.pop();

--- a/tests/src/helpers/util/prereqs/exportedValue.ts
+++ b/tests/src/helpers/util/prereqs/exportedValue.ts
@@ -1,0 +1,2 @@
+const values = [1, 2];
+export = { value: values.pop() };

--- a/tests/src/tests/prereqs.spec.ts
+++ b/tests/src/tests/prereqs.spec.ts
@@ -1,4 +1,158 @@
+import defaultValue from "../helpers/util/prereqs/defaultValue";
+import exportedValue = require("../helpers/util/prereqs/exportedValue");
+
 export = () => {
+	it("should evaluate module export prerequisites before importing their values", () => {
+		expect(defaultValue).to.equal(3);
+		expect(exportedValue.value).to.equal(2);
+	});
+
+	it("should apply optimized assignment defaults after evaluating the tuple", () => {
+		const values = [1, 2, 3];
+		const target = { value: 0 };
+		const array = [0];
+		let nested = 0;
+		let property = 0;
+		function read(): LuaTuple<[number?, Array<number>?, { value: number }?]> {
+			return $tuple(undefined, undefined, undefined);
+		}
+
+		[target.value = values.pop()!, [nested] = [values.pop()!], { value: property } = { value: values.pop()! }] =
+			read();
+		expect(target.value).to.equal(3);
+		expect(nested).to.equal(2);
+		expect(property).to.equal(1);
+		expect(values.size()).to.equal(0);
+
+		[array[0] = 10] = [undefined];
+		expect(array[0]).to.equal(10);
+	});
+
+	it("should apply optimized binding defaults after omitted tuple values", () => {
+		const values = [1, 2, 3];
+		function read(): LuaTuple<[number, number?, Array<number>?, { value: number }?]> {
+			return $tuple(10, undefined, undefined, undefined);
+		}
+
+		const [, a = values.pop()!, [b] = [values.pop()!], { value: c } = { value: values.pop()! }] = read();
+		expect(a).to.equal(3);
+		expect(b).to.equal(2);
+		expect(c).to.equal(1);
+		expect(values.size()).to.equal(0);
+	});
+
+	it("should assign inline iterator targets without defaults", () => {
+		let calls = 0;
+		const iterator = (() => {
+			calls += 1;
+			if (calls === 1) {
+				return $tuple(1, [2], { value: 3 });
+			}
+			return $tuple();
+		}) as IterableFunction<LuaTuple<[number, Array<number>, { value: number }]>>;
+		const target = { value: 0 };
+		let a = 0;
+		let b = 0;
+		for ([target.value, [a], { value: b }] of iterator) {
+			expect(target.value).to.equal(1);
+			expect(a).to.equal(2);
+			expect(b).to.equal(3);
+		}
+		expect(calls).to.equal(2);
+	});
+
+	it("should preserve single-value iterator and anonymous tuple iterator prerequisites", () => {
+		let calls = 0;
+		const iterator = (() => {
+			calls += 1;
+			return calls <= 2 ? calls : undefined;
+		}) as IterableFunction<number>;
+		const seen = new Array<number>();
+		for (const value of iterator) {
+			seen.push(value);
+		}
+		expect(seen.join(",")).to.equal("1,2");
+		expect(calls).to.equal(3);
+
+		let tupleCalls = 0;
+		for (const tuple of ((): LuaTuple<Array<number>> => {
+			tupleCalls += 1;
+			if (tupleCalls === 1) {
+				return $tuple(4, 5);
+			}
+			return $tuple();
+		}) as IterableFunction<LuaTuple<Array<number>>>) {
+			expect(tuple.join(",")).to.equal("4,5");
+		}
+		expect(tupleCalls).to.equal(2);
+	});
+
+	it("should repeat while prerequisites and support a for loop without a condition", () => {
+		const values = [1, 2, 3];
+		let iterations = 0;
+		while (values.pop() !== undefined) {
+			iterations += 1;
+		}
+		expect(iterations).to.equal(3);
+		expect(values.size()).to.equal(0);
+
+		let increments = 0;
+		for (;; increments += 1) {
+			if (increments === 2) {
+				break;
+			}
+		}
+		expect(increments).to.equal(2);
+	});
+
+	it("should evaluate omitted set and generator bindings", () => {
+		const set = new Set([10]);
+		const [,] = set;
+		expect(set.has(10)).to.equal(true);
+		expect(set.size()).to.equal(1);
+
+		let calls = 0;
+		function* numbers() {
+			calls += 1;
+			yield 1;
+			calls += 1;
+			yield 2;
+		}
+		const [, second] = numbers();
+		expect(second).to.equal(2);
+		expect(calls).to.equal(2);
+	});
+
+	it("should preserve mixed enum members and clear macro prerequisites", () => {
+		enum Mixed {
+			Text = "text",
+			Number = 1,
+		}
+		expect(Mixed.Text).to.equal("text");
+		expect(Mixed.Number).to.equal(1);
+		expect(Mixed[1]).to.equal("Number");
+
+		const values = [1, 2];
+		values.clear();
+		expect(values.size()).to.equal(0);
+		expect(values.clear()).to.equal(undefined);
+	});
+
+	it("should pass self to optional super method calls", () => {
+		class Base {
+			constructor(readonly value: number) {}
+			read(extra: number) {
+				return this.value + extra;
+			}
+		}
+		class Derived extends Base {
+			read(extra: number) {
+				return super.read?.(extra) ?? 0;
+			}
+		}
+		expect(new Derived(10).read(2)).to.equal(12);
+	});
+
 	it("should keep else-if and return prerequisites conditional", () => {
 		const values = [1, 2, 3];
 		function read(enabled: boolean) {

--- a/tests/src/tests/prereqs.spec.ts
+++ b/tests/src/tests/prereqs.spec.ts
@@ -1,0 +1,311 @@
+export = () => {
+	it("should keep else-if and return prerequisites conditional", () => {
+		const values = [1, 2, 3];
+		function read(enabled: boolean) {
+			if (enabled) {
+				return 0;
+			} else if (values.pop() === 3) {
+				return values.pop();
+			}
+			return values.pop();
+		}
+
+		expect(read(true)).to.equal(0);
+		expect(values.join(",")).to.equal("1,2,3");
+		expect(read(false)).to.equal(2);
+		expect(values.join(",")).to.equal("1");
+		expect(read(false)).to.equal(undefined);
+		expect(values.size()).to.equal(0);
+	});
+
+	it("should evaluate tuple return and throw prerequisites before finally", () => {
+		const values = [1, 2, 3, 4];
+		const failure = { message: "failed" };
+		const failures = [failure];
+		const remaining = new Array<number>();
+		function read(enabled: boolean) {
+			try {
+				if (enabled) {
+					return $tuple(values.pop(), values.pop());
+				}
+				throw failures.pop();
+			} catch (error) {
+				expect(error).to.equal(failure);
+				return $tuple(0, values.pop());
+			} finally {
+				remaining.push(values.size());
+			}
+		}
+
+		const first = read(true);
+		expect(first[0]).to.equal(4);
+		expect(first[1]).to.equal(3);
+		expect(failures.size()).to.equal(1);
+		const second = read(false);
+		expect(second[0]).to.equal(0);
+		expect(second[1]).to.equal(2);
+		expect(failures.size()).to.equal(0);
+		expect(remaining.join(",")).to.equal("2,1");
+		expect(values.join(",")).to.equal("1");
+	});
+
+	it("should isolate prerequisites in discarded conditional branches", () => {
+		const values = [1, 2, 3, 4];
+		function discard(enabled: boolean) {
+			enabled ? values.pop() : values.shift();
+		}
+
+		discard(true);
+		expect(values.join(",")).to.equal("1,2,3");
+		discard(false);
+		expect(values.join(",")).to.equal("2,3");
+	});
+
+	it("should evaluate for initializer prerequisites once before the condition", () => {
+		const values = [1, 3];
+		let index = 0;
+		const seen = new Array<number>();
+		for (index = values.pop()!; index > 0; index--) {
+			expect(values.size()).to.equal(1);
+			seen.push(index);
+		}
+
+		expect(seen.join(",")).to.equal("3,2,1");
+		expect(index).to.equal(0);
+		expect(values[0]).to.equal(1);
+	});
+
+	it("should evaluate field and parameter prerequisites only during construction", () => {
+		const values = [1, 2, 3];
+		class Example {
+			value = values.pop();
+			constructor(readonly other = values.pop()) {}
+		}
+
+		expect(values.size()).to.equal(3);
+		const first = new Example(10);
+		expect(first.other).to.equal(10);
+		expect(first.value).to.equal(3);
+		const second = new Example();
+		expect(second.other).to.equal(2);
+		expect(second.value).to.equal(1);
+		expect(values.size()).to.equal(0);
+	});
+
+	it("should isolate optional calls, macro callbacks, and conditional branches", () => {
+		const first = [1, 2];
+		const second = [3, 4];
+		function run(values: Array<number> | undefined, enabled: boolean) {
+			return values?.map(() => (enabled ? first.pop() : second.pop()));
+		}
+
+		expect(run(undefined, true)).to.equal(undefined);
+		expect(first.size()).to.equal(2);
+		expect(second.size()).to.equal(2);
+		const a = run([0, 0], true)!;
+		expect(a[0]).to.equal(2);
+		expect(a[1]).to.equal(1);
+		expect(second.size()).to.equal(2);
+		const b = run([0, 0], false)!;
+		expect(b[0]).to.equal(4);
+		expect(b[1]).to.equal(3);
+	});
+
+	it("should isolate destructuring defaults from object rest prerequisites", () => {
+		const values = [1, 2, 3];
+		function read({ value = values.pop(), ...rest }: { value?: number; other: number }) {
+			return [value, rest.other];
+		}
+
+		const first = read({ other: 4 });
+		expect(first[0]).to.equal(3);
+		expect(first[1]).to.equal(4);
+		const second = read({ value: 5, other: 6 });
+		expect(second[0]).to.equal(5);
+		expect(second[1]).to.equal(6);
+		expect(values.size()).to.equal(2);
+	});
+
+	it("should repeat loop prerequisites in order across continue", () => {
+		const values = [1, 2, 3];
+		const seen = new Array<number>();
+		let checks = 0;
+		let increments = 0;
+		for (; (checks += 1) < 4 && values.pop() !== undefined; increments += 1) {
+			if (checks === 2) {
+				continue;
+			}
+			seen.push(checks);
+		}
+
+		expect(checks).to.equal(4);
+		expect(increments).to.equal(3);
+		expect(values.size()).to.equal(0);
+		expect(seen.size()).to.equal(2);
+		expect(seen[0]).to.equal(1);
+		expect(seen[1]).to.equal(3);
+	});
+
+	it("should evaluate nested assignment defaults in source order", () => {
+		const values = [1, 2, 3, 4];
+		let a = 0;
+		let b = 0;
+		const array: [Array<number>?, { value: number }?] = [];
+		[[a] = [values.pop()!], { value: b } = { value: values.pop()! }] = array;
+		expect(a).to.equal(4);
+		expect(b).to.equal(3);
+
+		const object: { array?: Array<number>; object?: { value: number } } = {};
+		({ array: [a] = [values.pop()!], object: { value: b } = { value: values.pop()! } } = object);
+		expect(a).to.equal(2);
+		expect(b).to.equal(1);
+		expect(values.size()).to.equal(0);
+	});
+
+	it("should isolate nested binding and rest parameter defaults", () => {
+		const values = [1, 2, 3, 4, 5, 6];
+		function readArray([[a] = [values.pop()!], { value: b } = { value: values.pop()! }]: [
+			Array<number>?,
+			{ value: number }?,
+		]) {
+			return a + b;
+		}
+		function readObject({ array: [a] = [values.pop()!] }: { array?: Array<number> }) {
+			return a;
+		}
+		function readRest(
+			...[a = values.pop()!, [b] = [values.pop()!], { value: c } = { value: values.pop()! }]: [
+				number?,
+				Array<number>?,
+				{ value: number }?,
+			]
+		) {
+			return a + b + c;
+		}
+
+		expect(readArray([])).to.equal(11);
+		expect(readObject({})).to.equal(4);
+		expect(readRest()).to.equal(6);
+		expect(values.size()).to.equal(0);
+		expect(readArray([[10], { value: 20 }])).to.equal(30);
+		expect(readObject({ array: [30] })).to.equal(30);
+		expect(readRest(10, [20], { value: 30 })).to.equal(60);
+	});
+
+	it("should keep generator assignment prerequisites inside each iteration", () => {
+		const values = [1, 2, 3, 4];
+		function* arrays(): Generator<[number?]> {
+			yield [];
+			yield [10];
+			yield [];
+		}
+		function* objects(): Generator<{ value?: number }> {
+			yield {};
+			yield { value: 20 };
+			yield {};
+		}
+		let value = 0;
+		const seen = new Array<number>();
+		for ([value = values.pop()!] of arrays()) {
+			seen.push(value);
+		}
+		for ({ value = values.pop()! } of objects()) {
+			seen.push(value);
+		}
+
+		expect(seen.join(",")).to.equal("4,10,3,2,20,1");
+		expect(values.size()).to.equal(0);
+	});
+
+	it("should keep array assignment prerequisites inside each iteration", () => {
+		const values = [1, 2, 3, 4];
+		const arrays: Array<[number?]> = [[], [10], []];
+		const objects: Array<{ value?: number }> = [{}, { value: 20 }, {}];
+		let value = 0;
+		const seen = new Array<number>();
+		for ([value = values.pop()!] of arrays) {
+			seen.push(value);
+		}
+		for ({ value = values.pop()! } of objects) {
+			seen.push(value);
+		}
+
+		expect(seen.join(",")).to.equal("4,10,3,2,20,1");
+		expect(values.size()).to.equal(0);
+	});
+
+	it("should isolate inline iterator assignment defaults", () => {
+		const values = [1, 2, 3];
+		let count = 0;
+		const iterator = (() => {
+			count += 1;
+			if (count <= 2) {
+				return $tuple(count, undefined, undefined, undefined);
+			}
+			return $tuple();
+		}) as IterableFunction<LuaTuple<[number, number?, Array<number>?, { value: number }?]>>;
+		let a = 0;
+		let b = 0;
+		let c = 0;
+		for ([
+			,
+			a = values.pop() ?? 10,
+			[b] = [values.pop() ?? 20],
+			{ value: c } = { value: values.pop() ?? 30 },
+		] of iterator) {
+			if (count === 1) {
+				expect(a).to.equal(3);
+				expect(b).to.equal(2);
+				expect(c).to.equal(1);
+			} else {
+				expect(a).to.equal(10);
+				expect(b).to.equal(20);
+				expect(c).to.equal(30);
+			}
+		}
+
+		expect(count).to.equal(3);
+		expect(values.size()).to.equal(0);
+	});
+
+	it("should preserve omitted iterable reads and discarded results", () => {
+		let calls = 0;
+		const iterator = (() => ++calls) as IterableFunction<number>;
+		const [, second] = iterator;
+		expect(second).to.equal(2);
+		expect(calls).to.equal(2);
+
+		const tupleIterator = (() => $tuple(++calls, 10)) as IterableFunction<LuaTuple<[number, number]>>;
+		const [, [fourth, value]] = tupleIterator;
+		expect(fourth).to.equal(4);
+		expect(value).to.equal(10);
+		expect(calls).to.equal(4);
+
+		const [, character] = "abc";
+		expect(character).to.equal("b");
+		const values = [1, 2];
+		expect(void values.pop()).to.equal(undefined);
+		expect(values.size()).to.equal(1);
+	});
+
+	it("should assign generator and map values before the loop body", () => {
+		function* numbers() {
+			yield 1;
+			yield 2;
+		}
+		let value = 0;
+		const seen = new Array<number>();
+		for (value of numbers()) {
+			seen.push(value);
+		}
+		expect(seen.join(",")).to.equal("1,2");
+
+		let entry: [string, number] = ["", 0];
+		for (entry of new Map([["key", 10]])) {
+			expect(entry[0]).to.equal("key");
+			expect(entry[1]).to.equal(10);
+		}
+		expect(entry[0]).to.equal("key");
+		expect(entry[1]).to.equal(10);
+	});
+};

--- a/tests/src/tests/prereqsJsx.spec.tsx
+++ b/tests/src/tests/prereqsJsx.spec.tsx
@@ -1,0 +1,41 @@
+/** @jsxFrag Roact.Fragment */
+import Roact from "@rbxts/roact";
+
+export = () => {
+	it("should evaluate JSX attribute prerequisites in order", () => {
+		const values = [1, 2, 3];
+		const element = <frame LayoutOrder={values.pop()} ZIndex={values.pop()} />;
+		const props = element.props as Frame;
+
+		expect(props.LayoutOrder).to.equal(3);
+		expect(props.ZIndex).to.equal(2);
+		expect(values.join(",")).to.equal("1");
+	});
+
+	it("should evaluate conditional JSX spreads once", () => {
+		let calls = 0;
+		function props(enabled: boolean) {
+			calls += 1;
+			return enabled && { LayoutOrder: 3 };
+		}
+
+		const enabled = <frame ZIndex={2} {...props(true)} />;
+		const disabled = <frame ZIndex={4} {...props(false)} />;
+		expect((enabled.props as Frame).LayoutOrder).to.equal(3);
+		expect((disabled.props as Frame).LayoutOrder).to.equal(undefined);
+		expect((disabled.props as Frame).ZIndex).to.equal(4);
+		expect(calls).to.equal(2);
+	});
+
+	it("should preserve child prerequisites in shorthand fragments", () => {
+		const values = [1, 2];
+		const fragment = (
+			<>
+				<frame Key="Child" LayoutOrder={values.pop()} />
+			</>
+		);
+		const children = (fragment as unknown as { elements: { Child: Roact.Element } }).elements;
+		expect((children.Child.props as Frame).LayoutOrder).to.equal(2);
+		expect(values.join(",")).to.equal("1");
+	});
+};


### PR DESCRIPTION
- Replace `TransformState`'s implicit prerequisite stack with an explicit `Prereqs` parameter, making caller-prerequisite emission visible in transform and macro signatures.
- Give branches, loops, and callbacks their own collectors. Statement transforms return complete Luau statement lists, with prerequisite collection kept local.
- Preserve emitted Luau and evaluation order, with snapshot and runtime coverage for nested prerequisites, destructuring defaults, optional calls, loops, and returns.

```ts
const prereqs = new Prereqs();
const expression = transformExpression(state, prereqs, node);
luau.list.pushList(statements, prereqs.statements);
```

- Validation: `npm test` and lint pass; runtime fixtures and the representative project's emitted output are unchanged.

Fixes #2727. Related: #2729.
