### PR TITLE
Run compiler tests in parallel using all available CPUs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"devlink": "npm run build && cd devlink && npm link",
 		"update-test-types": "cd tests && npm install github:roblox-ts/compiler-types @rbxts/types@latest && npm install",
 		"test": "npm run build && npm run test-compile && npm run test-rojo && npm run test-run",
-		"test-compile": "jest --coverage --runInBand",
+		"test-compile": "jest --coverage --maxWorkers=100%",
 		"test-rojo": "rojo build tests -o ./tests/test.rbxl",
 		"test-run": "lune run ./tests/runTestsWithLune.luau ./tests/test.rbxl",
 		"test-roblox": "npm run build && npm run test-compile && npm run test-rojo && npm run run-in-roblox",

--- a/tests/compiler/projectReference/watchInputs.test.ts
+++ b/tests/compiler/projectReference/watchInputs.test.ts
@@ -3,6 +3,8 @@ import { projectPathKey } from "Project/classes/ProjectGraph";
 
 import { expectSuccess, ReferenceFixture, startWatch } from "../referenceFixture";
 
+jest.setTimeout(30000);
+
 let fixture: ReferenceFixture;
 beforeEach(() => {
 	fixture = new ReferenceFixture();


### PR DESCRIPTION
- Replace `--runInBand` with `--maxWorkers=100%` so compiler test files run in parallel using all available CPUs, adapting to each GitHub Actions runner.
- Give the watch-input suite the same 30-second timeout as the neighboring watch suites, allowing filesystem integration tests to finish under parallel CI load.
- Validated parallel execution with `npm test` (24 compiler suites, 91 snapshots, and 703 runtime tests passed), the adjusted watch-input suite, and `npm run eslint`.
