### PR TITLE
Bump roblox-ts support packages to latest patch releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@roblox-ts/luau-ast": "=2.1.0",
-				"@roblox-ts/path-translator": "=1.1.0",
-				"@roblox-ts/rojo-resolver": "=1.2.0",
+				"@roblox-ts/luau-ast": "=2.1.1",
+				"@roblox-ts/path-translator": "=1.1.1",
+				"@roblox-ts/rojo-resolver": "=1.2.1",
 				"chokidar": "^4.0.3",
 				"fs-extra": "^11.4.0",
 				"kleur": "^4.1.5",
@@ -1808,29 +1808,29 @@
 			}
 		},
 		"node_modules/@roblox-ts/luau-ast": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@roblox-ts/luau-ast/-/luau-ast-2.1.0.tgz",
-			"integrity": "sha512-gdctRw3wOzW0VYqnVK5BbpvgZ0rwSn3pT3I47KV6CZHJSSc37f0xajpQO9LtXsc1JC9N342lJmhrvdQ9YVUdKQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@roblox-ts/luau-ast/-/luau-ast-2.1.1.tgz",
+			"integrity": "sha512-k+c5Cc02Nhy+8nbU4bkL1MTIrrXTWgmhhS6N1avpebjdVVTc1myRUKGCsmUwmNHSOw85DEkG7QR2MswJv7Tw8w==",
 			"license": "MIT"
 		},
 		"node_modules/@roblox-ts/path-translator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@roblox-ts/path-translator/-/path-translator-1.1.0.tgz",
-			"integrity": "sha512-D0akTmnNYqBw+ZIek5JxocT3BjmbgGOuOy0x1nIIxHBPNLGCpzseToY8jyYs/0mlvnN2xnSP/k8Tv+jvGOQSwQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@roblox-ts/path-translator/-/path-translator-1.1.1.tgz",
+			"integrity": "sha512-t5vGL05ncxOt8A+oocfulpB0HUsExZhuKVrZ7PPl6mU4t2prJzVVekRdXCMXCPuIE2mMJGonxMGJoRh+4qHOgg==",
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^8.12.0",
-				"fs-extra": "^11.2.0"
+				"ajv": "^8.20.0",
+				"fs-extra": "^11.4.0"
 			}
 		},
 		"node_modules/@roblox-ts/rojo-resolver": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@roblox-ts/rojo-resolver/-/rojo-resolver-1.2.0.tgz",
-			"integrity": "sha512-Hpnwu7Zcggc6wdu72wrQj7vwKv29W4+EWqOyg6fJj2oqoC9AKdlqrO10O42MeJ37FiHIreqsdD/L1TWrTjoBag==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@roblox-ts/rojo-resolver/-/rojo-resolver-1.2.1.tgz",
+			"integrity": "sha512-jpk03dApr2Tk5dE7ZVQRMDmbIbhOIYq/mLpZuHvje2IbCxTh4+GUDmLIBXqG8bP4A3v29pAjbOSc6zR10xFUjQ==",
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^8.17.1",
-				"fs-extra": "^11.2.0"
+				"ajv": "^8.20.0",
+				"fs-extra": "^11.4.0"
 			}
 		},
 		"node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
-		"@roblox-ts/luau-ast": "=2.1.0",
-		"@roblox-ts/path-translator": "=1.1.0",
-		"@roblox-ts/rojo-resolver": "=1.2.0",
+		"@roblox-ts/luau-ast": "=2.1.1",
+		"@roblox-ts/path-translator": "=1.1.1",
+		"@roblox-ts/rojo-resolver": "=1.2.1",
 		"chokidar": "^4.0.3",
 		"fs-extra": "^11.4.0",
 		"kleur": "^4.1.5",


### PR DESCRIPTION
- Bump the exact package pins to the newly published patch releases: `@roblox-ts/luau-ast` 2.1.1, `@roblox-ts/path-translator` 1.1.1, and `@roblox-ts/rojo-resolver` 1.2.1.
- Refresh their lockfile metadata.
- `npm test` passes (25 compiler suites, 95 snapshots, and 703 runtime tests), along with lint and formatting checks.
