### PR TITLE
Expand TSTransformer coverage and fix uncovered compiler bugs

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,16 +12,9 @@ const config: Config = {
 		"^(Project|Shared|CLI|TSTransformer)/(.*)$": "<rootDir>/src/$1/$2",
 		"^(Project|Shared|CLI|TSTransformer)$": "<rootDir>/src/$1",
 	},
-	collectCoverageFrom: [
-		"src/**/*.ts",
-		"!src/CLI/**",
-		"!src/Shared/classes/LogService.ts",
-		"!src/TSTransformer/util/getFlags.ts",
-		"!src/TSTransformer/util/getKindName.ts",
-		"!src/TSTransformer/util/jsx/constants.ts",
-	],
+	collectCoverageFrom: ["src/**/*.ts", "!src/CLI/**", "!src/Shared/classes/LogService.ts"],
 	coverageDirectory: "coverage",
-	coverageReporters: ["lcov", "text"],
+	coverageReporters: ["json", "lcov", "text"],
 	verbose: true,
 	transform: {
 		"^.+\\.tsx?$": ["ts-jest", { tsconfig: "tests/compiler/tsconfig.json" }],

--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -99,7 +99,7 @@ export class MacroManager {
 	private constructorMacros = new Map<ts.Symbol, ConstructorMacro>();
 	private propertyCallMacros = new Map<ts.Symbol, PropertyCallMacro>();
 
-	constructor(typeChecker: ts.TypeChecker) {
+	constructor(private readonly typeChecker: ts.TypeChecker) {
 		for (const [name, macro] of Object.entries(IDENTIFIER_MACROS)) {
 			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, name, ts.SymbolFlags.Variable);
 			this.identifierMacros.set(symbol, macro);
@@ -190,13 +190,12 @@ export class MacroManager {
 
 	public getPropertyCallMacro(symbol: ts.Symbol) {
 		const macro = this.propertyCallMacros.get(symbol);
-		if (
-			!macro &&
-			symbol.parent &&
-			this.symbols.get(symbol.parent.name) === symbol.parent &&
-			this.isMacroOnlyClass(symbol.parent)
-		) {
-			assert(false, `Macro ${symbol.parent.name}.${symbol.name}() is not implemented!`);
+		if (!macro && symbol.parent) {
+			// augmented interface members retain their original, unmerged parent symbol
+			const parent = this.typeChecker.getMergedSymbol(symbol.parent);
+			if (this.symbols.get(parent.name) === parent && this.isMacroOnlyClass(parent)) {
+				assert(false, `Macro ${parent.name}.${symbol.name}() is not implemented!`);
+			}
 		}
 		return macro;
 	}

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -206,7 +206,14 @@ export class TransformState {
 
 	public getModuleExports(moduleSymbol: ts.Symbol) {
 		return getOrSetDefault(this.multiTransformState.getModuleExportsCache, moduleSymbol, () =>
-			this.typeChecker.getExportsOfModule(moduleSymbol),
+			this.typeChecker.getExportsOfModule(moduleSymbol).filter(exportSymbol => {
+				const typeOnlyDeclaration = this.typeChecker.getTypeOnlyAliasDeclaration(exportSymbol);
+				// erased aliases must not redirect mutable locals to properties on the exports table
+				return (
+					!typeOnlyDeclaration ||
+					(this.compilerOptions.verbatimModuleSyntax && !ts.isTypeOnlyExportDeclaration(typeOnlyDeclaration))
+				);
+			}),
 		);
 	}
 

--- a/src/TSTransformer/nodes/binding/transformArrayAssignmentPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformArrayAssignmentPattern.ts
@@ -6,8 +6,9 @@ import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformObjectAssignmentPattern } from "TSTransformer/nodes/binding/transformObjectAssignmentPattern";
 import { transformInitializer } from "TSTransformer/nodes/transformInitializer";
-import { transformWritableExpression } from "TSTransformer/nodes/transformWritable";
+import { captureWritableAssignmentTarget, transformWritableExpression } from "TSTransformer/nodes/transformWritable";
 import { getAccessorForBindingType } from "TSTransformer/util/binding/getAccessorForBindingType";
+import { getEffects } from "TSTransformer/util/evaluation/effects";
 import { getKindName } from "TSTransformer/util/getKindName";
 import { getSpreadDestructorForType } from "TSTransformer/util/spreadDestructuring";
 import { skipDownwards } from "TSTransformer/util/traversal";
@@ -36,9 +37,10 @@ export function transformArrayAssignmentPattern(
 				element = skipDownwards(element.left);
 			}
 
+			const valuePrereqs = new Prereqs();
 			const value = ts.isSpreadElement(element)
-				? destructor(prereqs, parentId, index, idStack)
-				: accessor(prereqs, parentId, index, idStack, false);
+				? destructor(valuePrereqs, parentId, index, idStack)
+				: accessor(valuePrereqs, parentId, index, idStack, false);
 
 			// diagnostic is needed because getTypeOfAssignmentPattern is implemented incorrectly:
 			// it errors, if that parent of node being passed in is ts.SpreadElement
@@ -56,12 +58,19 @@ export function transformArrayAssignmentPattern(
 				ts.isPropertyAccessExpression(element) ||
 				ts.isSpreadElement(element)
 			) {
-				const id = transformWritableExpression(
+				let id = transformWritableExpression(
 					state,
 					prereqs,
 					ts.isSpreadElement(element) ? element.expression : element,
 					initializer !== undefined,
 				);
+				id = captureWritableAssignmentTarget(
+					prereqs,
+					id,
+					getEffects(valuePrereqs.statements),
+					getEffects(value),
+				);
+				prereqs.pushList(valuePrereqs.statements);
 				prereqs.push(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: id,
@@ -73,12 +82,14 @@ export function transformArrayAssignmentPattern(
 					prereqs.push(transformInitializer(state, id, initializer));
 				}
 			} else if (ts.isArrayLiteralExpression(element)) {
+				prereqs.pushList(valuePrereqs.statements);
 				const id = prereqs.pushToVar(value, "binding");
 				if (initializer) {
 					prereqs.push(transformInitializer(state, id, initializer));
 				}
 				transformArrayAssignmentPattern(state, prereqs, element, id);
 			} else if (ts.isObjectLiteralExpression(element)) {
+				prereqs.pushList(valuePrereqs.statements);
 				const id = prereqs.pushToVar(value, "binding");
 				if (initializer) {
 					prereqs.push(transformInitializer(state, id, initializer));

--- a/src/TSTransformer/nodes/binding/transformArrayAssignmentPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformArrayAssignmentPattern.ts
@@ -24,7 +24,8 @@ export function transformArrayAssignmentPattern(
 	const idStack = new Array<luau.Identifier>();
 	const patternType = state.typeChecker.getTypeOfAssignmentPattern(assignmentPattern);
 
-	const accessor = getAccessorForBindingType(state, assignmentPattern, patternType);
+	const hasRest = assignmentPattern.elements.some(ts.isSpreadElement);
+	const accessor = getAccessorForBindingType(state, assignmentPattern, patternType, hasRest);
 	const destructor = getSpreadDestructorForType(state, assignmentPattern, patternType);
 
 	for (let element of assignmentPattern.elements) {

--- a/src/TSTransformer/nodes/binding/transformArrayBindingPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformArrayBindingPattern.ts
@@ -5,7 +5,9 @@ import { transformObjectBindingPattern } from "TSTransformer/nodes/binding/trans
 import { transformVariable } from "TSTransformer/nodes/statements/transformVariableStatement";
 import { transformInitializer } from "TSTransformer/nodes/transformInitializer";
 import { getAccessorForBindingType } from "TSTransformer/util/binding/getAccessorForBindingType";
+import { effectsCommute, getEffects, UNKNOWN_EFFECTS } from "TSTransformer/util/evaluation/effects";
 import { getSpreadDestructorForType } from "TSTransformer/util/spreadDestructuring";
+import { isDefinitelyType, isIterableFunctionType } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 import ts from "typescript";
 
@@ -17,10 +19,19 @@ export function transformArrayBindingPattern(
 ) {
 	validateNotAnyType(state, bindingPattern);
 
+	const type = state.getType(bindingPattern);
+	if (
+		isDefinitelyType(type, isIterableFunctionType(state)) &&
+		!effectsCommute(getEffects(parentId), UNKNOWN_EFFECTS)
+	) {
+		// advancing an iterator can rebind its source before later elements read it
+		parentId = prereqs.pushToVar(parentId, "iterator");
+	}
+
 	let index = 0;
 	const idStack = new Array<luau.AnyIdentifier>();
-	const accessor = getAccessorForBindingType(state, bindingPattern, state.getType(bindingPattern));
-	const destructor = getSpreadDestructorForType(state, bindingPattern, state.getType(bindingPattern));
+	const accessor = getAccessorForBindingType(state, bindingPattern, type);
+	const destructor = getSpreadDestructorForType(state, bindingPattern, type);
 
 	for (const element of bindingPattern.elements) {
 		if (ts.isOmittedExpression(element)) {

--- a/src/TSTransformer/nodes/binding/transformArrayBindingPattern.ts
+++ b/src/TSTransformer/nodes/binding/transformArrayBindingPattern.ts
@@ -30,7 +30,8 @@ export function transformArrayBindingPattern(
 
 	let index = 0;
 	const idStack = new Array<luau.AnyIdentifier>();
-	const accessor = getAccessorForBindingType(state, bindingPattern, type);
+	const hasRest = bindingPattern.elements.some(element => ts.isBindingElement(element) && element.dotDotDotToken);
+	const accessor = getAccessorForBindingType(state, bindingPattern, type, hasRest);
 	const destructor = getSpreadDestructorForType(state, bindingPattern, type);
 
 	for (const element of bindingPattern.elements) {

--- a/src/TSTransformer/nodes/jsx/transformJsxChildren.ts
+++ b/src/TSTransformer/nodes/jsx/transformJsxChildren.ts
@@ -32,8 +32,16 @@ export function transformJsxChildren(state: TransformState, prereqs: Prereqs, ch
 			.filter(v => !ts.isJsxExpression(v) || v.expression !== undefined),
 		(state, prereqs, node) => {
 			if (ts.isJsxText(node)) {
-				const text = fixupWhitespaceAndDecodeEntities(node.text) ?? "";
-				return luau.string(text.replace(/\\/g, "\\\\"));
+				let text = fixupWhitespaceAndDecodeEntities(node.text) ?? "";
+				text = text.replace(/\\/g, "\\\\");
+				text = text.replace(/"/g, '\\"');
+				text = text.replace(
+					// eslint-disable-next-line no-control-regex -- decoded entities can contain literal control characters
+					/[\x00-\x1f\x7f]/g,
+					character => `\\x${character.charCodeAt(0).toString(16).padStart(2, "0")}`,
+				);
+				// decoded text needs quoted escapes even when it contains both quote characters
+				return luau.string(text, '"');
 			}
 			return transformExpression(state, prereqs, node);
 		},

--- a/src/TSTransformer/nodes/statements/transformExportAssignment.ts
+++ b/src/TSTransformer/nodes/statements/transformExportAssignment.ts
@@ -56,7 +56,11 @@ export function transformExportAssignment(state: TransformState, node: ts.Export
 		DiagnosticService.addDiagnostic(errors.noExportAssignmentLet(node));
 	}
 
-	if (symbol && !isSymbolOfValue(ts.skipAlias(symbol, state.typeChecker))) {
+	if (
+		symbol &&
+		(!isSymbolOfValue(ts.skipAlias(symbol, state.typeChecker)) ||
+			(!state.compilerOptions.verbatimModuleSyntax && state.typeChecker.getTypeOnlyAliasDeclaration(symbol)))
+	) {
 		return luau.list.make<luau.Statement>();
 	}
 

--- a/src/TSTransformer/nodes/statements/transformForOfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForOfStatement.ts
@@ -340,7 +340,15 @@ const buildIterableFunctionLuaTupleLoop: (type: ts.Type) => LoopBuilder =
 			luau.list.push(
 				loopStatements,
 				luau.create(luau.SyntaxKind.IfStatement, {
-					condition: luau.binary(luau.unary("#", valueId), "==", luau.number(0)),
+					// Luau stops an iterator when its first return is nil, regardless of later returns
+					condition: luau.binary(
+						luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+							expression: valueId,
+							index: luau.number(1),
+						}),
+						"==",
+						luau.nil(),
+					),
 					statements: luau.list.make(luau.create(luau.SyntaxKind.BreakStatement, {})),
 					elseBody: luau.list.make(),
 				}),

--- a/src/TSTransformer/nodes/statements/transformImportEqualsDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformImportEqualsDeclaration.ts
@@ -9,15 +9,23 @@ import { isSymbolOfValue } from "TSTransformer/util/isSymbolOfValue";
 import ts from "typescript";
 
 export function transformImportEqualsDeclaration(state: TransformState, node: ts.ImportEqualsDeclaration) {
+	if (node.isTypeOnly) {
+		return luau.list.make<luau.Statement>();
+	}
+
 	const { moduleReference } = node;
 	if (ts.isExternalModuleReference(moduleReference)) {
 		const statements = luau.list.make<luau.Statement>();
-		assert(ts.isStringLiteral(moduleReference.expression));
-		const importExp = createImportExpression(state, node.getSourceFile(), moduleReference.expression);
-
 		const aliasSymbol = state.typeChecker.getSymbolAtLocation(node.name);
 		assert(aliasSymbol);
-		if (isSymbolOfValue(ts.skipAlias(aliasSymbol, state.typeChecker))) {
+		const isValue = isSymbolOfValue(ts.skipAlias(aliasSymbol, state.typeChecker));
+		if (!isValue && !state.compilerOptions.verbatimModuleSyntax) {
+			return statements;
+		}
+
+		assert(ts.isStringLiteral(moduleReference.expression));
+		const importExp = createImportExpression(state, node.getSourceFile(), moduleReference.expression);
+		if (isValue) {
 			const importPrereqs = new Prereqs();
 			transformVariable(state, importPrereqs, node.name, importExp);
 			luau.list.pushList(statements, importPrereqs.statements);

--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -112,7 +112,11 @@ function handleExports(
 
 	let mustPushExports = state.hasExportFrom;
 	const exportPairs = new Array<[luau.Expression, luau.AnyIdentifier]>();
-	if (!state.hasExportEquals) {
+	// even an erased export = replaces the module's named exports
+	const hasExportEquals = sourceFile.statements.some(
+		statement => ts.isExportAssignment(statement) && statement.isExportEquals,
+	);
+	if (!hasExportEquals) {
 		for (const exportSymbol of state.getModuleExports(symbol)) {
 			if (ignoredExportSymbols.has(exportSymbol)) continue;
 

--- a/src/TSTransformer/nodes/transformWritable.ts
+++ b/src/TSTransformer/nodes/transformWritable.ts
@@ -53,6 +53,31 @@ export function transformWritableExpression(
 	}
 }
 
+export function transformWritableAssignment(
+	state: TransformState,
+	prereqs: Prereqs,
+	writeNode: ts.Expression,
+	valueNode: ts.Expression,
+	readAfterWrite = false,
+	readBeforeWrite = false,
+) {
+	let writable = transformWritableExpression(state, prereqs, writeNode, readAfterWrite);
+	const valuePrereqs = new Prereqs();
+	const value = transformExpression(state, valuePrereqs, valueNode);
+	const prereqEffects = getEffects(valuePrereqs.statements);
+	const valueEffects = getEffects(value);
+	const effects = joinEffects(prereqEffects, valueEffects);
+	writable = captureWritableAssignmentTarget(prereqs, writable, prereqEffects, valueEffects);
+	// the assignment target and its old value may need separate snapshots
+	const readable =
+		readBeforeWrite && !effectsCommute(getEffects(writable), effects)
+			? prereqs.pushToVar(writable, "readable")
+			: writable;
+	prereqs.pushList(valuePrereqs.statements);
+
+	return { writable, readable, value };
+}
+
 export function captureWritableAssignmentTarget(
 	prereqs: Prereqs,
 	writable: luau.WritableExpression,
@@ -79,29 +104,4 @@ export function captureWritableAssignmentTarget(
 		}
 	}
 	return writable;
-}
-
-export function transformWritableAssignment(
-	state: TransformState,
-	prereqs: Prereqs,
-	writeNode: ts.Expression,
-	valueNode: ts.Expression,
-	readAfterWrite = false,
-	readBeforeWrite = false,
-) {
-	let writable = transformWritableExpression(state, prereqs, writeNode, readAfterWrite);
-	const valuePrereqs = new Prereqs();
-	const value = transformExpression(state, valuePrereqs, valueNode);
-	const prereqEffects = getEffects(valuePrereqs.statements);
-	const valueEffects = getEffects(value);
-	const effects = joinEffects(prereqEffects, valueEffects);
-	writable = captureWritableAssignmentTarget(prereqs, writable, prereqEffects, valueEffects);
-	// the assignment target and its old value may need separate snapshots
-	const readable =
-		readBeforeWrite && !effectsCommute(getEffects(writable), effects)
-			? prereqs.pushToVar(writable, "readable")
-			: writable;
-	prereqs.pushList(valuePrereqs.statements);
-
-	return { writable, readable, value };
 }

--- a/src/TSTransformer/nodes/transformWritable.ts
+++ b/src/TSTransformer/nodes/transformWritable.ts
@@ -8,7 +8,14 @@ import { transformExpression } from "TSTransformer/nodes/expressions/transformEx
 import { addOneIfArrayType } from "TSTransformer/util/addOneIfArrayType";
 import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexableExpression";
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
-import { effectsCommute, getEffects, isLateRead, joinEffects, NO_EFFECTS } from "TSTransformer/util/evaluation/effects";
+import {
+	effectsCommute,
+	EvaluationEffects,
+	getEffects,
+	isLateRead,
+	joinEffects,
+	NO_EFFECTS,
+} from "TSTransformer/util/evaluation/effects";
 import { skipDownwards } from "TSTransformer/util/traversal";
 import ts from "typescript";
 
@@ -46,25 +53,16 @@ export function transformWritableExpression(
 	}
 }
 
-export function transformWritableAssignment(
-	state: TransformState,
+export function captureWritableAssignmentTarget(
 	prereqs: Prereqs,
-	writeNode: ts.Expression,
-	valueNode: ts.Expression,
-	readAfterWrite = false,
-	readBeforeWrite = false,
+	writable: luau.WritableExpression,
+	prereqEffects: EvaluationEffects,
+	valueEffects: EvaluationEffects,
 ) {
-	let writable = transformWritableExpression(state, prereqs, writeNode, readAfterWrite);
-	const valuePrereqs = new Prereqs();
-	const value = transformExpression(state, valuePrereqs, valueNode);
-	const prereqEffects = getEffects(valuePrereqs.statements);
-	const valueEffects = getEffects(value);
-	const effects = joinEffects(prereqEffects, valueEffects);
 	// Luau evaluates complex bases and keys before an inline RHS, but can read
-	// locals at the store instruction. Hoisted prerequisites precede both.
+	// locals at the store instruction; hoisted prerequisites precede both
 	const intervening = (expression: luau.Expression) =>
 		joinEffects(prereqEffects, isLateRead(expression) ? valueEffects : NO_EFFECTS);
-	// the assignment target and its old value may need separate snapshots
 	if (!luau.isAnyIdentifier(writable)) {
 		const base = writable.expression;
 		const index = luau.isComputedIndexExpression(writable) ? writable.index : undefined;
@@ -80,6 +78,25 @@ export function transformWritableAssignment(
 			writable = luau.property(stableBase, writable.name);
 		}
 	}
+	return writable;
+}
+
+export function transformWritableAssignment(
+	state: TransformState,
+	prereqs: Prereqs,
+	writeNode: ts.Expression,
+	valueNode: ts.Expression,
+	readAfterWrite = false,
+	readBeforeWrite = false,
+) {
+	let writable = transformWritableExpression(state, prereqs, writeNode, readAfterWrite);
+	const valuePrereqs = new Prereqs();
+	const value = transformExpression(state, valuePrereqs, valueNode);
+	const prereqEffects = getEffects(valuePrereqs.statements);
+	const valueEffects = getEffects(value);
+	const effects = joinEffects(prereqEffects, valueEffects);
+	writable = captureWritableAssignmentTarget(prereqs, writable, prereqEffects, valueEffects);
+	// the assignment target and its old value may need separate snapshots
 	const readable =
 		readBeforeWrite && !effectsCommute(getEffects(writable), effects)
 			? prereqs.pushToVar(writable, "readable")

--- a/src/TSTransformer/util/assertNever.ts
+++ b/src/TSTransformer/util/assertNever.ts
@@ -6,17 +6,17 @@ import ts from "typescript";
 import util from "util";
 
 type LsInfo = {
-	name: string;
-	version: string;
-	dependencies: Record<string, LsInfo>;
+	name?: string;
+	version?: string;
+	dependencies?: Record<string, LsInfo>;
 };
 
-function findTypescriptVersion(info: LsInfo): string | undefined {
-	if (info.name === "roblox-ts" && info.dependencies.typescript) {
+function findTypescriptVersion(info: LsInfo, name = info.name): string | undefined {
+	if (name === "roblox-ts" && info.dependencies?.typescript) {
 		return info.dependencies.typescript.version;
 	}
-	for (const [, dep] of Object.entries(info.dependencies)) {
-		const found = findTypescriptVersion(dep);
+	for (const [name, dep] of Object.entries(info.dependencies ?? {})) {
+		const found = findTypescriptVersion(dep, name);
 		if (found) {
 			return found;
 		}
@@ -24,10 +24,19 @@ function findTypescriptVersion(info: LsInfo): string | undefined {
 }
 
 function error(message: string): never {
-	/* istanbul ignore */
-	const typescriptVersion = findTypescriptVersion(
-		JSON.parse(spawnSync("npm ls typescript --json").stdout.toString()) as LsInfo,
-	);
+	let typescriptVersion: string | undefined;
+	try {
+		const result = spawnSync("npm", ["ls", "typescript", "--json"], {
+			encoding: "utf8",
+			shell: process.platform === "win32",
+		});
+		if (result.stdout) {
+			typescriptVersion = findTypescriptVersion(JSON.parse(result.stdout) as LsInfo);
+		}
+	} catch {
+		// failure to obtain installation advice must not hide the original assertion
+	}
+
 	LogService.fatal(
 		kleur.red(`Exhaustive assertion failed! ${message}`) +
 			kleur.yellow("\nThis is usually caused by a TypeScript version mismatch.") +
@@ -43,8 +52,8 @@ function error(message: string): never {
  * @param message The message of the error
  */
 export function assertNever(value: never, message: string): never {
-	/* istanbul ignore next */
-	const isTsNode = typeof value === "object" && "kind" in value && ts.isNodeKind((value as ts.Node).kind);
+	const isTsNode =
+		value !== null && typeof value === "object" && "kind" in value && ts.isNodeKind((value as ts.Node).kind);
 	error(
 		`${message}, value was ${isTsNode ? `a TS node of kind ${getKindName((value as ts.Node).kind)}` : util.inspect(value)}`,
 	);

--- a/src/TSTransformer/util/binding/getAccessorForBindingType.ts
+++ b/src/TSTransformer/util/binding/getAccessorForBindingType.ts
@@ -123,6 +123,64 @@ const iterableFunctionAccessor: BindingAccessor = (prereqs, parentId, index, idS
 	}
 };
 
+function createExhaustibleIterableFunctionAccessor(isTuple: boolean): BindingAccessor {
+	return (prereqs, parentId, index, idStack, isOmitted) => {
+		const previousDoneId = idStack[0];
+		const stepPrereqs = new Prereqs();
+		let value: luau.Expression = luau.call(parentId);
+		let valueId: luau.TemporaryIdentifier | undefined;
+		if (!isOmitted) {
+			valueId = luau.tempId("value");
+			const right = isTuple ? luau.array([value]) : value;
+			if (previousDoneId) {
+				prereqs.push(luau.create(luau.SyntaxKind.VariableDeclaration, { left: valueId, right: undefined }));
+				stepPrereqs.push(luau.create(luau.SyntaxKind.Assignment, { left: valueId, operator: "=", right }));
+			} else {
+				stepPrereqs.push(luau.create(luau.SyntaxKind.VariableDeclaration, { left: valueId, right }));
+			}
+			value = isTuple
+				? luau.create(luau.SyntaxKind.ComputedIndexExpression, { expression: valueId, index: luau.number(1) })
+				: valueId;
+		}
+
+		const isDone = luau.binary(value, "==", luau.nil());
+		let doneId = previousDoneId;
+		if (doneId) {
+			stepPrereqs.push(luau.create(luau.SyntaxKind.Assignment, { left: doneId, operator: "=", right: isDone }));
+		} else {
+			doneId = stepPrereqs.pushToVar(isDone, "done");
+			// the rest collector shares this state with named and omitted prefix elements
+			idStack.push(doneId);
+		}
+
+		if (isTuple && valueId) {
+			// trailing returns do not produce a tuple after the first return ends iteration
+			stepPrereqs.push(
+				luau.create(luau.SyntaxKind.IfStatement, {
+					condition: doneId,
+					statements: luau.list.make(
+						luau.create(luau.SyntaxKind.Assignment, { left: valueId, operator: "=", right: luau.nil() }),
+					),
+					elseBody: luau.list.make(),
+				}),
+			);
+		}
+
+		if (previousDoneId) {
+			prereqs.push(
+				luau.create(luau.SyntaxKind.IfStatement, {
+					condition: luau.unary("not", previousDoneId),
+					statements: stepPrereqs.statements,
+					elseBody: luau.list.make(),
+				}),
+			);
+		} else {
+			prereqs.pushList(stepPrereqs.statements);
+		}
+		return valueId ?? luau.none();
+	};
+}
+
 const iterAccessor: BindingAccessor = (prereqs, parentId, index, idStack, isOmitted) => {
 	const callExp = luau.call(luau.property(parentId, "next"));
 	if (isOmitted) {
@@ -133,7 +191,12 @@ const iterAccessor: BindingAccessor = (prereqs, parentId, index, idStack, isOmit
 	}
 };
 
-export function getAccessorForBindingType(state: TransformState, node: ts.Node, type: ts.Type): BindingAccessor {
+export function getAccessorForBindingType(
+	state: TransformState,
+	node: ts.Node,
+	type: ts.Type,
+	hasRest: boolean,
+): BindingAccessor {
 	if (isDefinitelyType(type, isArrayType(state))) {
 		return arrayAccessor;
 	} else if (isDefinitelyType(type, isStringType)) {
@@ -143,9 +206,9 @@ export function getAccessorForBindingType(state: TransformState, node: ts.Node, 
 	} else if (isDefinitelyType(type, isMapType(state)) || isDefinitelyType(type, isSharedTableType(state))) {
 		return mapAccessor;
 	} else if (isDefinitelyType(type, isIterableFunctionLuaTupleType(state))) {
-		return iterableFunctionLuaTupleAccessor;
+		return hasRest ? createExhaustibleIterableFunctionAccessor(true) : iterableFunctionLuaTupleAccessor;
 	} else if (isDefinitelyType(type, isIterableFunctionType(state))) {
-		return iterableFunctionAccessor;
+		return hasRest ? createExhaustibleIterableFunctionAccessor(false) : iterableFunctionAccessor;
 	} else if (isDefinitelyType(type, isIterableType(state))) {
 		DiagnosticService.addDiagnostic(errors.noIterableIteration(node));
 		return () => luau.none();

--- a/src/TSTransformer/util/binding/getTargetIdForBindingPattern.ts
+++ b/src/TSTransformer/util/binding/getTargetIdForBindingPattern.ts
@@ -2,13 +2,21 @@ import luau from "@roblox-ts/luau-ast";
 import { Prereqs } from "TSTransformer/classes/Prereqs";
 import ts from "typescript";
 
+function bindingPatternContainsInitializers(name: ts.BindingPattern): boolean {
+	return name.elements.some(
+		element =>
+			!ts.isOmittedExpression(element) &&
+			(element.initializer !== undefined ||
+				(!ts.isIdentifier(element.name) && bindingPatternContainsInitializers(element.name))),
+	);
+}
+
 /**
  * Checks to see if the binding contains initializers and returns a new temporary identifier,
  * since they could mutate the binding variable.
  */
 export function getTargetIdForBindingPattern(prereqs: Prereqs, name: ts.BindingPattern, value: luau.Expression) {
-	return luau.isAnyIdentifier(value) &&
-		name.elements.every(element => ts.isOmittedExpression(element) || !element.initializer)
+	return luau.isAnyIdentifier(value) && !bindingPatternContainsInitializers(name)
 		? value
 		: prereqs.pushToVar(value, "binding");
 }

--- a/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
+++ b/src/TSTransformer/util/getAddIterableToArrayBuilder.ts
@@ -198,7 +198,15 @@ const addIterableFunctionLuaTuple: AddIterableToArrayBuilder = (
 					right: luau.array([luau.call(iterFuncId)]),
 				}),
 				luau.create(luau.SyntaxKind.IfStatement, {
-					condition: luau.binary(luau.unary("#", valueId), "==", luau.number(0)),
+					// later return values do not keep an iterator alive after its first return is nil
+					condition: luau.binary(
+						luau.create(luau.SyntaxKind.ComputedIndexExpression, {
+							expression: valueId,
+							index: luau.number(1),
+						}),
+						"==",
+						luau.nil(),
+					),
 					statements: luau.list.make(luau.create(luau.SyntaxKind.BreakStatement, {})),
 					elseBody: luau.list.make(),
 				}),

--- a/src/TSTransformer/util/getKindName.ts
+++ b/src/TSTransformer/util/getKindName.ts
@@ -23,8 +23,8 @@ export function getKindName(kind: ts.SyntaxKind) {
 	if (kind === ts.SyntaxKind.FirstNode) return "QualifiedName";
 	if (kind === ts.SyntaxKind.FirstJSDocNode) return "JSDocTypeExpression";
 	if (kind === ts.SyntaxKind.FirstJSDocTagNode) return "JSDocTag";
-	if (kind === ts.SyntaxKind.LastJSDocTagNode) return "JSDocPropertyTag";
+	if (kind === ts.SyntaxKind.LastJSDocTagNode) return "JSDocImportTag";
 	if (kind === ts.SyntaxKind.FirstContextualKeyword) return "AbstractKeyword";
-	if (kind === ts.SyntaxKind.LastContextualKeyword) return "OfKeyword";
+	if (kind === ts.SyntaxKind.LastContextualKeyword) return "DeferKeyword";
 	return ts.SyntaxKind[kind];
 }

--- a/src/TSTransformer/util/spreadDestructuring/index.ts
+++ b/src/TSTransformer/util/spreadDestructuring/index.ts
@@ -1,7 +1,9 @@
 import luau from "@roblox-ts/luau-ast";
-import { assert } from "Shared/util/assert";
+import { errors } from "Shared/diagnostics";
+import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { TransformState } from "TSTransformer/classes/TransformState";
+import { getAddIterableToArrayBuilder } from "TSTransformer/util/getAddIterableToArrayBuilder";
 import { spreadDestructureArray } from "TSTransformer/util/spreadDestructuring/spreadDestructureArray";
 import { spreadDestructureGenerator } from "TSTransformer/util/spreadDestructuring/spreadDestructureGenerator";
 import { spreadDestructureMap } from "TSTransformer/util/spreadDestructuring/spreadDestructureMap";
@@ -11,6 +13,8 @@ import {
 	isArrayType,
 	isDefinitelyType,
 	isGeneratorType,
+	isIterableFunctionType,
+	isIterableType,
 	isMapType,
 	isSetType,
 	isStringType,
@@ -42,7 +46,21 @@ export function getSpreadDestructorForType(state: TransformState, node: ts.Node,
 		return spreadDestructureString;
 	}
 
-	return () => {
-		assert(false, "Spread Destructuring not supported for type: " + state.typeChecker.typeToString(type));
+	return (prereqs, parentId) => {
+		if (!isDefinitelyType(type, isIterableFunctionType(state))) {
+			DiagnosticService.addDiagnostic(
+				isDefinitelyType(type, isIterableType(state))
+					? errors.noIterableIteration(node)
+					: errors.noUnsupportedIteration(node),
+			);
+			return luau.none();
+		}
+
+		// iterator functions retain the position advanced by preceding bindings
+		const restId = prereqs.pushToVar(luau.array(), "rest");
+		const lengthId = prereqs.pushToVar(luau.number(0), "length");
+		const addIterable = getAddIterableToArrayBuilder(state, node, type);
+		prereqs.pushList(addIterable(prereqs, parentId, restId, lengthId, 0, false));
+		return restId;
 	};
 }

--- a/src/TSTransformer/util/spreadDestructuring/index.ts
+++ b/src/TSTransformer/util/spreadDestructuring/index.ts
@@ -46,7 +46,7 @@ export function getSpreadDestructorForType(state: TransformState, node: ts.Node,
 		return spreadDestructureString;
 	}
 
-	return (prereqs, parentId) => {
+	return (prereqs, parentId, index, idStack) => {
 		if (!isDefinitelyType(type, isIterableFunctionType(state))) {
 			DiagnosticService.addDiagnostic(
 				isDefinitelyType(type, isIterableType(state))
@@ -58,9 +58,23 @@ export function getSpreadDestructorForType(state: TransformState, node: ts.Node,
 
 		// iterator functions retain the position advanced by preceding bindings
 		const restId = prereqs.pushToVar(luau.array(), "rest");
-		const lengthId = prereqs.pushToVar(luau.number(0), "length");
+		const restPrereqs = new Prereqs();
+		const lengthId = restPrereqs.pushToVar(luau.number(0), "length");
 		const addIterable = getAddIterableToArrayBuilder(state, node, type);
-		prereqs.pushList(addIterable(prereqs, parentId, restId, lengthId, 0, false));
+		restPrereqs.pushList(addIterable(restPrereqs, parentId, restId, lengthId, 0, false));
+
+		const doneId = idStack[0];
+		if (doneId) {
+			prereqs.push(
+				luau.create(luau.SyntaxKind.IfStatement, {
+					condition: luau.unary("not", doneId),
+					statements: restPrereqs.statements,
+					elseBody: luau.list.make(),
+				}),
+			);
+		} else {
+			prereqs.pushList(restPrereqs.statements);
+		}
 		return restId;
 	};
 }

--- a/tests/compiler/__snapshots__/callbacksVsMethods.test.ts.snap
+++ b/tests/compiler/__snapshots__/callbacksVsMethods.test.ts.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`class declarations honor explicit receivers 1`] = `
+"local Example
+do
+	Example = setmetatable({}, {
+		__tostring = function()
+			return "Example"
+		end,
+	})
+	Example.__index = Example
+	function Example.new(...)
+		local self = setmetatable({}, Example)
+		return self:constructor(...) or self
+	end
+	function Example:constructor()
+		self.value = 10
+	end
+	function Example.callback(value)
+		return value
+	end
+	function Example:method(value)
+		return self.value + value
+	end
+	function Example.staticCallback(value)
+		return value
+	end
+	function Example:staticMethod(value)
+		return self.staticCallback(value)
+	end
+end
+local object = Example.new()
+object.callback(123)
+object:method(123)
+Example.staticCallback(123)
+Example:staticMethod(123)
+return nil
+"
+`;
+
+exports[`documented non-void this overrides a callback signature 1`] = `
+"object:foo(123)
+return nil
+"
+`;
+
+exports[`documented void this overrides a method declaration 1`] = `
+"local object = {
+	foo = function(value)
+		return value
+	end,
+}
+object.foo(123)
+return nil
+"
+`;
+
+exports[`function declarations and expressions honor explicit receivers 1`] = `
+"local function callback(value)
+	return value
+end
+local function method(self, value)
+	return self.value + value
+end
+local callbackExpression = function(value)
+	return value
+end
+local methodExpression = function(self, value)
+	return self.value + value
+end
+local object = {
+	value = 10,
+	callback = callback,
+	method = method,
+	callbackExpression = callbackExpression,
+	methodExpression = methodExpression,
+}
+object.callback(123)
+object:method(123)
+object.callbackExpression(123)
+object:methodExpression(123)
+return nil
+"
+`;
+
+exports[`instantiated interface signatures honor explicit receivers 1`] = `
+"numbers.callback(123)
+numbers:method(123)
+strings.callback("value")
+strings:method("value")
+return nil
+"
+`;
+
+exports[`object literal declarations and expressions honor explicit receivers 1`] = `
+"local object = {
+	value = 10,
+	callback = function(value)
+		return value
+	end,
+	method = function(self, value)
+		return self.value + value
+	end,
+	callbackExpression = function(value)
+		return value
+	end,
+	methodExpression = function(self, value)
+		return self.value + value
+	end,
+}
+object.callback(123)
+object:method(123)
+object.callbackExpression(123)
+object:methodExpression(123)
+return nil
+"
+`;
+
+exports[`optional and indexed calls honor explicit receivers 1`] = `
+"object[callbackKey](123)
+object[methodKey](object, 123)
+local _result = optional
+if _result ~= nil then
+	_result.callback(123)
+end
+local _result_1 = optional
+if _result_1 ~= nil then
+	_result_1:method(123)
+end
+return nil
+"
+`;

--- a/tests/compiler/__snapshots__/emit.test.ts.snap
+++ b/tests/compiler/__snapshots__/emit.test.ts.snap
@@ -7,3 +7,13 @@ return {
 }
 "
 `;
+
+exports[`places Luau directives before the compiler header 1`] = `
+"--!strict
+--!native
+local value = 1
+return {
+	value = value,
+}
+"
+`;

--- a/tests/compiler/__snapshots__/imports.test.ts.snap
+++ b/tests/compiler/__snapshots__/imports.test.ts.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`elides type-only CommonJS imports (verbatimModuleSyntax: false) 1`] = `
+"local value = {
+	value = 42,
+}
+print(value.value)
+return nil
+"
+`;
+
+exports[`elides type-only CommonJS imports (verbatimModuleSyntax: true) 1`] = `
+"local value = {
+	value = 42,
+}
+print(value.value)
+return nil
+"
+`;
+
 exports[`imports a local module in VirtualProject without project references 1`] = `
 "local TS = _G[script]
 local value = TS.import(script, script.Parent, "value").value
@@ -7,5 +25,52 @@ local result = value
 return {
 	result = result,
 }
+"
+`;
+
+exports[`imports a package described by an ambient module declaration 1`] = `
+"local TS = _G[script]
+local value = TS.import(script, script.Parent, "include", "node_modules", "@rbxts", "example").value
+return {
+	value = value,
+}
+"
+`;
+
+exports[`imports a scoped dependency from a package 1`] = `
+"local TS = _G[script]
+local value = TS.import(script, TS.getModule(script, "@rbxts", "example")).value
+local result = value
+return {
+	result = result,
+}
+"
+`;
+
+exports[`preserves unmarked import-equals side effects with noCheck (verbatimModuleSyntax: false) 1`] = `
+"local value = {
+	value = 42,
+}
+print(value.value)
+return nil
+"
+`;
+
+exports[`preserves unmarked import-equals side effects with noCheck (verbatimModuleSyntax: true) 1`] = `
+"local TS = require(game:GetService("ReplicatedStorage"):WaitForChild("include"):WaitForChild("RuntimeLib"))
+TS.import(script, game:GetService("ReplicatedStorage"), "game", "shape")
+local value = {
+	value = 42,
+}
+print(value.value)
+return nil
+"
+`;
+
+exports[`uses relative imports within an isolated game container 1`] = `
+"local TS = require(game:GetService("ReplicatedStorage"):WaitForChild("include"):WaitForChild("RuntimeLib"))
+local value = TS.import(script, script, "value").value
+print(value)
+return nil
 "
 `;

--- a/tests/compiler/__snapshots__/loopOptimization.test.ts.snap
+++ b/tests/compiler/__snapshots__/loopOptimization.test.ts.snap
@@ -236,6 +236,21 @@ return nil
 "
 `;
 
+exports[`fallback tuple iterator assignment target 1`] = `
+"local pair
+local _iterator = iterator
+while true do
+	local _v = { _iterator() }
+	if _v[1] == nil then
+		break
+	end
+	pair = _v
+	print(pair[2])
+end
+return nil
+"
+`;
+
 exports[`fallback unsafe integer bound 1`] = `
 "do
 	local i = 0

--- a/tests/compiler/callbacksVsMethods.test.ts
+++ b/tests/compiler/callbacksVsMethods.test.ts
@@ -1,0 +1,108 @@
+import { createTestProject } from "./createTestProject";
+
+// keep tests alphabetized by name to match Jest's snapshot ordering
+it.each([
+	{
+		name: "class declarations honor explicit receivers",
+		source: `
+			class Example {
+				value = 10;
+				callback(this: void, value: number) { return value; }
+				method(this: Example, value: number) { return this.value + value; }
+				static staticCallback(this: void, value: number) { return value; }
+				static staticMethod(this: typeof Example, value: number) { return this.staticCallback(value); }
+			}
+			const object = new Example();
+			object.callback(123);
+			object.method(123);
+			Example.staticCallback(123);
+			Example.staticMethod(123);
+		`,
+	},
+	{
+		name: "documented non-void this overrides a callback signature",
+		source: `
+			declare const object: {
+				foo: (this: typeof object, value: number) => void;
+			};
+			object.foo(123);
+		`,
+	},
+	{
+		name: "documented void this overrides a method declaration",
+		source: `
+			const object = {
+				foo(this: void, value: number) { return value; },
+			};
+			object.foo(123);
+		`,
+	},
+	{
+		name: "function declarations and expressions honor explicit receivers",
+		source: `
+			type Receiver = { value: number };
+			function callback(this: void, value: number) { return value; }
+			function method(this: Receiver, value: number) { return this.value + value; }
+			const callbackExpression = function(this: void, value: number) { return value; };
+			const methodExpression = function(this: Receiver, value: number) { return this.value + value; };
+			const object = { value: 10, callback, method, callbackExpression, methodExpression };
+			object.callback(123);
+			object.method(123);
+			object.callbackExpression(123);
+			object.methodExpression(123);
+		`,
+	},
+	{
+		name: "instantiated interface signatures honor explicit receivers",
+		source: `
+			interface API<T> {
+				callback(this: void, value: T): T;
+				method: (this: API<T>, value: T) => T;
+			}
+			declare const numbers: API<number>;
+			declare const strings: API<string>;
+			numbers.callback(123);
+			numbers.method(123);
+			strings.callback("value");
+			strings.method("value");
+		`,
+	},
+	{
+		name: "object literal declarations and expressions honor explicit receivers",
+		source: `
+			type Receiver = { value: number };
+			const object = {
+				value: 10,
+				callback(this: void, value: number) { return value; },
+				method(this: Receiver, value: number) { return this.value + value; },
+				callbackExpression: function(this: void, value: number) { return value; },
+				methodExpression: function(this: Receiver, value: number) { return this.value + value; },
+			};
+			object.callback(123);
+			object.method(123);
+			object.callbackExpression(123);
+			object.methodExpression(123);
+		`,
+	},
+	{
+		name: "optional and indexed calls honor explicit receivers",
+		source: `
+			interface API {
+				callback(this: void, value: number): void;
+				method: (this: API, value: number) => void;
+			}
+			declare const object: API;
+			declare const optional: API | undefined;
+			declare const callbackKey: "callback";
+			declare const methodKey: "method";
+			object[callbackKey](123);
+			object[methodKey](123);
+			optional?.callback(123);
+			optional?.method(123);
+		`,
+	},
+])("$name", ({ source }) => {
+	const project = createTestProject();
+	const output = project.compileSource(source);
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});

--- a/tests/compiler/destructuring/__snapshots__/rest.test.ts.snap
+++ b/tests/compiler/destructuring/__snapshots__/rest.test.ts.snap
@@ -2,7 +2,12 @@
 
 exports[`captures iterators before nested defaults can reassign them 1`] = `
 "local _binding = iterator
-local _binding_1 = { _binding() }
+local _value = { _binding() }
+local _done = _value[1] == nil
+if _done then
+	_value = nil
+end
+local _binding_1 = _value
 local first = _binding_1[1]
 local value = _binding_1[2]
 if value == nil then
@@ -10,17 +15,27 @@ if value == nil then
 	local _ = iterator
 	value = 99
 end
-local second = { _binding() }
-local _rest = {}
-local _length = 0
-local _iterFunc = _binding
-while true do
-	local _results = { _iterFunc() }
-	if _results[1] == nil then
-		break
+local _value_1
+if not _done then
+	_value_1 = { _binding() }
+	_done = _value_1[1] == nil
+	if _done then
+		_value_1 = nil
 	end
-	_length += 1
-	_rest[_length] = _results
+end
+local second = _value_1
+local _rest = {}
+if not _done then
+	local _length = 0
+	local _iterFunc = _binding
+	while true do
+		local _results = { _iterFunc() }
+		if _results[1] == nil then
+			break
+		end
+		_length += 1
+		_rest[_length] = _results
+	end
 end
 local rest = _rest
 print(first, value, second, rest)
@@ -39,13 +54,22 @@ iterator = (function()
 	return if calls <= 3 then calls else nil
 end)
 local _iterator = iterator
-local first = _iterator()
-local second = _iterator()
+local _value = _iterator()
+local _done = _value == nil
+local first = _value
+local _value_1
+if not _done then
+	_value_1 = _iterator()
+	_done = _value_1 == nil
+end
+local second = _value_1
 local _rest = {}
-local _length = 0
-for _result in _iterator do
-	_length += 1
-	_rest[_length] = _result
+if not _done then
+	local _length = 0
+	for _result in _iterator do
+		_length += 1
+		_rest[_length] = _result
+	end
 end
 local rest = _rest
 print(first, second, rest)
@@ -89,18 +113,27 @@ return nil
 `;
 
 exports[`collects iterator rest bindings with fixed tuples after preceding elements 1`] = `
-"local first = { iterator() }
-iterator()
+"local _value = { iterator() }
+local _done = _value[1] == nil
+if _done then
+	_value = nil
+end
+local first = _value
+if not _done then
+	_done = iterator() == nil
+end
 local _rest = {}
-local _length = 0
-local _iterFunc = iterator
-while true do
-	local _results = { _iterFunc() }
-	if _results[1] == nil then
-		break
+if not _done then
+	local _length = 0
+	local _iterFunc = iterator
+	while true do
+		local _results = { _iterFunc() }
+		if _results[1] == nil then
+			break
+		end
+		_length += 1
+		_rest[_length] = _results
 	end
-	_length += 1
-	_rest[_length] = _results
 end
 local rest = _rest
 return {
@@ -111,13 +144,19 @@ return {
 `;
 
 exports[`collects iterator rest bindings with single values after preceding elements 1`] = `
-"local first = iterator()
-iterator()
+"local _value = iterator()
+local _done = _value == nil
+local first = _value
+if not _done then
+	_done = iterator() == nil
+end
 local _rest = {}
-local _length = 0
-for _result in iterator do
-	_length += 1
-	_rest[_length] = _result
+if not _done then
+	local _length = 0
+	for _result in iterator do
+		_length += 1
+		_rest[_length] = _result
+	end
 end
 local rest = _rest
 return {
@@ -128,23 +167,92 @@ return {
 `;
 
 exports[`collects iterator rest bindings with variadic tuples after preceding elements 1`] = `
-"local first = { iterator() }
-iterator()
+"local _value = { iterator() }
+local _done = _value[1] == nil
+if _done then
+	_value = nil
+end
+local first = _value
+if not _done then
+	_done = iterator() == nil
+end
 local _rest = {}
-local _length = 0
-local _iterFunc = iterator
-while true do
-	local _results = { _iterFunc() }
-	if _results[1] == nil then
-		break
+if not _done then
+	local _length = 0
+	local _iterFunc = iterator
+	while true do
+		local _results = { _iterFunc() }
+		if _results[1] == nil then
+			break
+		end
+		_length += 1
+		_rest[_length] = _results
 	end
-	_length += 1
-	_rest[_length] = _results
 end
 local rest = _rest
 return {
 	first = first,
 	rest = rest,
 }
+"
+`;
+
+exports[`guards iterator assignment targets after exhaustion (LuaTuple<[number, string]>) 1`] = `
+"local _binding = iterator
+local _exp = target()
+local _value = { _binding() }
+local _done = _value[1] == nil
+if _done then
+	_value = nil
+end
+_exp.value = _value
+if _exp.value == nil then
+	_exp.value = { fallback() }
+end
+if not _done then
+	_done = _binding() == nil
+end
+local _exp_1 = target()
+local _rest = {}
+if not _done then
+	local _length = 0
+	local _iterFunc = _binding
+	while true do
+		local _results = { _iterFunc() }
+		if _results[1] == nil then
+			break
+		end
+		_length += 1
+		_rest[_length] = _results
+	end
+end
+_exp_1.rest = _rest
+return nil
+"
+`;
+
+exports[`guards iterator assignment targets after exhaustion (number) 1`] = `
+"local _binding = iterator
+local _exp = target()
+local _value = _binding()
+local _done = _value == nil
+_exp.value = _value
+if _exp.value == nil then
+	_exp.value = fallback()
+end
+if not _done then
+	_done = _binding() == nil
+end
+local _exp_1 = target()
+local _rest = {}
+if not _done then
+	local _length = 0
+	for _result in _binding do
+		_length += 1
+		_rest[_length] = _result
+	end
+end
+_exp_1.rest = _rest
+return nil
 "
 `;

--- a/tests/compiler/destructuring/__snapshots__/rest.test.ts.snap
+++ b/tests/compiler/destructuring/__snapshots__/rest.test.ts.snap
@@ -1,0 +1,150 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`captures iterators before nested defaults can reassign them 1`] = `
+"local _binding = iterator
+local _binding_1 = { _binding() }
+local first = _binding_1[1]
+local value = _binding_1[2]
+if value == nil then
+	iterator = replacement
+	local _ = iterator
+	value = 99
+end
+local second = { _binding() }
+local _rest = {}
+local _length = 0
+local _iterFunc = _binding
+while true do
+	local _results = { _iterFunc() }
+	if _results[1] == nil then
+		break
+	end
+	_length += 1
+	_rest[_length] = _results
+end
+local rest = _rest
+print(first, value, second, rest)
+return nil
+"
+`;
+
+exports[`captures reassignable iterators before preceding bindings 1`] = `
+"local calls = 0
+local iterator
+iterator = (function()
+	calls += 1
+	iterator = (function()
+		error("replacement iterator")
+	end)
+	return if calls <= 3 then calls else nil
+end)
+local _iterator = iterator
+local first = _iterator()
+local second = _iterator()
+local _rest = {}
+local _length = 0
+for _result in _iterator do
+	_length += 1
+	_rest[_length] = _result
+end
+local rest = _rest
+print(first, second, rest)
+return nil
+"
+`;
+
+exports[`captures rest assignment targets before collecting LuaTuple<[number, string]> iterators 1`] = `
+"local _binding = iterator
+local _exp = target()
+local _index = key() + 1
+local _rest = {}
+local _length = 0
+local _iterFunc = _binding
+while true do
+	local _results = { _iterFunc() }
+	if _results[1] == nil then
+		break
+	end
+	_length += 1
+	_rest[_length] = _results
+end
+_exp[_index] = _rest
+return nil
+"
+`;
+
+exports[`captures rest assignment targets before collecting number iterators 1`] = `
+"local _binding = iterator
+local _exp = target()
+local _index = key() + 1
+local _rest = {}
+local _length = 0
+for _result in _binding do
+	_length += 1
+	_rest[_length] = _result
+end
+_exp[_index] = _rest
+return nil
+"
+`;
+
+exports[`collects iterator rest bindings with fixed tuples after preceding elements 1`] = `
+"local first = { iterator() }
+iterator()
+local _rest = {}
+local _length = 0
+local _iterFunc = iterator
+while true do
+	local _results = { _iterFunc() }
+	if _results[1] == nil then
+		break
+	end
+	_length += 1
+	_rest[_length] = _results
+end
+local rest = _rest
+return {
+	first = first,
+	rest = rest,
+}
+"
+`;
+
+exports[`collects iterator rest bindings with single values after preceding elements 1`] = `
+"local first = iterator()
+iterator()
+local _rest = {}
+local _length = 0
+for _result in iterator do
+	_length += 1
+	_rest[_length] = _result
+end
+local rest = _rest
+return {
+	first = first,
+	rest = rest,
+}
+"
+`;
+
+exports[`collects iterator rest bindings with variadic tuples after preceding elements 1`] = `
+"local first = { iterator() }
+iterator()
+local _rest = {}
+local _length = 0
+local _iterFunc = iterator
+while true do
+	local _results = { _iterFunc() }
+	if _results[1] == nil then
+		break
+	end
+	_length += 1
+	_rest[_length] = _results
+end
+local rest = _rest
+return {
+	first = first,
+	rest = rest,
+}
+"
+`;

--- a/tests/compiler/destructuring/rest.test.ts
+++ b/tests/compiler/destructuring/rest.test.ts
@@ -54,3 +54,14 @@ it.each([
 
 	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
 });
+
+it.each(["number", "LuaTuple<[number, string]>"])("guards iterator assignment targets after exhaustion (%s)", type => {
+	const output = createTestProject().compileSource(`
+			declare const iterator: IterableFunction<${type}>;
+			declare function target(): { value: ${type}; rest: Array<${type}> };
+			declare function fallback(): ${type};
+			[target().value = fallback(), , ...target().rest] = iterator;
+		`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});

--- a/tests/compiler/destructuring/rest.test.ts
+++ b/tests/compiler/destructuring/rest.test.ts
@@ -1,0 +1,56 @@
+import { createTestProject } from "../createTestProject";
+
+// keep tests alphabetized by name to match Jest's snapshot ordering
+it("captures iterators before nested defaults can reassign them", () => {
+	const output = createTestProject().compileSource(`
+		declare let iterator: IterableFunction<LuaTuple<[number, number?]>>;
+		declare const replacement: typeof iterator;
+		const [[first, value = (iterator = replacement, 99)], second, ...rest] = iterator;
+		print(first, value, second, rest);
+	`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it("captures reassignable iterators before preceding bindings", () => {
+	const output = createTestProject().compileSource(`
+		let calls = 0;
+		let iterator: IterableFunction<number>;
+		iterator = (() => {
+			calls++;
+			iterator = ((): number => { throw "replacement iterator"; }) as IterableFunction<number>;
+			return calls <= 3 ? calls : undefined;
+		}) as IterableFunction<number>;
+		const [first, second, ...rest] = iterator;
+		print(first, second, rest);
+	`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it.each(["number", "LuaTuple<[number, string]>"])(
+	"captures rest assignment targets before collecting %s iterators",
+	type => {
+		const output = createTestProject().compileSource(`
+			declare const iterator: IterableFunction<${type}>;
+			declare function target(): Array<Array<${type}>>;
+			declare function key(): number;
+			[...target()[key()]] = iterator;
+		`);
+
+		expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+	},
+);
+
+it.each([
+	["fixed tuples", "LuaTuple<[number, string]>"],
+	["single values", "number"],
+	["variadic tuples", "LuaTuple<Array<string>>"],
+])("collects iterator rest bindings with %s after preceding elements", (name, type) => {
+	const output = createTestProject().compileSource(`
+		declare const iterator: IterableFunction<${type}>;
+		export const [first, , ...rest] = iterator;
+	`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});

--- a/tests/compiler/emit.test.ts
+++ b/tests/compiler/emit.test.ts
@@ -1,8 +1,33 @@
 // keep tests alphabetized by name to match Jest's snapshot ordering
 import { createTestProject } from "./createTestProject";
+import { expectSuccess, ReferenceFixture } from "./referenceFixture";
 
 it("emits a module export", () => {
 	const project = createTestProject();
 	const output = project.compileSource('export const message = "hello";');
 	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it("places Luau directives before the compiler header", () => {
+	const project = createTestProject();
+	const output = project.compileSource("//!strict\n//!native\nexport const value = 1;");
+
+	expect(output.replace(/^-- Compiled with.*\n/m, "")).toMatchSnapshot();
+});
+
+it.each([false, true])("respects removeComments: %s for leading and trailing comments", removeComments => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game", [], { removeComments });
+		fixture.write("game/src/index.ts", "// before\nprint(1);\n// after\n");
+
+		expectSuccess(fixture.createBuild().build());
+
+		const output = fixture.read("out/game/init.luau");
+		expect(output.includes("-- before")).toBe(!removeComments);
+		expect(output.includes("-- after")).toBe(!removeComments);
+		expect(output).toContain("print(1)");
+	} finally {
+		fixture.close();
+	}
 });

--- a/tests/compiler/imports.test.ts
+++ b/tests/compiler/imports.test.ts
@@ -1,4 +1,56 @@
+import { ProjectType } from "Shared/constants";
+
 import { createTestProject } from "./createTestProject";
+import { expectSuccess, ReferenceFixture } from "./referenceFixture";
+
+it.each([false, true])("elides type-only CommonJS imports (verbatimModuleSyntax: %s)", verbatimModuleSyntax => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game", [], { verbatimModuleSyntax });
+		fixture.write("game/src/value.ts", "class Value { value = 0; } export = Value;");
+		fixture.write(
+			"game/src/index.ts",
+			'import type Value = require("./value"); const value: Value = { value: 42 }; print(value.value);',
+		);
+
+		expectSuccess(fixture.createBuild().build());
+
+		const output = fixture.read("out/game/init.luau");
+		expect(output).not.toContain("RuntimeLib");
+		expect(output).not.toContain("TS.import");
+		expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+	} finally {
+		fixture.close();
+	}
+});
+
+it.each(["export { Value };", "export default Value;", "export = Value;"])(
+	"elides type-only CommonJS imports re-exported with %s",
+	exportStatement => {
+		const project = createTestProject();
+		project.vfs.writeFile("/src/value.ts", "class Value { value = 0; } export = Value;");
+
+		const output = project.compileSource(`import type Value = require("./value"); ${exportStatement}`);
+
+		expect(output.replace(/^-- Compiled with.*\n/, "")).toBe("return nil\n");
+	},
+);
+
+it("elides type-only mutable exports without redirecting local reads or writes", () => {
+	const output = createTestProject().compileSource("let value = 1; export type { value }; value = 2; print(value);");
+
+	expect(output).not.toContain("exports");
+	expect(output).toContain("local value = 1");
+	expect(output).toContain("value = 2");
+});
+
+it("elides unused default bindings alongside used named imports", () => {
+	const project = createTestProject();
+	project.vfs.writeFile("/src/value.ts", "export default 1; export const named = 2;");
+	const output = project.compileSource('import unused, { named } from "./value"; print(named);');
+	expect(output).not.toContain("unused");
+	expect(output).toContain(".named");
+});
 
 it("imports a local module in VirtualProject without project references", () => {
 	const project = createTestProject();
@@ -7,4 +59,114 @@ it("imports a local module in VirtualProject without project references", () => 
 	const output = project.compileSource('import { value } from "./value"; export const result = value;');
 
 	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it("imports a package described by an ambient module declaration", () => {
+	const project = createTestProject();
+	project.vfs.writeFile("/src/ambient.d.ts", 'declare module "@rbxts/example" { export const value: number; }');
+	project.vfs.writeFile("/node_modules/@rbxts/example/index.d.ts", "export declare const value: number;");
+	project.setMapping("/node_modules/@rbxts/example/index.d.ts", "/node_modules/@rbxts/example/init.luau");
+
+	const output = project.compileSource('import { value } from "@rbxts/example"; export { value };');
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it("imports a scoped dependency from a package", () => {
+	const project = createTestProject({ type: ProjectType.Package });
+	project.vfs.writeFile("/node_modules/@rbxts/example/index.d.ts", "export declare const value: number;");
+	project.setMapping("/node_modules/@rbxts/example/index.d.ts", "/node_modules/@rbxts/example/init.luau");
+
+	const output = project.compileSource('import { value } from "@rbxts/example"; export const result = value;');
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it.each([false, true])(
+	"keeps explicit type-only export aliases erased (verbatimModuleSyntax: %s)",
+	verbatimModuleSyntax => {
+		const fixture = new ReferenceFixture();
+		try {
+			fixture.project("game", [], { verbatimModuleSyntax, noCheck: true });
+			fixture.write("game/src/value.ts", "class Value {} export = Value;");
+			fixture.write(
+				"game/src/index.ts",
+				'import type Value = require("./value"); export { Value }; let value = 1; export { value as live }; export type { value as hidden }; value = 2;',
+			);
+
+			expectSuccess(fixture.createBuild().build());
+			const output = fixture.read("out/game/init.luau");
+			expect(output).toContain("exports.live = 2");
+			expect(output).not.toContain("hidden");
+			expect(output.includes("exports.Value = Value")).toBe(verbatimModuleSyntax);
+		} finally {
+			fixture.close();
+		}
+	},
+);
+
+it.each([false, true])(
+	"preserves unmarked import-equals side effects with noCheck (verbatimModuleSyntax: %s)",
+	verbatimModuleSyntax => {
+		const fixture = new ReferenceFixture();
+		try {
+			fixture.project("game", [], { verbatimModuleSyntax, noCheck: true });
+			fixture.write(
+				"game/src/shape.ts",
+				'print("module side effect"); interface Shape { value: number; } export = Shape;',
+			);
+			fixture.write(
+				"game/src/index.ts",
+				'import Shape = require("./shape"); const value: Shape = { value: 42 }; print(value.value);',
+			);
+
+			expectSuccess(fixture.createBuild().build());
+
+			const output = fixture.read("out/game/init.luau");
+			expect(output.includes("TS.import")).toBe(verbatimModuleSyntax);
+			expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+		} finally {
+			fixture.close();
+		}
+	},
+);
+
+it("preserves verbatim import side effects and value re-exports with noCheck", () => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game", [], { verbatimModuleSyntax: true, noCheck: true });
+		fixture.write("game/src/value.ts", "export const value = 42; export type Shape = number;");
+		fixture.write("game/src/index.ts", 'import { type Shape } from "./value"; export { value } from "./value";');
+
+		expectSuccess(fixture.createBuild().build());
+		const output = fixture.read("out/game/init.luau");
+		expect(output.match(/TS\.import\(/g)).toHaveLength(2);
+		expect(output).toContain("exports.value = TS.import");
+		expect(output).not.toContain("Shape");
+	} finally {
+		fixture.close();
+	}
+});
+
+it("uses relative imports within an isolated game container", () => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game");
+		fixture.json("default.project.json", {
+			name: "isolated",
+			tree: {
+				$className: "DataModel",
+				ReplicatedStorage: { $className: "ReplicatedStorage", include: { $path: "include" } },
+				StarterGui: { $className: "StarterGui", game: { $path: "out/game" } },
+			},
+		});
+		fixture.write("game/src/value.ts", "export const value = 7;");
+		fixture.write("game/src/index.ts", 'import { value } from "./value"; print(value);');
+
+		expectSuccess(fixture.createBuild().build());
+
+		expect(fixture.read("out/game/init.luau").replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+	} finally {
+		fixture.close();
+	}
 });

--- a/tests/compiler/jsx/__snapshots__/text.test.ts.snap
+++ b/tests/compiler/jsx/__snapshots__/text.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`quotes decoded JSX text without changing backslashes or control characters 1`] = `
+"local value = React.createElement("text", nil, "\\"'\\\\path\\x001\\x09\\x0a\\x0d\\x7f\\x1f")
+return {
+	value = value,
+}
+"
+`;

--- a/tests/compiler/jsx/syntax.test.ts
+++ b/tests/compiler/jsx/syntax.test.ts
@@ -1,0 +1,17 @@
+import { DiagnosticError } from "Shared/errors/DiagnosticError";
+
+import { createTestProject } from "../createTestProject";
+
+it("rejects private JSX tag names during parsing even with semantic checks disabled", () => {
+	const project = createTestProject({ allowCommentDirectives: true });
+	try {
+		project.compileSource("// @ts-nocheck\nconst element = <Component.#value/>;");
+		throw new Error("Expected a JSX syntax diagnostic");
+	} catch (error) {
+		expect(error).toBeInstanceOf(DiagnosticError);
+		if (!(error instanceof DiagnosticError)) {
+			throw error;
+		}
+		expect(error.diagnostics.map(diagnostic => diagnostic.code)).toContain(1003);
+	}
+});

--- a/tests/compiler/jsx/text.test.ts
+++ b/tests/compiler/jsx/text.test.ts
@@ -1,0 +1,41 @@
+import { createTestProject } from "../createTestProject";
+import { expectSuccess, ReferenceFixture } from "../referenceFixture";
+
+it("quotes decoded JSX text without changing backslashes or control characters", () => {
+	const project = createTestProject();
+	const output = project.compileSource(String.raw`
+		declare namespace React {
+			function createElement(tag: string, props: unknown, ...children: Array<string>): string;
+			namespace JSX {
+				type Element = string;
+				interface IntrinsicElements { text: {} }
+			}
+		}
+		export const value = <text>&quot;&apos;\path&#0;1&#9;&#10;&#13;&#127;&#x1f;</text>;
+	`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it("uses the default fragment factory for an empty JSX fragment", () => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game", [], { jsx: "react" });
+		fixture.write(
+			"game/src/fragment.tsx",
+			`
+			declare namespace React {
+				function createElement(tag: unknown, props?: unknown): {};
+				namespace JSX { type Element = {}; }
+			}
+			declare const Fragment: unique symbol;
+			const element = <></>;
+			print(element);
+		`,
+		);
+		expectSuccess(fixture.createBuild().build());
+		expect(fixture.read("out/game/fragment.luau")).toContain("React.createElement(Fragment)");
+	} finally {
+		fixture.close();
+	}
+});

--- a/tests/compiler/loopOptimization.test.ts
+++ b/tests/compiler/loopOptimization.test.ts
@@ -36,6 +36,12 @@ describe("fallback", () => {
 		["multiplicative step", "for (let i = 1; i < 4; i *= 2) { print(i); }"],
 		["negated identifier bound", "const limit = 3; for (let i = 0; i > -limit; i--) { print(i); }"],
 		["nonmutating unary incrementor", "for (let i = 0; i < 3; -i) { print(i); break; }"],
+		[
+			"tuple iterator assignment target",
+			`declare const iterator: IterableFunction<LuaTuple<[number | undefined, number]>>;
+			let pair: LuaTuple<[number | undefined, number]>;
+			for (pair of iterator) { print(pair[1]); }`,
+		],
 		["unsafe integer bound", "for (let i = 0; i < 9007199254740992; i++) { print(i); break; }"],
 		["wrong step direction", "for (let i = 3; i < 0; i--) { print(i); }"],
 		["zero step", "for (let i = 0; i < 1; i += 0) { print(i); break; }"],

--- a/tests/compiler/moduleDiagnostics.test.ts
+++ b/tests/compiler/moduleDiagnostics.test.ts
@@ -1,10 +1,64 @@
 import fs from "fs-extra";
-import { errors, getDiagnosticId } from "Shared/diagnostics";
+import { ProjectType } from "Shared/constants";
+import { errors, getDiagnosticId, warnings } from "Shared/diagnostics";
 import { DiagnosticError } from "Shared/errors/DiagnosticError";
 import ts from "typescript";
 
 import { createTestProject } from "./createTestProject";
 import { expectSuccess, ReferenceFixture } from "./referenceFixture";
+
+it.each(['export * from "./missing";', 'export * as missing from "./missing";'])(
+	"reports an unresolved re-export with semantic checks disabled: %s",
+	source => {
+		const project = createTestProject({ allowCommentDirectives: true });
+
+		try {
+			project.compileSource(`// @ts-nocheck\n${source}`);
+			throw new Error("Expected a module resolution diagnostic");
+		} catch (error) {
+			expect(error).toBeInstanceOf(DiagnosticError);
+			if (!(error instanceof DiagnosticError)) {
+				throw error;
+			}
+			expect(error.diagnostics.map(getDiagnosticId)).toEqual([errors.noModuleSpecifierFile.id]);
+		}
+	},
+);
+
+it.each([
+	["unmapped dependency", {}, errors.noRojoData],
+	[
+		"scope outside node_modules",
+		{ packages: { "@rbxts": { $path: "node_modules/@rbxts" } } },
+		errors.noPackageImportWithoutScope,
+	],
+	[
+		"node_modules without scope",
+		{ node_modules: { $path: "node_modules/@rbxts" } },
+		errors.noPackageImportWithoutScope,
+	],
+])("rejects a %s in the Rojo tree", (name, mappings, diagnostic) => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game");
+		fixture.json("node_modules/@rbxts/example/package.json", {
+			name: "@rbxts/example",
+			types: "index.d.ts",
+			main: "init.luau",
+		});
+		fixture.write("node_modules/@rbxts/example/index.d.ts", "export declare const value: number;");
+		fixture.write("node_modules/@rbxts/example/init.luau", "return { value = 1 }");
+		fixture.rojo(mappings);
+		fixture.write("game/src/index.ts", 'import "@rbxts/example";');
+
+		const result = fixture.createBuild().build();
+
+		expect(result.emitSkipped).toBe(true);
+		expect(result.diagnostics.map(getDiagnosticId)).toEqual([diagnostic.id]);
+	} finally {
+		fixture.close();
+	}
+});
 
 it.each([false, true])("explains external package entry points (symlink: %s)", linked => {
 	const fixture = new ReferenceFixture();
@@ -86,11 +140,104 @@ it("imports a correctly resolved linked package", () => {
 		fixture.write("packages/example/init.luau", "return { value = 1 }");
 		fs.ensureSymlinkSync(fixture.file("packages/example"), fixture.file("node_modules/@rbxts/example"), "junction");
 		fixture.rojo({ node_modules: { "@rbxts": { $path: "node_modules/@rbxts" } } });
-		fixture.write("game/src/index.ts", 'import { value } from "@rbxts/example"; print(value);');
+		fixture.write("game/src/local.ts", "export const localValue = 2;");
+		fixture.write(
+			"game/src/index.ts",
+			'import { value } from "@rbxts/example"; import { localValue } from "./local"; print(value, localValue);',
+		);
 
 		expectSuccess(fixture.createBuild().build());
 
-		expect(fixture.read("out/game/init.luau")).toContain('"node_modules", "@rbxts", "example"');
+		const output = fixture.read("out/game/init.luau");
+		expect(output).toContain('"node_modules", "@rbxts", "example"');
+		expect(output).toContain('"game", "local"');
+	} finally {
+		fixture.close();
+	}
+});
+
+it("warns when ReplicatedFirst code uses the runtime library", () => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game");
+		fixture.json("default.project.json", {
+			name: "early",
+			tree: {
+				$className: "DataModel",
+				ReplicatedStorage: { $className: "ReplicatedStorage", include: { $path: "include" } },
+				ReplicatedFirst: { $className: "ReplicatedFirst", game: { $path: "out/game" } },
+			},
+		});
+		fixture.write("game/src/index.ts", "export async function load() { return 1; }");
+
+		const result = fixture.createBuild().build();
+
+		expect(result.emitSkipped).toBe(false);
+		expect(result.diagnostics.map(getDiagnosticId)).toEqual([warnings.runtimeLibUsedInReplicatedFirst.id]);
+		expect(result.diagnostics[0].category).toBe(ts.DiagnosticCategory.Warning);
+		expect(fixture.read("out/game/init.luau")).toContain("TS.async");
+	} finally {
+		fixture.close();
+	}
+});
+
+it.each([ProjectType.Game, ProjectType.Model])(
+	"rejects unmapped source files needing runtime imports in a %s",
+	type => {
+		const fixture = new ReferenceFixture();
+		try {
+			fixture.project("game");
+			fixture.rojo({ game: { $path: "out/game/value.luau" } });
+			fixture.write("game/src/value.ts", "export const value = 7;");
+			fixture.write("game/src/index.ts", 'import { value } from "./value"; print(value);');
+
+			const result = fixture.createBuild({ type }).build();
+
+			expect(result.emitSkipped).toBe(true);
+			expect(result.diagnostics.length).toBeGreaterThan(0);
+			expect(result.diagnostics.every(diagnostic => getDiagnosticId(diagnostic) === errors.noRojoData.id)).toBe(
+				true,
+			);
+		} finally {
+			fixture.close();
+		}
+	},
+);
+
+it("rejects an ambient module declaration without a backing module file", () => {
+	const project = createTestProject();
+	project.vfs.writeFile("/src/ambient.d.ts", 'declare module "@rbxts/example" { export const value: number; }');
+
+	try {
+		project.compileSource('import { value } from "@rbxts/example"; print(value);');
+		throw new Error("Expected an import diagnostic");
+	} catch (error) {
+		expect(error).toBeInstanceOf(DiagnosticError);
+		if (!(error instanceof DiagnosticError)) {
+			throw error;
+		}
+		expect(error.diagnostics.map(getDiagnosticId)).toEqual([errors.noModuleSpecifierFile.id]);
+	}
+});
+
+it("rejects a package omitted from the scope's Rojo project", () => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game");
+		fixture.json("node_modules/@rbxts/example/package.json", {
+			name: "@rbxts/example",
+			types: "index.d.ts",
+			main: "init.luau",
+		});
+		fixture.write("node_modules/@rbxts/example/index.d.ts", "export declare const value: number;");
+		fixture.write("node_modules/@rbxts/example/init.luau", "return { value = 1 }");
+		fixture.json("node_modules/@rbxts/default.project.json", { name: "scope", tree: {} });
+		fixture.write("game/src/index.ts", 'import { value } from "@rbxts/example"; print(value);');
+
+		const result = fixture.createBuild({ type: ProjectType.Package }).build();
+
+		expect(result.emitSkipped).toBe(true);
+		expect(result.diagnostics.map(getDiagnosticId)).toEqual([errors.noRojoData.id]);
 	} finally {
 		fixture.close();
 	}

--- a/tests/compiler/transformer/bindings.test.ts
+++ b/tests/compiler/transformer/bindings.test.ts
@@ -1,0 +1,28 @@
+import { getDeclaredVariables } from "TSTransformer/util/getDeclaredVariables";
+import ts from "typescript";
+
+it("collects names from a declaration and a declaration list without initializer references", () => {
+	const source = ts.createSourceFile(
+		"bindings.ts",
+		"const { original: renamed, nested: [first, , ...rest] } = input, [second] = other;",
+		ts.ScriptTarget.Latest,
+		true,
+	);
+	const statement = source.statements[0];
+	if (!ts.isVariableStatement(statement)) {
+		throw new Error("Expected a variable statement");
+	}
+	const declarations = statement.declarationList;
+
+	expect(getDeclaredVariables(declarations).map(identifier => identifier.text)).toEqual([
+		"renamed",
+		"first",
+		"rest",
+		"second",
+	]);
+	expect(getDeclaredVariables(declarations.declarations[0]).map(identifier => identifier.text)).toEqual([
+		"renamed",
+		"first",
+		"rest",
+	]);
+});

--- a/tests/compiler/transformer/createTransformState.ts
+++ b/tests/compiler/transformer/createTransformState.ts
@@ -1,0 +1,22 @@
+import { assert } from "Shared/util/assert";
+import { TransformState } from "TSTransformer";
+import * as sourceTransform from "TSTransformer/nodes/transformSourceFile";
+
+import { createTestProject } from "../createTestProject";
+
+// retain a real compilation's state for helpers whose inputs are Luau nodes or checker types
+export function createTransformState(source = "export const value = 1;") {
+	let state: TransformState | undefined;
+	const transformSourceFile = sourceTransform.transformSourceFile;
+	const spy = jest.spyOn(sourceTransform, "transformSourceFile").mockImplementation((currentState, node) => {
+		state = currentState;
+		return transformSourceFile(currentState, node);
+	});
+	try {
+		createTestProject().compileSource(source);
+	} finally {
+		spy.mockRestore();
+	}
+	assert(state);
+	return state;
+}

--- a/tests/compiler/transformer/debugging.test.ts
+++ b/tests/compiler/transformer/debugging.test.ts
@@ -1,0 +1,79 @@
+import luau from "@roblox-ts/luau-ast";
+import { TransformState } from "TSTransformer/classes/TransformState";
+import { getFlags } from "TSTransformer/util/getFlags";
+import { getKindName } from "TSTransformer/util/getKindName";
+import ts from "typescript";
+
+describe("debug rendering", () => {
+	it("renders an expression without a compilation context", () => {
+		const { debugRender } = TransformState.prototype;
+
+		expect(debugRender(luau.binary(luau.number(1), "+", luau.number(2)))).toBe("1 + 2");
+	});
+
+	it("resolves temporary names in a statement list", () => {
+		const { debugRenderList } = TransformState.prototype;
+		const temporary = luau.tempId("value");
+		const statements = luau.list.make<luau.Statement>(
+			luau.create(luau.SyntaxKind.VariableDeclaration, { left: temporary, right: luau.number(1) }),
+			luau.create(luau.SyntaxKind.ReturnStatement, { expression: temporary }),
+		);
+
+		expect(debugRenderList(statements)).toBe("local _value = 1\nreturn _value\n");
+		expect(debugRenderList(statements)).toBe("local _value = 1\nreturn _value\n");
+	});
+});
+
+describe("syntax kind names", () => {
+	it.each([
+		"EqualsToken",
+		"PlusEqualsToken",
+		"WithKeyword",
+		"BreakKeyword",
+		"ImplementsKeyword",
+		"YieldKeyword",
+		"TypePredicate",
+		"ImportType",
+		"OpenBraceToken",
+		"Unknown",
+		"SingleLineCommentTrivia",
+		"ConflictMarkerTrivia",
+		"NumericLiteral",
+		"NoSubstitutionTemplateLiteral",
+		"TemplateTail",
+		"LessThanToken",
+		"CaretEqualsToken",
+		"VariableStatement",
+		"DebuggerStatement",
+		"QualifiedName",
+		"JSDocTypeExpression",
+		"JSDocTag",
+		"JSDocImportTag",
+		"AbstractKeyword",
+		"DeferKeyword",
+		"JSDocPropertyTag",
+		"OfKeyword",
+		"Identifier",
+	] as const)("names %s without exposing enum range aliases", name => {
+		expect(getKindName(ts.SyntaxKind[name])).toBe(name);
+	});
+});
+
+describe("debugging flags", () => {
+	enum Flags {
+		None = 0,
+		Read = 1,
+		Write = 2,
+		Execute = 4,
+		ReadWrite = Read | Write,
+	}
+
+	it("reports intersecting flag names without numeric reverse mappings", () => {
+		expect(getFlags(Flags.Read | Flags.Execute, Flags)).toEqual(["Read", "Execute", "ReadWrite"]);
+	});
+
+	it("does not report unset or unknown flags", () => {
+		expect(getFlags(Flags.None, Flags)).toEqual([]);
+		expect(getFlags(8, Flags)).toEqual([]);
+	});
+});

--- a/tests/compiler/transformer/diagnostics.test.ts
+++ b/tests/compiler/transformer/diagnostics.test.ts
@@ -1,0 +1,45 @@
+import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import ts from "typescript";
+
+afterEach(() => DiagnosticService.flush());
+
+function diagnostic(code: number, category = ts.DiagnosticCategory.Error): ts.Diagnostic {
+	return { code, category, messageText: `diagnostic ${code}`, file: undefined, start: undefined, length: undefined };
+}
+
+it("deduplicates single diagnostics until the next compilation boundary", () => {
+	const first = diagnostic(1);
+	const duplicate = diagnostic(1);
+	const second = diagnostic(2);
+	DiagnosticService.addSingleDiagnostic(first);
+	DiagnosticService.addSingleDiagnostic(duplicate);
+	DiagnosticService.addSingleDiagnostic(second);
+
+	expect(DiagnosticService.flush()).toEqual([first, second]);
+	DiagnosticService.addSingleDiagnostic(duplicate);
+	expect(DiagnosticService.flush()).toEqual([duplicate]);
+});
+
+it("keeps cached diagnostics independent from single diagnostics", () => {
+	const cache = new Set<string>();
+	const first = diagnostic(1);
+	DiagnosticService.addDiagnosticWithCache("first", first, cache);
+	DiagnosticService.addDiagnosticWithCache("first", diagnostic(1), cache);
+	DiagnosticService.addDiagnosticWithCache("second", first, cache);
+	DiagnosticService.addSingleDiagnostic(first);
+
+	expect(DiagnosticService.flush()).toEqual([first, first, first]);
+	expect(cache).toEqual(new Set(["first", "second"]));
+});
+
+it("preserves order and distinguishes warnings from errors", () => {
+	const warning = diagnostic(1, ts.DiagnosticCategory.Warning);
+	const error = diagnostic(2);
+	DiagnosticService.addDiagnostic(warning);
+	expect(DiagnosticService.hasErrors()).toBe(false);
+	DiagnosticService.addDiagnostics([warning, error]);
+	expect(DiagnosticService.hasErrors()).toBe(true);
+	expect(DiagnosticService.flush()).toEqual([warning, warning, error]);
+	expect(DiagnosticService.hasErrors()).toBe(false);
+	expect(DiagnosticService.flush()).toEqual([]);
+});

--- a/tests/compiler/transformer/exhaustiveness.test.ts
+++ b/tests/compiler/transformer/exhaustiveness.test.ts
@@ -1,0 +1,86 @@
+import childProcess from "child_process";
+import { LogService } from "Shared/classes/LogService";
+import { assertNever } from "TSTransformer/util/assertNever";
+import ts from "typescript";
+
+beforeEach(() => {
+	jest.spyOn(LogService, "fatal").mockImplementation(message => {
+		throw new Error(message);
+	});
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+function mockNpm(stdout: string) {
+	return jest.spyOn(childProcess, "spawnSync").mockReturnValue({
+		pid: 1,
+		output: [null, stdout, ""],
+		stdout,
+		stderr: "",
+		status: 0,
+		signal: null,
+	});
+}
+
+it("reports syntax kinds and the compiler's installed TypeScript version", () => {
+	const spawn = mockNpm(JSON.stringify({ name: "roblox-ts", dependencies: { typescript: { version: "5.9.3" } } }));
+
+	const expression = ts.factory.createPrefixUnaryExpression(
+		ts.SyntaxKind.MinusToken,
+		ts.factory.createNumericLiteral(1),
+	);
+	expect(() => assertNever(expression as never, "unexpected expression")).toThrow(
+		"unexpected expression, value was a TS node of kind PrefixUnaryExpression",
+	);
+	expect(LogService.fatal).toHaveBeenCalledWith(expect.stringContaining("npm install typescript@=5.9.3"));
+	expect(spawn).toHaveBeenCalledWith("npm", ["ls", "typescript", "--json"], {
+		encoding: "utf8",
+		shell: process.platform === "win32",
+	});
+});
+
+it("finds TypeScript below an installed compiler after unrelated leaf dependencies", () => {
+	mockNpm(
+		JSON.stringify({
+			name: "project",
+			dependencies: {
+				unrelated: { version: "1.0.0" },
+				wrapper: { dependencies: { "roblox-ts": { dependencies: { typescript: { version: "5.9.3" } } } } },
+			},
+		}),
+	);
+
+	expect(() => assertNever("unknown" as never, "unexpected operator")).toThrow("npm install typescript@=5.9.3");
+});
+
+it.each(["", "invalid JSON", "{}", '{"name":"roblox-ts"}', '{"name":"roblox-ts","dependencies":{}}'])(
+	"keeps the original assertion when npm returns %j",
+	output => {
+		mockNpm(output);
+
+		expect(() => assertNever(null as never, "unexpected value")).toThrow("unexpected value, value was null");
+		expect(LogService.fatal).toHaveBeenCalledWith(expect.not.stringContaining("npm install typescript@="));
+	},
+);
+
+it("keeps the original assertion when npm cannot start", () => {
+	jest.spyOn(childProcess, "spawnSync").mockImplementation(() => {
+		throw new Error("npm unavailable");
+	});
+
+	expect(() => assertNever({ kind: ts.SyntaxKind.PlusToken } as never, "unexpected token")).toThrow(
+		"unexpected token, value was { kind:",
+	);
+});
+
+it("uses the command shell for npm on Windows", () => {
+	const spawn = mockNpm("{}");
+	const platform = process.platform;
+	Object.defineProperty(process, "platform", { value: "win32" });
+	try {
+		expect(() => assertNever(42 as never, "unexpected value")).toThrow("unexpected value, value was 42");
+		expect(spawn).toHaveBeenCalledWith("npm", ["ls", "typescript", "--json"], { encoding: "utf8", shell: true });
+	} finally {
+		Object.defineProperty(process, "platform", { value: platform });
+	}
+});

--- a/tests/compiler/transformer/expressions.test.ts
+++ b/tests/compiler/transformer/expressions.test.ts
@@ -1,0 +1,93 @@
+import luau from "@roblox-ts/luau-ast";
+import { assert } from "Shared/util/assert";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
+import { transformLogical } from "TSTransformer/nodes/transformLogical";
+import { createBinaryFromOperator } from "TSTransformer/util/createBinaryFromOperator";
+import { expressionMightMutate } from "TSTransformer/util/expressionMightMutate";
+import { isUsedAsStatement } from "TSTransformer/util/isUsedAsStatement";
+import { isBooleanLiteralType } from "TSTransformer/util/types";
+import { valueToIdStr } from "TSTransformer/util/valueToIdStr";
+import ts from "typescript";
+
+import { createTransformState } from "./createTransformState";
+
+it.each([
+	["object.value;", true],
+	["(object.value);", true],
+	["const result = object.value;", false],
+	["for (object.value; ; ) {}", true],
+	["for (; object.value; ) {}", false],
+	["for (; ; object.value) {}", true],
+	["delete object.value;", true],
+	["const result = delete object.value;", false],
+])("identifies whether %s discards its value", (source, expected) => {
+	const sourceFile = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+	const expressions = new Array<ts.PropertyAccessExpression>();
+	function visit(node: ts.Node) {
+		if (ts.isPropertyAccessExpression(node)) {
+			expressions.push(node);
+		}
+		ts.forEachChild(node, visit);
+	}
+	visit(sourceFile);
+
+	expect(expressions).toHaveLength(1);
+	expect(isUsedAsStatement(expressions[0])).toBe(expected);
+});
+
+it.each([
+	["identifier", luau.id("Players"), "players"],
+	["property", luau.property(luau.id("services"), "Players"), "players"],
+	["constructor", luau.call(luau.property(luau.id("Widget"), "new")), "widget"],
+	["namespaced constructor", luau.call(luau.property(luau.property(luau.id("UI"), "Widget"), "new")), "widget"],
+	["computed constructor", luau.call(luau.property(luau.call(luau.id("getClass")), "new")), ""],
+	["ordinary function", luau.call(luau.id("getValue")), ""],
+	["ordinary method", luau.call(luau.property(luau.id("Widget"), "create")), ""],
+	["literal", luau.number(1), ""],
+])("derives a readable temporary name for a %s", (name, expression, expected) => {
+	expect(valueToIdStr(expression)).toBe(expected);
+});
+
+it("recognizes stable varargs and checks both operands of binary expressions", () => {
+	const state = createTransformState();
+	expect(expressionMightMutate(state, luau.create(luau.SyntaxKind.VarArgsLiteral, {}))).toBe(false);
+	expect(expressionMightMutate(state, luau.binary(luau.number(1), "+", luau.number(2)))).toBe(false);
+	expect(expressionMightMutate(state, luau.binary(luau.number(1), "+", luau.call(luau.id("read"))))).toBe(true);
+});
+
+it("distinguishes both boolean literals through the checker", () => {
+	const state = createTransformState();
+	const isTrue = isBooleanLiteralType(state, true);
+	const isFalse = isBooleanLiteralType(state, false);
+	expect(isTrue(state.typeChecker.getTrueType())).toBe(true);
+	expect(isTrue(state.typeChecker.getFalseType())).toBe(false);
+	expect(isFalse(state.typeChecker.getFalseType())).toBe(true);
+	expect(isFalse(state.typeChecker.getTrueType())).toBe(false);
+});
+
+it("rejects binary operators that require a dedicated transform", () => {
+	const state = createTransformState();
+	const numberType = state.typeChecker.getNumberType();
+	expect(() =>
+		createBinaryFromOperator(
+			new Prereqs(),
+			luau.number(1),
+			numberType,
+			ts.SyntaxKind.EqualsEqualsToken,
+			luau.number(2),
+			numberType,
+		),
+	).toThrow("createBinaryFromOperator unknown operator: EqualsEqualsToken");
+});
+
+it("rejects arithmetic expressions in logical lowering", () => {
+	const state = createTransformState("export const value = 1 + 2;");
+	const source = state.program.getSourceFile("/src/playground.tsx");
+	assert(source);
+	const statement = source.statements[0];
+	assert(ts.isVariableStatement(statement));
+	const expression = statement.declarationList.declarations[0].initializer;
+	assert(expression && ts.isBinaryExpression(expression));
+
+	expect(() => transformLogical(state, new Prereqs(), expression)).toThrow("Operator not implemented: PlusToken");
+});

--- a/tests/compiler/transformer/invalidSource.test.ts
+++ b/tests/compiler/transformer/invalidSource.test.ts
@@ -1,0 +1,58 @@
+import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+
+import { createTestProject } from "../createTestProject";
+
+afterEach(() => DiagnosticService.flush());
+
+it.each([
+	["with ({}) {}", "Unknown statement: WithStatement"],
+	["const value = import.meta;", "Unknown expression: MetaProperty"],
+	["({ value: 42 } = { value: 1 });", "transformObjectAssignmentPattern invalid initializer: NumericLiteral"],
+	["({ method() {} } = {});", "transformObjectAssignmentPattern invalid property: MethodDeclaration"],
+	["[42] = (() => [1])();", "transformArrayAssignmentPattern invalid element: NumericLiteral"],
+	["const { ...a, ...b } = {};", "Unknown expression type"],
+	["const [value] = 42;", "Destructuring not supported for type: 42"],
+])("rejects unsupported source after semantic checks are disabled: %s", (source, message) => {
+	const project = createTestProject({ allowCommentDirectives: true });
+
+	expect(() => project.compileSource(`// @ts-nocheck\n${source}`)).toThrow(message);
+});
+
+it("handles a call whose callee has the never type after semantic checks are disabled", () => {
+	const project = createTestProject({ allowCommentDirectives: true });
+	const output = project.compileSource("// @ts-nocheck\ndeclare const callback: never; callback();");
+	expect(output).toContain("callback()");
+});
+
+it("lowers an untyped this receiver when semantic checks are disabled", () => {
+	const project = createTestProject({ allowCommentDirectives: true });
+	const output = project.compileSource("// @ts-nocheck\nfunction read() { return this; }");
+	expect(output).toContain("return self");
+});
+
+it("preserves local namespace export specifiers when semantic checks are disabled", () => {
+	const project = createTestProject({ allowCommentDirectives: true });
+	const output = project.compileSource(
+		"// @ts-nocheck\nnamespace N { const value = 42; export { value }; } print(N.value);",
+	);
+	expect(output).toContain("_container.value = value");
+});
+
+it("accepts namespace export alias references when semantic checks are disabled", () => {
+	const project = createTestProject({ allowCommentDirectives: true });
+	const output = project.compileSource(
+		"// @ts-nocheck\nnamespace N { const value = 42; export { value as alias }; print(alias); }",
+	);
+
+	expect(output).toContain("print(alias)");
+});
+
+it.each([
+	["class prototype", "export class Value {} export = Value;"],
+	["function property", "export function Value() {} Value.property = 42; export = Value;"],
+])("accepts namespace export-equals with a %s when semantic checks are disabled", (name, body) => {
+	const project = createTestProject({ allowCommentDirectives: true });
+	const output = project.compileSource(`// @ts-nocheck\nnamespace N { ${body} } print(N);`);
+
+	expect(output).toContain("print(N)");
+});

--- a/tests/compiler/transformer/macroTypes.test.ts
+++ b/tests/compiler/transformer/macroTypes.test.ts
@@ -1,0 +1,82 @@
+import { assert } from "Shared/util/assert";
+
+import { createTestProject } from "../createTestProject";
+
+function changeCompilerTypes(file: string, rewrite: (source: string) => string) {
+	const project = createTestProject();
+	const path = `/node_modules/@rbxts/compiler-types/types/${file}.d.ts`;
+	const source = project.vfs.readFile(path);
+	assert(source !== undefined);
+	const changed = rewrite(source);
+	expect(changed).not.toBe(source);
+	project.vfs.writeFile(path, changed);
+	return project;
+}
+
+it.each([
+	["Promise", "Promise", "declare const Promise: PromiseConstructor;", ""],
+	["ArrayConstructor", "Array", "interface ArrayConstructor", "interface MissingConstructor"],
+	["TemplateStringsArray", "Array", "interface TemplateStringsArray", "interface MissingTemplateStringsArray"],
+])("explains a missing %s compiler type", (symbol, file, before, after) => {
+	const project = changeCompilerTypes(file, source => source.replace(before, after));
+
+	expect(() => project.compileSource("export const value = 1;")).toThrow(
+		`MacroManager could not find symbol for ${symbol}`,
+	);
+});
+
+it("explains a missing constructor signature", () => {
+	const project = changeCompilerTypes("Array", source => source.replace(/new <T>\([^;]*;/g, ""));
+
+	expect(() => project.compileSource("export const value = 1;")).toThrow(
+		"MacroManager could not find constructor for ArrayConstructor",
+	);
+});
+
+it("explains a missing macro method", () => {
+	const project = changeCompilerTypes("Array", source => source.replace("push(", "missingPush("));
+
+	expect(() => project.compileSource("export const value = 1;")).toThrow(
+		"MacroManager could not find method for Array.push",
+	);
+});
+
+it("accepts constructor metadata and merged namespace declarations", () => {
+	const project = changeCompilerTypes("Array", source =>
+		source.replace(
+			"interface ArrayConstructor {",
+			"interface ArrayConstructor { readonly metadata: unique symbol;",
+		),
+	);
+	project.vfs.writeFile(
+		"/src/augmentation.d.ts",
+		"declare namespace ReadonlyArray { const metadata: unique symbol; }",
+	);
+
+	expect(project.compileSource("export const values = new Array<number>();")).toContain("local values = {}");
+});
+
+it("rejects added array methods that have no runtime implementation", () => {
+	const project = createTestProject();
+	project.vfs.writeFile("/src/augmentation.d.ts", "interface ReadonlyArray<T> { custom(): void; }");
+
+	expect(() => project.compileSource("[1].custom();")).toThrow("Macro ReadonlyArray.custom() is not implemented!");
+});
+
+it("finds a constructor interface after its merged namespace", () => {
+	const project = changeCompilerTypes(
+		"Array",
+		source => `declare namespace ArrayConstructor { const metadata: unique symbol; }\n${source}`,
+	);
+	expect(project.compileSource("export const values = new Array<number>();")).toContain("local values = {}");
+});
+
+it.each([
+	["an interface", "interface LuaTuple<T extends Array<any>> {}"],
+	["an unbranded alias", "type LuaTuple<T extends Array<any>> = T;"],
+])("allows unrelated compilation when LuaTuple is %s", (description, declaration) => {
+	const project = changeCompilerTypes("core", source =>
+		source.replace(/type LuaTuple<T extends Array<any>> = T & \{[^}]*\};/, declaration),
+	);
+	expect(project.compileSource("export const value = 1;")).toContain("local value = 1");
+});

--- a/tests/compiler/transformer/offset.test.ts
+++ b/tests/compiler/transformer/offset.test.ts
@@ -1,0 +1,17 @@
+import luau, { renderAST } from "@roblox-ts/luau-ast";
+import { offset } from "TSTransformer/util/offset";
+
+it("preserves expression identity when no index adjustment is needed", () => {
+	const expression = luau.call(luau.id("index"));
+
+	expect(offset(expression, 0)).toBe(expression);
+	const statement = luau.create(luau.SyntaxKind.ReturnStatement, { expression: offset(expression, 0) });
+	expect(renderAST(luau.list.make(statement))).toBe("return index()\n");
+});
+
+it("preserves a dynamic right operand when adjusting an index", () => {
+	const expression = luau.binary(luau.id("start"), "+", luau.id("delta"));
+	const statement = luau.create(luau.SyntaxKind.ReturnStatement, { expression: offset(expression, 1) });
+
+	expect(renderAST(luau.list.make(statement))).toBe("return start + delta + 1\n");
+});

--- a/tests/compiler/transformer/pointers.test.ts
+++ b/tests/compiler/transformer/pointers.test.ts
@@ -1,0 +1,17 @@
+import luau, { renderAST } from "@roblox-ts/luau-ast";
+import { assert } from "Shared/util/assert";
+import { Prereqs } from "TSTransformer/classes/Prereqs";
+import { createArrayPointer, disableArrayInline } from "TSTransformer/util/pointer";
+
+it("materializes an array pointer once when multiple operations disable inlining", () => {
+	const prereqs = new Prereqs();
+	const pointer = createArrayPointer("values");
+	assert(luau.isArray(pointer.value));
+	luau.list.push(pointer.value.members, luau.number(42));
+	disableArrayInline(prereqs, pointer);
+	const identifier = pointer.value;
+	disableArrayInline(prereqs, pointer);
+
+	expect(pointer.value).toBe(identifier);
+	expect(renderAST(prereqs.statements)).toBe("local _values = { 42 }\n");
+});

--- a/tests/compiler/transformer/state.test.ts
+++ b/tests/compiler/transformer/state.test.ts
@@ -1,0 +1,36 @@
+import { assert } from "Shared/util/assert";
+import { hasMultipleDefinitions } from "TSTransformer/util/hasMultipleDefinitions";
+import ts from "typescript";
+
+import { createTransformState } from "./createTransformState";
+
+it("tracks only the active try statement and clears it after popping", () => {
+	const state = createTransformState();
+	state.markTryUses("usesReturn");
+	expect(state.tryUsesStack).toEqual([]);
+
+	const outer = state.pushTryUsesStack();
+	state.markTryUses("usesReturn");
+	const inner = state.pushTryUsesStack();
+	state.markTryUses("usesBreak");
+	expect(outer).toEqual({ usesReturn: true, usesBreak: false, usesContinue: false });
+	expect(inner).toEqual({ usesReturn: false, usesBreak: true, usesContinue: false });
+
+	state.popTryUsesStack();
+	state.markTryUses("usesContinue");
+	expect(outer.usesContinue).toBe(true);
+	state.popTryUsesStack();
+	state.markTryUses("usesBreak");
+	expect(state.tryUsesStack).toEqual([]);
+});
+
+it("handles inferred tuple properties without source declarations", () => {
+	const state = createTransformState("export type Tuple = [number];");
+	const source = state.program.getSourceFile("/src/playground.tsx");
+	assert(source);
+	const symbol = state.typeChecker.getTypeAtLocation(source.statements[0]).getProperty("0");
+	assert(symbol);
+	expect(symbol.getDeclarations()).toBeUndefined();
+	expect(hasMultipleDefinitions(symbol, ts.isFunctionDeclaration)).toBe(false);
+	expect(state.getModuleIdPropertyAccess(symbol)).toBeUndefined();
+});

--- a/tests/compiler/transformer/truthiness.test.ts
+++ b/tests/compiler/transformer/truthiness.test.ts
@@ -1,0 +1,36 @@
+import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
+import ts from "typescript";
+
+import { createTestProject } from "../createTestProject";
+
+afterEach(() => {
+	jest.restoreAllMocks();
+	DiagnosticService.flush();
+});
+
+it.each([
+	["number", "0, NaN"],
+	["string", '""'],
+	["number | string", '0, NaN, ""'],
+])("reports the extra truthiness checks for %s without changing output", (type, checks) => {
+	const source = `export function truthy(value: ${type}) { return !!value; }`;
+	const original = createTestProject().compileSource(source);
+	const add = jest.spyOn(DiagnosticService, "addDiagnostic");
+	const output = createTestProject({ logTruthyChanges: true }).compileSource(source);
+
+	expect(output).toBe(original);
+	expect(add).toHaveBeenCalledTimes(1);
+	expect(add.mock.calls[0][0]).toMatchObject({
+		category: ts.DiagnosticCategory.Warning,
+		messageText: `Value will be checked against ${checks}`,
+	});
+});
+
+it("does not warn when a boolean needs no additional checks", () => {
+	const add = jest.spyOn(DiagnosticService, "addDiagnostic");
+	createTestProject({ logTruthyChanges: true }).compileSource(
+		"export function truthy(value: boolean) { return !!value; }",
+	);
+
+	expect(add).not.toHaveBeenCalled();
+});

--- a/tests/src/diagnostics/noAsyncGeneratorFunctions.ts
+++ b/tests/src/diagnostics/noAsyncGeneratorFunctions.ts
@@ -1,3 +1,13 @@
 async function* foo() {
 	yield 1;
 }
+
+const expression = async function* () {
+	yield 1;
+};
+
+class Generator {
+	async *values() {
+		yield 1;
+	}
+}

--- a/tests/src/diagnostics/noAutoAccessorModifiers.ts
+++ b/tests/src/diagnostics/noAutoAccessorModifiers.ts
@@ -1,0 +1,3 @@
+class Accessor {
+	accessor value = 1;
+}

--- a/tests/src/diagnostics/noConstructorMacroWithoutNew.1.ts
+++ b/tests/src/diagnostics/noConstructorMacroWithoutNew.1.ts
@@ -1,0 +1,3 @@
+class Value {
+	constructor(value = Array) {}
+}

--- a/tests/src/diagnostics/noGetterSetter.3.ts
+++ b/tests/src/diagnostics/noGetterSetter.3.ts
@@ -1,0 +1,6 @@
+const object = {
+	get value() {
+		return 1;
+	},
+	set value(value: number) {},
+};

--- a/tests/src/diagnostics/noGlobalThis.ts
+++ b/tests/src/diagnostics/noGlobalThis.ts
@@ -1,1 +1,11 @@
 print(globalThis);
+
+function withGlobalReceiver(this: typeof globalThis) {
+	print(this);
+}
+
+const contextualReceiver: ThisType<typeof globalThis> & { method(): void } = {
+	method() {
+		this;
+	},
+};

--- a/tests/src/diagnostics/noIndexWithoutCall.7.ts
+++ b/tests/src/diagnostics/noIndexWithoutCall.7.ts
@@ -1,0 +1,1 @@
+const check = typeIs;

--- a/tests/src/diagnostics/noIndexWithoutCall.8.ts
+++ b/tests/src/diagnostics/noIndexWithoutCall.8.ts
@@ -1,0 +1,4 @@
+declare const callback: never;
+const object = { method() {} };
+// @ts-ignore
+callback(object.method);

--- a/tests/src/diagnostics/noIterableIteration.ts
+++ b/tests/src/diagnostics/noIterableIteration.ts
@@ -1,0 +1,7 @@
+declare const values: Iterable<number>;
+for (const value of values) {
+	print(value);
+}
+const array = [...values];
+const [first] = values;
+const [, ...rest] = values;

--- a/tests/src/diagnostics/noMacroExtends.ts
+++ b/tests/src/diagnostics/noMacroExtends.ts
@@ -1,0 +1,1 @@
+class Derived extends Array<string> {}

--- a/tests/src/diagnostics/noModuleSpecifierFile.ts
+++ b/tests/src/diagnostics/noModuleSpecifierFile.ts
@@ -1,3 +1,6 @@
 // @ts-expect-error
 import { x } from "packageThatDoesNotExist";
 print(x);
+
+const modulePath = "./module";
+$getModuleTree(modulePath);

--- a/tests/src/diagnostics/noNamespaceMerging.1.ts
+++ b/tests/src/diagnostics/noNamespaceMerging.1.ts
@@ -1,0 +1,5 @@
+function Merged(): void;
+function Merged() {}
+namespace Merged {
+	export const value = 1;
+}

--- a/tests/src/diagnostics/noNamespaceMerging.2.ts
+++ b/tests/src/diagnostics/noNamespaceMerging.2.ts
@@ -1,0 +1,4 @@
+class Merged {}
+namespace Merged {
+	export const value = 1;
+}

--- a/tests/src/diagnostics/noNonNumberUnaryMinus.ts
+++ b/tests/src/diagnostics/noNonNumberUnaryMinus.ts
@@ -1,0 +1,1 @@
+const value = -"1";

--- a/tests/src/diagnostics/noNonStringModuleSpecifier.ts
+++ b/tests/src/diagnostics/noNonStringModuleSpecifier.ts
@@ -1,0 +1,2 @@
+const name = "module";
+const promise = import(name);

--- a/tests/src/diagnostics/noPrivateIdentifier.2.ts
+++ b/tests/src/diagnostics/noPrivateIdentifier.2.ts
@@ -1,0 +1,4 @@
+class PrivateMembers {
+	static #value = 1;
+	#method() {}
+}

--- a/tests/src/diagnostics/noPrivateIdentifier.3.ts
+++ b/tests/src/diagnostics/noPrivateIdentifier.3.ts
@@ -1,0 +1,4 @@
+const object = {
+	// @ts-ignore check the compiler diagnostic when TypeScript's private-name diagnostic is suppressed
+	#value: 1,
+};

--- a/tests/src/diagnostics/noPrototype.ts
+++ b/tests/src/diagnostics/noPrototype.ts
@@ -1,3 +1,6 @@
 function foo() {}
 
 print(foo.prototype);
+
+class Example {}
+Example.prototype = new Example();

--- a/tests/src/diagnostics/noRangeMacroOutsideForOf.ts
+++ b/tests/src/diagnostics/noRangeMacroOutsideForOf.ts
@@ -1,0 +1,1 @@
+const range = $range(1, 3);

--- a/tests/src/diagnostics/noUnsupportedIteration.ts
+++ b/tests/src/diagnostics/noUnsupportedIteration.ts
@@ -1,0 +1,3 @@
+declare const values: IterableIterator<number>;
+const [first, ...rest] = values;
+const array = [...values];

--- a/tests/src/tests/array.spec.ts
+++ b/tests/src/tests/array.spec.ts
@@ -1,4 +1,30 @@
 export = () => {
+	it("should stop tuple iterator spreads at the first nil return", () => {
+		const values = [false, 0] as const;
+		let calls = 0;
+		const iterator = (() => {
+			calls++;
+			assert(calls <= 3, "iterator was called after its first return became nil");
+			return $tuple(calls <= 2 ? values[calls - 1] : undefined, calls * 10);
+		}) as IterableFunction<LuaTuple<[boolean | number | undefined, number]>>;
+
+		const result = [...iterator];
+
+		expect(result.size()).to.equal(2);
+		expect(result[0][0]).to.equal(false);
+		expect(result[1][0]).to.equal(0);
+		expect(result[1][1]).to.equal(20);
+		expect(calls).to.equal(3);
+	});
+
+	it("should preserve omitted array elements at their written indices", () => {
+		const values = [1, , 3];
+
+		expect(values[0]).to.equal(1);
+		expect(values[1]).to.equal(undefined);
+		expect(values[2]).to.equal(3);
+	});
+
 	it("should support optional chain call on array index", () => {
 		let v: { onEnd: Array<(arg?: string) => void> } = {
 			onEnd: [
@@ -95,6 +121,7 @@ export = () => {
 		values[10] = 123;
 		values[-10] = 456;
 		expect(values[1_0]).to.equal(123);
+		// prettier-ignore
 		expect(values[0x0_A]).to.equal(123);
 		expect(values[0b1_010]).to.equal(123);
 		expect(values[0o1_2]).to.equal(123);
@@ -276,7 +303,7 @@ export = () => {
 	it("should support forEach", () => {
 		const bin = [1, 2, 3];
 		let str = "";
-		bin.forEach(v => (str += v));
+		expect(bin.forEach(v => (str += v))).to.equal(undefined);
 		expect(str).to.equal("123");
 	});
 
@@ -377,9 +404,16 @@ export = () => {
 	});
 
 	it("should allow spread 2", () => {
-		const c = [...[1], ...[2]];
-		expect(c[0]).to.equal(1);
-		expect(c[1]).to.equal(2);
+		const c = [0, ...[1], ...[2]];
+		expect(c[0]).to.equal(0);
+		expect(c[1]).to.equal(1);
+		expect(c[2]).to.equal(2);
+	});
+
+	it("should preserve elements between array and tuple iterator spreads", () => {
+		const chunks = [...[["a"]], ["b"], ..."cd".gmatch(".")];
+
+		expect(chunks.map(chunk => chunk[0]).join("")).to.equal("abcd");
 	});
 
 	it("should allow spread 3", () => {
@@ -481,6 +515,9 @@ export = () => {
 		expect(arr.size()).to.equal(7);
 		expect(arr[4]).to.equal(7);
 		expect(arr[6]).to.equal(6);
+		arr.unorderedRemove(0);
+		expect(arr.size()).to.equal(6);
+		expect(arr[0]).to.equal(6);
 	});
 
 	it("should support spreading non-apparent types", () => {

--- a/tests/src/tests/class.spec.ts
+++ b/tests/src/tests/class.spec.ts
@@ -1,4 +1,34 @@
 export = () => {
+	it("should inherit from an abstract class without a base", () => {
+		abstract class Base {
+			value = 41;
+			abstract read(): number;
+		}
+		class Derived extends Base {
+			read() {
+				return this.value + 1;
+			}
+		}
+
+		expect(new Derived().read()).to.equal(42);
+	});
+
+	it("should preserve the receiver for computed super calls", () => {
+		class Base {
+			value = 42;
+			read() {
+				return this.value;
+			}
+		}
+		class Derived extends Base {
+			read() {
+				return super["read"]() + 1;
+			}
+		}
+
+		expect(new Derived().read()).to.equal(43);
+	});
+
 	it("should properly initialize static properties and use `this` in a static context correctly", () => {
 		class X {
 			static value1 = "a";
@@ -344,7 +374,8 @@ export = () => {
 
 	it("should support methods keys that emit prereqs", () => {
 		let i = 0;
-		class A {
+		class Base {}
+		class A extends Base {
 			[++i]() {
 				return "first";
 			}

--- a/tests/src/tests/decorator.spec.ts
+++ b/tests/src/tests/decorator.spec.ts
@@ -1,4 +1,30 @@
 export = () => {
+	it("should initialize decorators with undecorated trailing parameters", () => {
+		const events = new Array<string>();
+		function classDecorator() {
+			events.push("class initializer");
+			return (target: defined) => {
+				events.push("class decorator");
+			};
+		}
+		function parameterDecorator() {
+			events.push("parameter initializer");
+			return (target: defined, key: string | undefined, index: number) => {
+				events.push(`parameter ${index}`);
+			};
+		}
+		@classDecorator()
+		class Empty {}
+		@classDecorator()
+		class Value {
+			constructor(value: number) {}
+			method(@parameterDecorator() first: number, second: number) {}
+		}
+		expect(events.join(",")).to.equal(
+			"class initializer,class decorator,parameter initializer,parameter 0,class initializer,class decorator",
+		);
+	});
+
 	it("should support static parameter decorators", () => {
 		let buzz: string | undefined;
 

--- a/tests/src/tests/delete.spec.ts
+++ b/tests/src/tests/delete.spec.ts
@@ -5,6 +5,18 @@ type fruits = {
 };
 
 export = () => {
+	it("should delete optional properties only when the receiver exists", () => {
+		function remove(object?: { value?: number }) {
+			delete object?.value;
+			return delete object?.value;
+		}
+		const object = { value: 42 };
+
+		expect(remove(object)).to.equal(true);
+		expect(object.value).to.equal(undefined);
+		expect(remove()).to.equal(true);
+	});
+
 	describe("should work for objects", () => {
 		it("should delete from the object with property acccess", () => {
 			const myTrolly: fruits = {

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -1,6 +1,140 @@
 /* eslint-disable prefer-const */
 
 export = () => {
+	it("should evaluate empty destructuring initializers exactly once", () => {
+		let calls = 0;
+		function value() {
+			calls++;
+			return 42;
+		}
+		const [] = [];
+		const [] = [value()];
+		const {} = {};
+		expect(calls).to.equal(1);
+	});
+
+	it("should assign a nested object without a default initializer", () => {
+		let value = 0;
+		function read() {
+			return [{ value: 42 }];
+		}
+		[{ value }] = read();
+		expect(value).to.equal(42);
+	});
+
+	it("should collect the remaining values from iterator functions", () => {
+		let calls = 0;
+		const iterator = (() => {
+			calls++;
+			return calls <= 4 ? calls : undefined;
+		}) as IterableFunction<number>;
+		const [first, , ...rest] = iterator;
+
+		expect(first).to.equal(1);
+		expect(rest.join(",")).to.equal("3,4");
+		expect(calls).to.equal(5);
+	});
+
+	it("should retain the iterator when advancing it rebinds its source", () => {
+		let calls = 0;
+		let iterator: IterableFunction<number>;
+		iterator = (() => {
+			calls++;
+			iterator = ((): number => {
+				throw "replacement iterator must not be called";
+			}) as IterableFunction<number>;
+			return calls <= 3 ? calls : undefined;
+		}) as IterableFunction<number>;
+
+		const [first, second, ...rest] = iterator;
+
+		expect(first).to.equal(1);
+		expect(second).to.equal(2);
+		expect(rest.join(",")).to.equal("3");
+		expect(calls).to.equal(4);
+	});
+
+	it("should retain the iterator when a nested default rebinds its source", () => {
+		let calls = 0;
+		const original = (() => {
+			calls++;
+			return $tuple(calls <= 3 ? calls : undefined, undefined);
+		}) as IterableFunction<LuaTuple<[number, number?]>>;
+		const replacement = ((): LuaTuple<[number, number?]> => {
+			throw "replacement iterator must not be called";
+		}) as IterableFunction<LuaTuple<[number, number?]>>;
+		let iterator = original;
+
+		const [[first, value = ((iterator = replacement), 99)], second, ...rest] = iterator;
+
+		expect(first).to.equal(1);
+		expect(value).to.equal(99);
+		expect(second[0]).to.equal(2);
+		expect(rest[0][0]).to.equal(3);
+		expect(rest.size()).to.equal(1);
+		expect(calls).to.equal(4);
+		expect(iterator).to.equal(replacement);
+	});
+
+	it("should evaluate a rest assignment target before consuming its iterator", () => {
+		let calls = 0;
+		const events = new Array<string>();
+		const original = new Array<Array<number>>();
+		const replacement = new Array<Array<number>>();
+		let target = original;
+		const iterator = (() => {
+			events.push("next");
+			target = replacement;
+			return ++calls <= 2 ? calls : undefined;
+		}) as IterableFunction<number>;
+		function key() {
+			events.push("key");
+			return 0;
+		}
+
+		[...target[key()]] = iterator;
+
+		expect(events.join(",")).to.equal("key,next,next,next");
+		expect(original[0].join(",")).to.equal("1,2");
+		expect(replacement.size()).to.equal(0);
+	});
+
+	it("should collect remaining tuples from iterator functions", () => {
+		const [[first], , ...rest] = "a,b,c,d".gmatch("[^,]+");
+
+		expect(first).to.equal("a");
+		expect(rest.size()).to.equal(2);
+		expect(rest[0][0]).to.equal("c");
+		expect(rest[1][0]).to.equal("d");
+
+		let head: LuaTuple<Array<string | number>>;
+		let tail: Array<LuaTuple<Array<string | number>>>;
+		[head, ...tail] = "e,f,g".gmatch("[^,]+");
+
+		expect(head[0]).to.equal("e");
+		expect(tail.size()).to.equal(2);
+		expect(tail[0][0]).to.equal("f");
+		expect(tail[1][0]).to.equal("g");
+	});
+
+	it("should stop tuple iterator rest bindings at the first nil return", () => {
+		const values = [false, 0] as const;
+		let calls = 0;
+		const iterator = (() => {
+			calls++;
+			assert(calls <= 3, "iterator was called after its first return became nil");
+			return $tuple(calls <= 2 ? values[calls - 1] : undefined, calls * 10);
+		}) as IterableFunction<LuaTuple<[boolean | number | undefined, number]>>;
+
+		const [first, ...rest] = iterator;
+
+		expect(first[0]).to.equal(false);
+		expect(rest.size()).to.equal(1);
+		expect(rest[0][0]).to.equal(0);
+		expect(rest[0][1]).to.equal(20);
+		expect(calls).to.equal(3);
+	});
+
 	it("should destructure simple arrays", () => {
 		const [a, b] = [1, 2];
 		expect(a).to.equal(1);
@@ -262,6 +396,7 @@ export = () => {
 	it("should support nested object destructure assignment with length property", () => {
 		let length: number;
 
+		// prettier-ignore
 		([{ length }] = [{ length: 42 }] as const);
 
 		expect(length).to.equal(42);
@@ -964,6 +1099,15 @@ export = () => {
 		let x = 0;
 		[] = pcall(() => (x = 123));
 		expect(x).to.equal(123);
+
+		[] = [];
+		({} = {});
+		const array = [1];
+		const object = { value: 2 };
+		expect(([] = array)).to.equal(array);
+		expect(({} = object)).to.equal(object);
+		({} = pcall(() => x++));
+		expect(x).to.equal(124);
 	});
 
 	it("should support function destructuring if not a method", () => {

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -1,5 +1,9 @@
 /* eslint-disable prefer-const */
 
+function makePair(first: number, second: number) {
+	return $tuple(first, second);
+}
+
 export = () => {
 	it("should evaluate empty destructuring initializers exactly once", () => {
 		let calls = 0;
@@ -20,6 +24,109 @@ export = () => {
 		}
 		[{ value }] = read();
 		expect(value).to.equal(42);
+	});
+
+	it("should stop advancing short scalar iterators before collecting rest bindings", () => {
+		for (const length of [0, 1, 2, 3, 5]) {
+			let calls = 0;
+			const iterator = (() => {
+				calls++;
+				assert(calls <= length + 1, "advanced after exhaustion");
+				return calls <= length ? calls : undefined;
+			}) as IterableFunction<number>;
+
+			const [first = 10, second = 20, , ...rest] = iterator;
+
+			expect(first).to.equal(length >= 1 ? 1 : 10);
+			expect(second).to.equal(length >= 2 ? 2 : 20);
+			expect(rest.join(",")).to.equal(length === 5 ? "4,5" : "");
+			expect(calls).to.equal(length + 1);
+		}
+	});
+
+	it("should remember exhaustion in an omitted first iterator binding", () => {
+		let calls = 0;
+		const iterator = (() => {
+			calls++;
+			assert(calls === 1, "advanced after exhaustion");
+			return undefined as number | undefined;
+		}) as IterableFunction<number>;
+
+		const [, , value = 42, ...rest] = iterator;
+
+		expect(value).to.equal(42);
+		expect(rest.size()).to.equal(0);
+		expect(calls).to.equal(1);
+	});
+
+	it("should evaluate assignment targets and defaults after iterator exhaustion", () => {
+		const events = new Array<string>();
+		const target = { first: 0, second: 0, rest: new Array<number>() };
+		let calls = 0;
+		const iterator = (() => {
+			events.push("next");
+			calls++;
+			assert(calls === 1, "advanced after exhaustion");
+			return undefined as number | undefined;
+		}) as IterableFunction<number>;
+		function getTarget(name: string) {
+			events.push(name);
+			return target;
+		}
+		function initialize(name: string) {
+			events.push(`default:${name}`);
+			return 42;
+		}
+
+		[
+			getTarget("first").first = initialize("first"),
+			,
+			getTarget("second").second = initialize("second"),
+			...getTarget("rest").rest
+		] = iterator;
+
+		expect(events.join(",")).to.equal("first,next,default:first,second,default:second,rest");
+		expect(target.first).to.equal(42);
+		expect(target.second).to.equal(42);
+		expect(target.rest.size()).to.equal(0);
+		expect(calls).to.equal(1);
+	});
+
+	it("should stop short tuple iterators even when their trailing returns are populated", () => {
+		for (const length of [0, 1, 2, 3, 5]) {
+			let calls = 0;
+			const iterator = (() => {
+				calls++;
+				assert(calls <= length + 1, "advanced after exhaustion");
+				return $tuple(calls <= length ? calls : undefined, 99);
+			}) as IterableFunction<LuaTuple<[number, number]>>;
+
+			const [first = makePair(10, 11), second = makePair(20, 21), , ...rest] = iterator;
+
+			expect(first[0]).to.equal(length >= 1 ? 1 : 10);
+			expect(first[1]).to.equal(length >= 1 ? 99 : 11);
+			expect(second[0]).to.equal(length >= 2 ? 2 : 20);
+			expect(rest.size()).to.equal(length === 5 ? 2 : 0);
+			expect(calls).to.equal(length + 1);
+		}
+	});
+
+	it("should preserve tuple assignment defaults after an omitted element exhausts the iterator", () => {
+		let calls = 0;
+		const iterator = (() => {
+			calls++;
+			assert(calls === 1, "advanced after exhaustion");
+			return $tuple(undefined as number | undefined, 99);
+		}) as IterableFunction<LuaTuple<[number, number]>>;
+		let value: LuaTuple<[number, number]>;
+		let rest: Array<LuaTuple<[number, number]>>;
+
+		[, value = makePair(42, 43), , ...rest] = iterator;
+
+		expect(value[0]).to.equal(42);
+		expect(value[1]).to.equal(43);
+		expect(rest.size()).to.equal(0);
+		expect(calls).to.equal(1);
 	});
 
 	it("should collect the remaining values from iterator functions", () => {

--- a/tests/src/tests/enum.spec.ts
+++ b/tests/src/tests/enum.spec.ts
@@ -79,6 +79,7 @@ export = () => {
 	it("should support numeric const enums", () => {
 		expect(Person.Validark).to.equal(0);
 		expect(Person.Osyris).to.equal(1);
+		expect(Person["Osyris"]).to.equal(1);
 		expect(Person.Evaera).to.equal(2);
 		expect(Person.Vorlias).to.equal(3);
 		expect(Person.DataBrain).to.equal(4);
@@ -88,6 +89,7 @@ export = () => {
 	it("should support string const enums", () => {
 		expect(Animal.Bear).to.equal("BEAR");
 		expect(Animal.Dog).to.equal("DOG");
+		expect(Animal["Dog"]).to.equal("DOG");
 		expect(Animal.Snake).to.equal("SNAKE");
 		expect(Animal.$).to.equal("SCARAB");
 	});

--- a/tests/src/tests/function.spec.ts
+++ b/tests/src/tests/function.spec.ts
@@ -23,6 +23,35 @@ namespace N {
 }
 
 export = () => {
+	it("should destructure nested rest parameters without defaults", () => {
+		function add(...[[first], { second }]: [[number], { second: number }]) {
+			return first + second;
+		}
+
+		expect(add([1], { second: 2 })).to.equal(3);
+	});
+
+	it("should preserve a constrained generic callback in an object property", () => {
+		function call<T extends () => number>(callback: T) {
+			const object: { callback: () => number } = { callback };
+			return object.callback();
+		}
+
+		expect(call(() => 42)).to.equal(42);
+	});
+
+	it("should preserve omitted rest parameters and evaluate defaults lazily", () => {
+		let defaults = 0;
+		function read(...[, value = ++defaults]: [number, number?]) {
+			return value;
+		}
+
+		expect(read(10, 42)).to.equal(42);
+		expect(defaults).to.equal(0);
+		expect(read(10)).to.equal(1);
+		expect(defaults).to.equal(1);
+	});
+
 	it("should support function declarations", () => {
 		function foo() {
 			return true;

--- a/tests/src/tests/generator.spec.ts
+++ b/tests/src/tests/generator.spec.ts
@@ -1,4 +1,34 @@
 export = () => {
+	it("should distinguish a bare yield from completion", () => {
+		function* generate() {
+			yield;
+			return 42;
+		}
+
+		const iterator = generate();
+		const yielded = iterator.next();
+		expect(yielded.done).to.equal(false);
+		expect(yielded.value).to.equal(undefined);
+
+		const completed = iterator.next();
+		expect(completed.done).to.equal(true);
+		expect(completed.value).to.equal(42);
+	});
+
+	it("should support generator methods", () => {
+		class Counter {
+			constructor(private value: number) {}
+
+			*values() {
+				yield this.value;
+				yield ++this.value;
+			}
+		}
+
+		const values = [...new Counter(4).values()];
+		expect(values.join(",")).to.equal("4,5");
+	});
+
 	it("should support generator function declarations", () => {
 		function* foo() {
 			yield 1;

--- a/tests/src/tests/hoist.spec.ts
+++ b/tests/src/tests/hoist.spec.ts
@@ -1,4 +1,71 @@
 export = () => {
+	it("should preserve uninitialized bindings captured by earlier closures", () => {
+		const read = () => value;
+		let value: number | undefined;
+		expect(read()).to.equal(undefined);
+		value = 42;
+		expect(read()).to.equal(42);
+	});
+
+	it("should hoist declarations across default switch clauses", () => {
+		function read(input: number) {
+			switch (input) {
+				case 1:
+					return () => value;
+				default:
+					const value = 42;
+					return () => value;
+			}
+		}
+		expect(read(0)()).to.equal(42);
+		expect(read(1)()).to.equal(undefined);
+	});
+
+	it("should hoist async functions referenced by earlier closures", () => {
+		function read() {
+			return value();
+		}
+		async function value() {
+			return 42;
+		}
+
+		const [success, result] = read().await();
+		expect(success).to.equal(true);
+		expect(result).to.equal(42);
+	});
+
+	it("should hoist enums referenced by earlier closures", () => {
+		function read() {
+			return Choice.First;
+		}
+		function initialValue() {
+			return 42;
+		}
+		enum Choice {
+			First = initialValue(),
+		}
+
+		expect(read()).to.equal(42);
+	});
+
+	it("should hoist destructured bindings across switch cases", () => {
+		const results = new Array<number>();
+		function run(value: number) {
+			switch (value) {
+				case 0:
+					const [first, second] = [1, 2];
+					results.push(first);
+				case 1:
+					const read = () => results.push(first, second);
+					read();
+					break;
+			}
+		}
+
+		run(0);
+		expect(results.join(",")).to.equal("1,1,2");
+	});
+
 	it("should support variable hoisting", () => {
 		function test() {
 			expect(x).to.equal(1);

--- a/tests/src/tests/jsx.spec.tsx
+++ b/tests/src/tests/jsx.spec.tsx
@@ -1,0 +1,81 @@
+/** @jsx createElement */
+
+interface RenderedElement {
+	tag: string;
+	props: unknown;
+	children: Array<string | RenderedElement>;
+}
+
+function createElement(tag: string, props: unknown, ...children: Array<string | RenderedElement>): RenderedElement {
+	return { tag, props, children };
+}
+
+declare namespace createElement {
+	namespace JSX {
+		type Element = RenderedElement;
+
+		interface IntrinsicElements {
+			text: { "custom:value"?: number };
+			"custom:text": {};
+		}
+	}
+}
+
+export = () => {
+	it("should ignore a line containing only nonbreaking whitespace", () => {
+		// prettier-ignore
+		const element = <text> 
+		</text>;
+		expect(element.children.size()).to.equal(0);
+	});
+
+	it("should ignore trailing blank lines in JSX text", () => {
+		// prettier-ignore
+		const element = <text>value
+
+		</text>;
+		expect(element.children[0]).to.equal("value");
+		expect(element.children.size()).to.equal(1);
+	});
+
+	it("should preserve namespaced attribute names", () => {
+		const element = <text custom:value={42} />;
+
+		expect((element.props as { "custom:value": number })["custom:value"]).to.equal(42);
+	});
+
+	it("should decode JSX text entities and preserve literal backslashes", () => {
+		const element = <text>&amp;&lt;&gt;&quot;&apos;&#65;&#x42;&unknown;\path</text>;
+
+		expect(element.children[0]).to.equal("&<>\"'AB&unknown;\\path");
+	});
+
+	it("should preserve control characters decoded from JSX entities", () => {
+		const element = <text>&#0;1&#9;&#10;&#13;&#127;&#x1f;</text>;
+
+		expect(element.children[0]).to.equal("\x001\t\n\r\x7f\x1f");
+	});
+
+	it("should trim JSX lines while preserving spaces beside tags", () => {
+		// prettier-ignore
+		const element = <text> first
+			second
+
+			third </text>;
+
+		expect(element.children[0]).to.equal(" first second third ");
+	});
+
+	it("should ignore empty JSX expressions and whitespace-only lines", () => {
+		const element = (
+			<text>
+				{}
+				{/* an empty expression contributes no child */}
+				<custom:text />
+			</text>
+		);
+
+		expect(element.children.size()).to.equal(1);
+		expect((element.children[0] as RenderedElement).tag).to.equal("custom:text");
+	});
+};

--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -14,6 +14,137 @@ function difference<T>(set1: Set<T>, set2: Set<T>): Set<T> {
 }
 
 export = () => {
+	it("should retain loop finalizers around empty blocks and branches", () => {
+		const callbacks = new Array<() => number>();
+		const limit = 3;
+		for (let i = 0; i < limit; i++) {
+			if (i === 1) {
+			}
+			{
+			}
+			callbacks.push(() => i);
+		}
+		expect(callbacks.map(callback => callback()).join(",")).to.equal("0,1,2");
+	});
+
+	it("should iterate inferred tuples through declarations and assignment targets", () => {
+		let index = 0;
+		function advance() {
+			index++;
+			assert(index <= 3, "iterator was called after its first return value became nil");
+			return $tuple(index <= 2 ? index : undefined, index * 10);
+		}
+		const iterator = advance as IterableFunction<ReturnType<typeof advance>>;
+		let total = 0;
+		for (const pair of iterator) {
+			total += pair[1];
+		}
+		expect(total).to.equal(30);
+
+		index = 0;
+		let pair: ReturnType<typeof advance>;
+		for (pair of iterator) {
+			total += pair[1];
+		}
+		expect(total).to.equal(60);
+	});
+
+	it("should run loop increments around empty branches and blocks", () => {
+		const limit = 3;
+		let visits = 0;
+		for (let i = 0; i < limit; i++) {
+			if (i === 0) {
+			} else {
+				visits++;
+			}
+			{
+			}
+		}
+
+		expect(visits).to.equal(2);
+	});
+
+	it("should finalize captured loop variables before nested continues", () => {
+		const values = new Array<() => number>();
+		const visited = new Array<number>();
+		const limit = 4;
+		for (let i = 0; i < limit; i++) {
+			values.push(() => i);
+			if (i === 0) {
+				visited.push(i);
+				continue;
+			} else if (i === 1) {
+				continue;
+			} else {
+				{
+					if (i === 2) {
+						continue;
+					}
+					visited.push(i);
+					continue;
+				}
+			}
+		}
+
+		expect(values.map(read => read()).join(",")).to.equal("0,1,2,3");
+		expect(visited.join(",")).to.equal("0,3");
+	});
+
+	it("should retain the initializer binding captured by a loop initializer", () => {
+		const initial = new Array<() => number>();
+		const iterations = new Array<() => number>();
+		for (let i = 0, read = () => i; i < 3; i++) {
+			initial.push(read);
+			iterations.push(() => i);
+		}
+
+		expect(initial.map(read => read()).join(",")).to.equal("0,0,0");
+		expect(iterations.map(read => read()).join(",")).to.equal("0,1,2");
+	});
+
+	it("should collect nested loop bindings and omit skipped elements", () => {
+		const values = new Array<number>();
+		for (let [{ value }, , [other]] = [{ value: 0 }, 100, [2]] as const; value < 2; value++) {
+			values.push(value + other);
+		}
+
+		expect(values.join(",")).to.equal("2,3");
+	});
+
+	it("should retain loops with missing initializers or incrementors", () => {
+		const values = new Array<number>();
+		for (let i; (i = values.size()) < 2; i++) {
+			values.push(i);
+		}
+		for (let i = 2; i < 4; ) {
+			values.push(i++);
+		}
+		for (let i = 0; i > 10; i++) {
+			values.push(100);
+		}
+		for (let i = 0; i !== 2; i++) {
+			values.push(i);
+		}
+
+		expect(values.join(",")).to.equal("0,1,2,3,0,1");
+	});
+
+	it("should evaluate a negated do-while condition after each iteration", () => {
+		let iterations = 0;
+		let checks = 0;
+		function finished() {
+			checks++;
+			return iterations === 3 ? "done" : "";
+		}
+
+		do {
+			iterations++;
+		} while (!finished());
+
+		expect(iterations).to.equal(3);
+		expect(checks).to.equal(3);
+	});
+
 	it("should support numeric separators in loop bounds and steps", () => {
 		const ascending = new Array<number>();
 		for (let i = 0x0_0; i < 3_0; i += 1_0) {
@@ -476,7 +607,8 @@ export = () => {
 	});
 
 	it("should support iterator function with single return when indexing tuple as array", () => {
-		const shortIterator: IterableFunction<LuaTuple<[boolean]>> = (() => [true] as LuaTuple<[boolean]>) as never;
+		const shortIterator: IterableFunction<LuaTuple<[value: boolean]>> = (() =>
+			[true] as LuaTuple<[value: boolean]>) as never;
 
 		for (const tuple of shortIterator) {
 			expect(tuple.size()).to.equal(1);

--- a/tests/src/tests/macro_math.spec.ts
+++ b/tests/src/tests/macro_math.spec.ts
@@ -7,6 +7,8 @@ export = () => {
 		expect(value.idiv(2)).to.equal(5);
 		expect(value.idiv(3)).to.equal(3);
 		expect(value.idiv(4)).to.equal(2);
+		const divisor = 2;
+		expect(value.idiv(divisor + 1)).to.equal(3);
 	});
 
 	it("should support CFrame * CFrame = CFrame", () => {

--- a/tests/src/tests/map.spec.ts
+++ b/tests/src/tests/map.spec.ts
@@ -1,4 +1,22 @@
 export = () => {
+	it("should iterate with omitted keys and assignment patterns", () => {
+		const map = new Map([["key", 42]]);
+		let defaults = 0;
+		for (const [, value = ++defaults] of map) {
+			expect(value).to.equal(42);
+		}
+		expect(defaults).to.equal(0);
+
+		let key = "";
+		let value = 0;
+		for ([key, value] of map) {
+			expect(key).to.equal("key");
+			expect(value).to.equal(42);
+		}
+		expect(key).to.equal("key");
+		expect(value).to.equal(42);
+	});
+
 	it("should support map constructor", () => {
 		const map = new Map([
 			["foo", 1],
@@ -53,7 +71,7 @@ export = () => {
 
 	it("should support clear", () => {
 		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
-		map.clear();
+		expect(map.clear()).to.equal(undefined);
 		expect(map.has("a")).to.equal(false);
 		expect(map.has("b")).to.equal(false);
 		expect(map.has("c")).to.equal(false);
@@ -70,7 +88,7 @@ export = () => {
 
 		const map = new Map<string, number>().set("a", 1).set("b", 2).set("c", 3);
 
-		map.forEach((value, key, obj) => {
+		const result = map.forEach((value, key, obj) => {
 			if (key === "a" && value === 1) {
 				hitA++;
 			} else if (key === "b" && value === 2) {
@@ -84,6 +102,8 @@ export = () => {
 		expect(hitA).to.equal(1);
 		expect(hitB).to.equal(1);
 		expect(hitC).to.equal(1);
+		expect(result).to.equal(undefined);
+		map.forEach((value, key) => expect(map.get(key)).to.equal(value));
 	});
 
 	it("should support constructor parameters", () => {

--- a/tests/src/tests/moduleSyntax.spec.ts
+++ b/tests/src/tests/moduleSyntax.spec.ts
@@ -1,3 +1,8 @@
+import "./moduleSyntax/sideEffect";
+import { effects } from "./moduleSyntax/effects";
+import anonymous from "./moduleSyntax/defaultAnonymous";
+import DefaultClass from "./moduleSyntax/defaultClass";
+import named from "./moduleSyntax/defaultNamed";
 import * as directReExport from "./moduleSyntax/quotedDirectReExport";
 import {
 	"" as empty,
@@ -18,12 +23,76 @@ import {
 } from "./moduleSyntax/quotedReExport";
 // type-only import (import type {...}) -> transformImportDeclaration phaseModifier branch
 import type { RenamedType } from "./moduleSyntax/renamedExport";
-import { plain, renamedValue } from "./moduleSyntax/renamedExport";
+import * as declared from "./moduleSyntax/renamedExport";
+import { plain, prototype as prototypeValue, renamedValue } from "./moduleSyntax/renamedExport";
+import * as star from "./moduleSyntax/starExport";
+import Shape = require("./moduleSyntax/typeExport");
+import type TypeOnlyValue = require("./moduleSyntax/typeOnlyValue");
+import * as typeOnly from "./moduleSyntax/typeOnlyReExport";
 
 const typed: RenamedType = renamedValue;
 
 export = () => {
+	it("should execute imports used only for side effects", () => {
+		const shape: Shape = { value: effects.size() };
+
+		expect(shape.value).to.equal(1);
+		expect(effects[0]).to.equal("loaded");
+	});
+
+	it("should resolve module trees without a regular import", () => {
+		let [instance, parts] = $getModuleTree("./moduleSyntax/moduleTree");
+		for (const part of parts) {
+			instance = instance.WaitForChild(part);
+		}
+		const module = require(instance as ModuleScript) as { value: number };
+
+		expect(module.value).to.equal(42);
+	});
+
+	it("should preserve named and anonymous default exports", () => {
+		expect(named()).to.equal(42);
+		expect(anonymous()).to.equal(43);
+		expect(new DefaultClass().value).to.equal(44);
+	});
+
+	it("should re-export values and elide type-only re-exports", () => {
+		const value: star.ImplicitType = star.renamedValue;
+
+		expect(value).to.equal(1);
+		expect(star.plain).to.equal(2);
+		expect("RenamedType" in star).to.equal(false);
+		expect("ImplicitType" in star).to.equal(false);
+		expect("absent" in star).to.equal(false);
+		expect(star.game).to.equal(game);
+	});
+
+	it("should initialize exported variables that have no initializer", () => {
+		expect(declared.later).to.equal(undefined);
+		declared.initializeLater();
+		expect(declared.later).to.equal(42);
+		expect(prototypeValue).to.equal(42);
+	});
+
+	it("should keep runtime export aliases separate from type-only aliases", () => {
+		expect(typeOnly.live).to.equal(2);
+		expect(typeOnly.read()).to.equal(2);
+		expect("hidden" in typeOnly).to.equal(false);
+		expect("Value" in typeOnly).to.equal(false);
+		expect("default" in typeOnly).to.equal(false);
+	});
+
+	it("should resolve dynamic imports", () => {
+		const [success, value] = import("./moduleSyntax/renamedExport").await();
+
+		expect(success).to.equal(true);
+		assert(success);
+		expect(value.plain).to.equal(2);
+	});
+
 	it("should support type-only imports and renamed exports", () => {
+		const object: TypeOnlyValue = { value: 42 };
+		expect(object.value).to.equal(42);
 		expect(typed).to.equal(1);
 		expect(renamedValue).to.equal(1);
 		expect(plain).to.equal(2);

--- a/tests/src/tests/moduleSyntax/defaultAnonymous.ts
+++ b/tests/src/tests/moduleSyntax/defaultAnonymous.ts
@@ -1,0 +1,3 @@
+export default function () {
+	return 43;
+}

--- a/tests/src/tests/moduleSyntax/defaultClass.ts
+++ b/tests/src/tests/moduleSyntax/defaultClass.ts
@@ -1,0 +1,3 @@
+export default class {
+	value = 44;
+}

--- a/tests/src/tests/moduleSyntax/defaultNamed.ts
+++ b/tests/src/tests/moduleSyntax/defaultNamed.ts
@@ -1,0 +1,3 @@
+export default function read() {
+	return 42;
+}

--- a/tests/src/tests/moduleSyntax/effects.ts
+++ b/tests/src/tests/moduleSyntax/effects.ts
@@ -1,0 +1,1 @@
+export const effects = new Array<string>();

--- a/tests/src/tests/moduleSyntax/moduleTree.ts
+++ b/tests/src/tests/moduleSyntax/moduleTree.ts
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/tests/src/tests/moduleSyntax/renamedExport.ts
+++ b/tests/src/tests/moduleSyntax/renamedExport.ts
@@ -7,3 +7,14 @@ export { renamed as renamedValue };
 export { plain };
 
 export type RenamedType = number;
+
+export declare const absent: number;
+declare const game: DataModel;
+export { game };
+
+export let later: number | undefined;
+export function initializeLater() {
+	later = 42;
+}
+
+export const prototype = 42;

--- a/tests/src/tests/moduleSyntax/sideEffect.ts
+++ b/tests/src/tests/moduleSyntax/sideEffect.ts
@@ -1,0 +1,3 @@
+import { effects } from "./effects";
+
+effects.push("loaded");

--- a/tests/src/tests/moduleSyntax/starExport.ts
+++ b/tests/src/tests/moduleSyntax/starExport.ts
@@ -1,0 +1,3 @@
+export * from "./renamedExport";
+export { plain as mixedValue, type RenamedType } from "./renamedExport";
+export { RenamedType as ImplicitType } from "./renamedExport";

--- a/tests/src/tests/moduleSyntax/typeExport.ts
+++ b/tests/src/tests/moduleSyntax/typeExport.ts
@@ -1,0 +1,5 @@
+interface Shape {
+	value: number;
+}
+
+export = Shape;

--- a/tests/src/tests/moduleSyntax/typeOnlyReExport.ts
+++ b/tests/src/tests/moduleSyntax/typeOnlyReExport.ts
@@ -1,0 +1,13 @@
+import type Value = require("./typeOnlyValue");
+
+export { Value };
+export default Value;
+
+let value = 1;
+export { value as live };
+export type { value as hidden };
+value = 2;
+
+export function read() {
+	return value;
+}

--- a/tests/src/tests/moduleSyntax/typeOnlyValue.ts
+++ b/tests/src/tests/moduleSyntax/typeOnlyValue.ts
@@ -1,0 +1,9 @@
+import { effects } from "./effects";
+
+effects.push("type-only module executed");
+
+class TypeOnlyValue {
+	value = 0;
+}
+
+export = TypeOnlyValue;

--- a/tests/src/tests/namespace.spec.ts
+++ b/tests/src/tests/namespace.spec.ts
@@ -1,5 +1,40 @@
+function readNamespace() {
+	return n1.a;
+}
+
+interface n1 {
+	value: number;
+}
+
+declare namespace n1 {
+	interface DeclaredShape {
+		value: number;
+	}
+}
+
+namespace TypesOnly {
+	export interface Shape {
+		value: number;
+	}
+}
+
 namespace n1 {
+	export declare const absent: number;
 	export const a = "a";
+	export function read(value: string): string;
+	export function read(value: string) {
+		return value;
+	}
+	export interface Shape {
+		value: number;
+	}
+	export const Shape = { value: 42 };
+	export type Label = string;
+	export const Label = "label";
+}
+
+namespace dotted.inner {
+	export const value = 42;
 }
 
 namespace n2 {
@@ -16,9 +51,39 @@ namespace foo {
 	}
 }
 
+let namespaceEffects = 0;
+namespace Empty {
+	namespaceEffects++;
+}
+namespace WithFunction {
+	export function value() {
+		return 42;
+	}
+}
+namespace Nested.Self {
+	export function value() {
+		return Self;
+	}
+}
+
 export = () => {
+	it("should execute namespaces without exports", () => {
+		expect(namespaceEffects).to.equal(1);
+		expect(WithFunction.value()).to.equal(42);
+		expect(Nested.Self.value()).to.equal(Nested.Self);
+	});
+
 	it("should support namespaces", () => {
+		const typed: TypesOnly.Shape & n1.DeclaredShape & n1 = { value: 42 };
+
+		expect(typed.value).to.equal(42);
+		expect("absent" in n1).to.equal(false);
 		expect(n1.a).to.equal("a");
+		expect(readNamespace()).to.equal("a");
+		expect(n1.read("value")).to.equal("value");
+		expect(n1.Shape.value).to.equal(42);
+		expect(n1.Label).to.equal("label");
+		expect(dotted.inner.value).to.equal(42);
 	});
 
 	it("should support nested namespaces", () => {

--- a/tests/src/tests/object.spec.ts
+++ b/tests/src/tests/object.spec.ts
@@ -1,4 +1,5 @@
 declare const self: undefined;
+declare const objectBrand: unique symbol;
 
 namespace N {
 	export let x = 5;
@@ -6,6 +7,32 @@ namespace N {
 }
 
 export = () => {
+	it("should preserve methods in directly spread object literals", () => {
+		const object = {
+			...{
+				value() {
+					return 42;
+				},
+			},
+		};
+		expect(object.value()).to.equal(42);
+	});
+
+	it("should spread objects with optional nominal properties", () => {
+		interface Branded {
+			readonly [objectBrand]?: never;
+			value: number;
+		}
+		function copy(value: Branded): Branded {
+			return { ...value };
+		}
+
+		const original: Branded = { value: 42 };
+		const result = copy(original);
+		expect(result.value).to.equal(42);
+		expect(result).never.to.equal(original);
+	});
+
 	it("should support object literal brackets", () => {
 		/* prettier-ignore */
 		const obj = {
@@ -117,6 +144,10 @@ export = () => {
 		expect(bar.d).to.equal(4);
 		expect(bar.e).to.equal(5);
 		expect(bar.f).to.equal(6);
+
+		const narrowed: { a: number } = { ...foo };
+		expect(narrowed.a).to.equal(1);
+		expect("b" in narrowed).to.equal(true);
 	});
 
 	it("should support spread with non-objects", () => {

--- a/tests/src/tests/promise.spec.ts
+++ b/tests/src/tests/promise.spec.ts
@@ -1,4 +1,13 @@
 export = () => {
+	it("should lower Promise.then to andThen", () => {
+		const [success, value] = Promise.resolve(1)
+			.then(value => value + 1)
+			.await();
+
+		expect(success).to.equal(true);
+		expect(value).to.equal(2);
+	});
+
 	it("should allow async function declarations", () => {
 		async function foo() {
 			return "foo";

--- a/tests/src/tests/roblox.spec.ts
+++ b/tests/src/tests/roblox.spec.ts
@@ -1,6 +1,8 @@
 export = () => {
 	it("should support using the Roblox API", () => {
 		expect(game.FindFirstChild("Workspace")).to.equal(game.GetService("Workspace"));
+		expect(classIs(game.GetService("Workspace"), "Workspace")).to.equal(true);
+		expect(classIs(new Instance("Part"), "Folder")).to.equal(false);
 	});
 
 	it("should support calling Roblox API methods with element expressions", () => {

--- a/tests/src/tests/set.spec.ts
+++ b/tests/src/tests/set.spec.ts
@@ -164,7 +164,7 @@ export = () => {
 		let hitC = 0;
 
 		const set = new Set<string>().add("a").add("b").add("c");
-		set.forEach((value, value2, obj) => {
+		const result = set.forEach((value, value2, obj) => {
 			expect(value).to.equal(value2);
 			expect(obj).to.equal(set);
 			if (value === "a") {
@@ -178,6 +178,8 @@ export = () => {
 		expect(hitA).to.equal(1);
 		expect(hitB).to.equal(1);
 		expect(hitC).to.equal(1);
+		expect(result).to.equal(undefined);
+		set.forEach(value => expect(set.has(value)).to.equal(true));
 	});
 
 	it("should support size", () => {

--- a/tests/src/tests/switch.spec.ts
+++ b/tests/src/tests/switch.spec.ts
@@ -1,4 +1,62 @@
 export = () => {
+	it("should compare allocated case values by identity and preserve operand order", () => {
+		const events = new Array<string>();
+		function value() {
+			events.push("value");
+			return 1;
+		}
+		function key() {
+			events.push("key");
+			return "key";
+		}
+		function classify(input: unknown) {
+			switch (input) {
+				case () => 1:
+				case [1]:
+				case [value()]:
+				case new Set([1]):
+				case new Set([value()]):
+				case { key: 1 }:
+				case { [key()]: 1 }:
+				case { key: value() }:
+				case -1:
+				case -value():
+					return "matched";
+				default:
+					return "different";
+			}
+		}
+
+		expect(classify({ key: 1 })).to.equal("different");
+		expect(events.join(",")).to.equal("value,value,key,value,value");
+	});
+
+	it("should evaluate conditional case values against the original discriminant", () => {
+		let mutable = 1;
+		function classify(input: number) {
+			switch (input) {
+				case true ? 0 : 1:
+					return "zero";
+				case true ? mutable : 0:
+					return "first";
+				case false ? 0 : mutable + 1:
+					return "second";
+				// prettier-ignore
+				case (mutable + 2):
+					mutable = 10;
+					return "third";
+				default:
+					return "missing";
+			}
+		}
+
+		expect(classify(0)).to.equal("zero");
+		expect(classify(1)).to.equal("first");
+		expect(classify(2)).to.equal("second");
+		expect(classify(3)).to.equal("third");
+		expect(mutable).to.equal(10);
+	});
+
 	it("should support switch statements with fall through", () => {
 		function foo(s: string) {
 			switch (s) {

--- a/tests/src/tests/truthiness.spec.ts
+++ b/tests/src/tests/truthiness.spec.ts
@@ -1,4 +1,28 @@
 export = () => {
+	it("should preserve a defined return value passed through a macro", () => {
+		function value(): defined {
+			return 42;
+		}
+
+		expect(identity(value())).to.equal(42);
+	});
+
+	it("should support truthiness of template literal types", () => {
+		function numberText(value: `${number}`) {
+			return !!value;
+		}
+		function prefixed(value: `prefix${number}`) {
+			return !!value;
+		}
+		function suffixed(value: `${number}suffix`) {
+			return !!value;
+		}
+
+		expect(numberText("0")).to.equal(true);
+		expect(prefixed("prefix0")).to.equal(true);
+		expect(suffixed("0suffix")).to.equal(true);
+	});
+
 	it("should support JS truthiness", () => {
 		function isTruthy(x?: unknown) {
 			const y = !!x;

--- a/tests/src/tests/try.spec.ts
+++ b/tests/src/tests/try.spec.ts
@@ -1,4 +1,20 @@
 export = () => {
+	it("should preserve a bare return through finally", () => {
+		const events = new Array<string>();
+		function run() {
+			try {
+				events.push("try");
+				return;
+			} finally {
+				events.push("finally");
+			}
+			events.push("after");
+		}
+
+		expect(run()).to.equal(undefined);
+		expect(events.join(",")).to.equal("try,finally");
+	});
+
 	it("should support try/catch", () => {
 		let x: number = 123;
 		try {

--- a/tests/src/tests/tuple.spec.ts
+++ b/tests/src/tests/tuple.spec.ts
@@ -1,4 +1,18 @@
 export = () => {
+	it("should discard tuple results in for clauses and void expressions", () => {
+		let calls = 0;
+		function values() {
+			return $tuple(++calls, "value");
+		}
+		for (values(); calls < 3; values()) {
+			expect(calls < 3).to.equal(true);
+		}
+		const ignored = void values();
+
+		expect(calls).to.equal(4);
+		expect(ignored).to.equal(undefined);
+	});
+
 	it("should support numeric separators in tuple return indices", () => {
 		function values(): LuaTuple<[number, number]> {
 			return $tuple(123, 456);

--- a/tests/src/tests/typeof.spec.ts
+++ b/tests/src/tests/typeof.spec.ts
@@ -1,4 +1,17 @@
 export = () => {
+	it("should inspect method types without calling the methods", () => {
+		let calls = 0;
+		const object = {
+			method() {
+				calls++;
+			},
+		};
+
+		expect(typeIs(object.method, "function")).to.equal(true);
+		expect(typeOf(object.method)).to.equal("function");
+		expect(calls).to.equal(0);
+	});
+
 	it("should support typeOf", () => {
 		expect(typeOf({})).to.equal("table");
 		expect(typeOf(undefined)).to.equal("nil");


### PR DESCRIPTION
- Erase type-only import-equals declarations and exports without loading modules or redirecting writes to live bindings.
- Support iterator rest destructuring, preserve iterator sources across rebinding and nested defaults, and evaluate assignment targets before collecting rest values. Remember exhaustion across preceding elements and rest, including omitted elements and tuple defaults. Stop tuple loops and spreads when the first return is `nil`, even if later returns contain values.
- Escape quotes and control characters decoded from JSX text while preserving literal backslashes.
- Detect augmented macro methods without runtime implementations, preserve exhaustive assertion messages when npm lookup fails, and correct TypeScript 5.9 syntax-kind names.
- Expand runtime, diagnostic, and emitted-Luau regression coverage, including previously excluded transformer utilities.

Local validation: 579 compiler tests, 121 snapshots, and 767 runtime tests passed. Original-versus-patched reproducers cover the retained fixes; 36 comparisons of previously supported destructuring produced identical runtime results. Full lint reports two existing formatting warnings in `createTransformerList.ts` and `transformOptionalChain.ts`.
