### PR TITLE
fix(runtime): allow re-registration by the same RuntimeLib script

### DIFF
--- a/include/RuntimeLib.luau
+++ b/include/RuntimeLib.luau
@@ -12,6 +12,9 @@ local TS = {}
 
 TS.Promise = Promise
 
+-- re-execution creates a fresh TS table, but preserves the runtime's ModuleScript identity
+TS.__runtimeScript = script
+
 local function isPlugin(context)
 	return RunService:IsStudio() and context:FindFirstAncestorWhichIsA("Plugin") ~= nil
 end
@@ -88,7 +91,8 @@ function TS.import(context, module, ...)
 	end
 
 	if not registeredLibraries[module] then
-		if _G[module] then
+		local registeredBy = _G[module]
+		if registeredBy ~= nil and (type(registeredBy) ~= "table" or registeredBy.__runtimeScript ~= script) then
 			error(
 				OUTPUT_PREFIX
 				.. "Invalid module access! Do you have multiple TS runtimes trying to import this? "

--- a/tests/src/tests/runtimeImport.spec.luau
+++ b/tests/src/tests/runtimeImport.spec.luau
@@ -1,0 +1,64 @@
+-- Luau lets the guard tests seed _G without casts around roblox-ts' opaque typing
+
+return function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+	local include = ReplicatedStorage:FindFirstChild("include")
+	assert(include, "Unable to find include folder")
+	local runtimeLibModule = include:FindFirstChild("RuntimeLib")
+	assert(runtimeLibModule, "Unable to find RuntimeLib")
+
+	local TS = require(runtimeLibModule)
+	local runtimeScript = TS.__runtimeScript
+	assert(runtimeScript ~= nil, "RuntimeLib did not expose __runtimeScript")
+
+	local function fixture(name: string)
+		-- requiring the clone returns the spec function without running its tests
+		local module = script:Clone()
+		module.Name = name
+		return module
+	end
+
+	it("tolerates re-registration by the same runtime", function()
+		local module = fixture("sameRuntime")
+		-- stand in for a prior runtime table left by the same RuntimeLib script
+		_G[module] = { __runtimeScript = runtimeScript }
+
+		expect(function()
+			TS.import(script, module)
+		end).never.to.throw()
+	end)
+
+	it("rejects a module owned by a different runtime", function()
+		local module = fixture("differentRuntime")
+		TS.import(script, module)
+		local otherRuntimeModule = runtimeLibModule:Clone()
+		otherRuntimeModule.Name = "OtherRuntimeLib"
+		otherRuntimeModule.Parent = include
+		local otherRuntime = require(otherRuntimeModule)
+		otherRuntimeModule:Destroy()
+
+		expect(function()
+			otherRuntime.import(script, module)
+		end).to.throw("multiple TS runtimes")
+		expect(_G[module]).to.equal(TS)
+	end)
+
+	it("rejects untagged and non-table _G owners", function()
+		local module = fixture("nonTableOwner")
+		for _, owner in { {}, true, false, "invalid", 42 } do
+			_G[module] = owner
+			expect(function()
+				TS.import(script, module)
+			end).to.throw("multiple TS runtimes")
+			expect(_G[module]).to.equal(owner)
+		end
+	end)
+
+	it("preserves cached runtime and package identity", function()
+		local module = fixture("cachedRuntime")
+		local packageModule = TS.import(script, module)
+		expect(require(runtimeLibModule)).to.equal(TS)
+		expect(TS.import(script, module)).to.equal(packageModule)
+	end)
+end


### PR DESCRIPTION
Re-executing RuntimeLib creates a fresh TS table and registration cache, while _G can retain registrations from the previous execution. Tagging TS with its RuntimeLib ModuleScript lets a later execution recognize the same installation; a different RuntimeLib ModuleScript still throws.

Adds one self-contained TestEZ spec covering prior same-script registrations, distinct runtime installations, invalid owners, and cached imports. The same-script case seeds a prior registration; it does not re-execute RuntimeLib. No runner or configuration changes.

Validation: all four cases pass through the existing Lune runner using a temporary focused place. Restoring the original guard fails the same-script case. Lint passes. Full npm test stops at the build step with TypeScript errors in unchanged files, including ts-expose-internals and ProjectBuild.ts, so the full upstream suite has not passed locally.

Related to #3011 and #3019.

Generated with Codex.
