### PR TITLE
Limit Jest to two workers on macOS CI

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,8 @@ import type { Config } from "jest";
 const config: Config = {
 	preset: "ts-jest",
 	testEnvironment: "node",
+	// leave headroom for compiler watch tests on the smaller macOS runners
+	maxWorkers: process.env.GITHUB_ACTIONS === "true" && process.platform === "darwin" ? 2 : "100%",
 	workerIdleMemoryLimit: "512MB",
 	testMatch: ["<rootDir>/tests/compiler/**/*.test.ts"],
 	modulePathIgnorePatterns: ["<rootDir>/out/"],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"devlink": "npm run build && cd devlink && npm link",
 		"update-test-types": "cd tests && npm install github:roblox-ts/compiler-types @rbxts/types@latest && npm install",
 		"test": "npm run build && npm run test-compile && npm run test-rojo && npm run test-run",
-		"test-compile": "jest --coverage --maxWorkers=100%",
+		"test-compile": "jest --coverage",
 		"test-rojo": "rojo build tests -o ./tests/test.rbxl",
 		"test-run": "lune run ./tests/runTestsWithLune.luau ./tests/test.rbxl",
 		"test-roblox": "npm run build && npm run test-compile && npm run test-rojo && npm run run-in-roblox",


### PR DESCRIPTION
- Limit Jest to two workers on macOS GitHub Actions runners to reduce resource contention during compiler watch tests, which have intermittently exceeded their 30-second timeout.
- Keep the existing `100%` worker default elsewhere and preserve CLI overrides.
- Checked worker selection and configuration loading locally; all CI checks pass, including compiler and runtime tests on macOS, Linux, and Windows.
