### PR TITLE
Update rojo-resolver to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@roblox-ts/luau-ast": "=2.1.0",
 				"@roblox-ts/path-translator": "=1.1.0",
-				"@roblox-ts/rojo-resolver": "=1.1.0",
+				"@roblox-ts/rojo-resolver": "=1.2.0",
 				"chokidar": "^4.0.3",
 				"fs-extra": "^11.3.0",
 				"kleur": "^4.1.5",
@@ -1556,9 +1556,9 @@
 			}
 		},
 		"node_modules/@roblox-ts/rojo-resolver": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@roblox-ts/rojo-resolver/-/rojo-resolver-1.1.0.tgz",
-			"integrity": "sha512-QmvVryu1EeME+3QUoG5j/gHGJoJUaffCgZ92mhlG7cJSd1uyhgpY4CNWriZAwZJYkTlzd5Htkpn+18yDFbOFXA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@roblox-ts/rojo-resolver/-/rojo-resolver-1.2.0.tgz",
+			"integrity": "sha512-Hpnwu7Zcggc6wdu72wrQj7vwKv29W4+EWqOyg6fJj2oqoC9AKdlqrO10O42MeJ37FiHIreqsdD/L1TWrTjoBag==",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	"dependencies": {
 		"@roblox-ts/luau-ast": "=2.1.0",
 		"@roblox-ts/path-translator": "=1.1.0",
-		"@roblox-ts/rojo-resolver": "=1.1.0",
+		"@roblox-ts/rojo-resolver": "=1.2.0",
 		"chokidar": "^4.0.3",
 		"fs-extra": "^11.3.0",
 		"kleur": "^4.1.5",


### PR DESCRIPTION
- Update `@roblox-ts/rojo-resolver` to 1.2.0 so modules with dotted filenames, such as `module.require.ts`, receive the required `return nil`.
- Recognize `.plugin.lua` and `.plugin.luau` as scripts through the resolver update.

Fixes #2851. Supersedes #2887.
