### PR TITLE
Cover CLI and LogService

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
 		"^(Project|Shared|CLI|TSTransformer)/(.*)$": "<rootDir>/src/$1/$2",
 		"^(Project|Shared|CLI|TSTransformer)$": "<rootDir>/src/$1",
 	},
-	collectCoverageFrom: ["src/**/*.ts", "!src/CLI/**", "!src/Shared/classes/LogService.ts"],
+	collectCoverageFrom: ["src/**/*.ts", "!src/Shared/classes/LogService.ts"],
 	coverageDirectory: "coverage",
 	coverageReporters: ["json", "lcov", "text"],
 	verbose: true,

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
 		"^(Project|Shared|CLI|TSTransformer)/(.*)$": "<rootDir>/src/$1/$2",
 		"^(Project|Shared|CLI|TSTransformer)$": "<rootDir>/src/$1",
 	},
-	collectCoverageFrom: ["src/**/*.ts", "!src/Shared/classes/LogService.ts"],
+	collectCoverageFrom: ["src/**/*.ts"],
 	coverageDirectory: "coverage",
 	coverageReporters: ["json", "lcov", "text"],
 	verbose: true,

--- a/tests/compiler/cli/build.test.ts
+++ b/tests/compiler/cli/build.test.ts
@@ -1,0 +1,161 @@
+import buildCommand from "CLI/commands/build";
+import { CLIError } from "CLI/errors/CLIError";
+import { ProjectBuild } from "Project/classes/ProjectBuild";
+import * as watch from "Project/functions/setupProjectWatchProgram";
+import { LogService } from "Shared/classes/LogService";
+import ts from "typescript";
+import type yargs from "yargs";
+
+import { ReferenceFixture } from "../referenceFixture";
+
+let fixture: ReferenceFixture;
+let output: string;
+const originalExitCode = process.exitCode;
+const originalVerbose = LogService.verbose;
+
+beforeEach(() => {
+	fixture = new ReferenceFixture();
+	fixture.project("game");
+	output = "";
+	process.exitCode = undefined;
+	jest.spyOn(ts.sys, "write").mockImplementation(message => {
+		output += message;
+	});
+	jest.spyOn(LogService, "writeLine").mockImplementation((...messages) => {
+		output += messages.join("\n");
+	});
+});
+
+afterEach(() => {
+	fixture.close();
+	process.exitCode = originalExitCode;
+	LogService.verbose = originalVerbose;
+	jest.restoreAllMocks();
+});
+
+async function build(project = "game", options = {}) {
+	await buildCommand.handler({
+		_: [],
+		$0: "rbxtsc",
+		project: fixture.file(project),
+		...fixture.options(),
+		...options,
+	});
+}
+
+it.each(["game", "game/tsconfig.json", "game/src"])("finds the project configuration from %s", async project => {
+	const close = jest.spyOn(ProjectBuild.prototype, "close");
+
+	await build(project);
+
+	expect(fixture.read("out/game/init.luau")).toContain("local value = 1");
+	expect(process.exitCode).toBeUndefined();
+	expect(close).toHaveBeenCalledTimes(1);
+});
+
+it.each(["missing", "."])("reports a missing configuration for %s", async project => {
+	await build(project);
+
+	expect(output).toContain("Unable to find tsconfig.json!");
+	expect(process.exitCode).toBe(1);
+});
+
+it("reports compiler errors and closes the build", async () => {
+	fixture.write("game/src/index.ts", 'export const value: number = "invalid";');
+	const close = jest.spyOn(ProjectBuild.prototype, "close");
+
+	await build();
+
+	expect(output).toContain("Type 'string' is not assignable to type 'number'");
+	expect(process.exitCode).toBe(1);
+	expect(close).toHaveBeenCalledTimes(1);
+});
+
+it("reports warnings without making the command fail", async () => {
+	fixture.write("game/src/index.ts", "export function truthy(value: number) { return !!value; }");
+
+	await build("game", { logTruthyChanges: true });
+
+	expect(output).toContain("Value will be checked against 0, NaN");
+	expect(fixture.read("out/game/init.luau")).toContain("local function truthy");
+	expect(process.exitCode).toBeUndefined();
+});
+
+it.each([false, true])("passes polling=%s to watch mode and leaves the build open", async usePolling => {
+	const setup = jest.spyOn(watch, "setupProjectWatchProgram").mockImplementation(build => {
+		return { close: async () => build.close() };
+	});
+	const compile = jest.spyOn(ProjectBuild.prototype, "build");
+	const close = jest.spyOn(ProjectBuild.prototype, "close");
+
+	try {
+		await build("game", { watch: true, usePolling, verbose: true });
+
+		expect(setup).toHaveBeenCalledWith(expect.any(ProjectBuild), usePolling);
+		expect(compile).not.toHaveBeenCalled();
+		expect(close).not.toHaveBeenCalled();
+		expect(LogService.verbose).toBe(true);
+	} finally {
+		for (const [build] of setup.mock.calls) {
+			build.close();
+		}
+	}
+});
+
+it("logs expected build failures and closes the build", async () => {
+	jest.spyOn(ProjectBuild.prototype, "build").mockImplementation(() => {
+		throw new CLIError("build failed");
+	});
+	const close = jest.spyOn(ProjectBuild.prototype, "close");
+
+	await build();
+
+	expect(output).toContain("build failed");
+	expect(process.exitCode).toBe(1);
+	expect(close).toHaveBeenCalledTimes(1);
+});
+
+it("rethrows unexpected build failures after closing the build", async () => {
+	const error = new Error("unexpected failure");
+	jest.spyOn(ProjectBuild.prototype, "build").mockImplementation(() => {
+		throw error;
+	});
+	const close = jest.spyOn(ProjectBuild.prototype, "close");
+
+	await expect(build()).rejects.toBe(error);
+
+	expect(process.exitCode).toBe(1);
+	expect(close).toHaveBeenCalledTimes(1);
+});
+
+it("registers build flags without overriding project defaults", () => {
+	const option = jest.fn().mockReturnThis();
+	const parser = { option } as unknown as yargs.Argv;
+	if (typeof buildCommand.builder !== "function") {
+		throw new Error("Expected a build command builder");
+	}
+
+	buildCommand.builder(parser);
+
+	expect(option.mock.calls.map(([name]) => name)).toEqual([
+		"project",
+		"watch",
+		"usePolling",
+		"verbose",
+		"noInclude",
+		"logTruthyChanges",
+		"writeOnlyChanged",
+		"writeTransformedFiles",
+		"optimizedLoops",
+		"type",
+		"includePath",
+		"rojo",
+		"allowCommentDirectives",
+		"luau",
+	]);
+	expect(option).toHaveBeenCalledWith("project", expect.objectContaining({ alias: "p", default: "." }));
+	expect(option).toHaveBeenCalledWith("usePolling", expect.objectContaining({ implies: "watch" }));
+	for (const [, configuration] of option.mock.calls.slice(1)) {
+		expect(configuration).not.toHaveProperty("default");
+	}
+});

--- a/tests/compiler/cli/cli.test.ts
+++ b/tests/compiler/cli/cli.test.ts
@@ -1,0 +1,92 @@
+import { CLIError } from "CLI/errors/CLIError";
+import { LogService } from "Shared/classes/LogService";
+import { COMPILER_VERSION, PACKAGE_ROOT } from "Shared/constants";
+
+const originalExitCode = process.exitCode;
+
+afterEach(() => {
+	process.exitCode = originalExitCode;
+	jest.restoreAllMocks();
+	jest.dontMock("yargs/yargs");
+	jest.dontMock("yargs/helpers");
+	jest.dontMock("CLI/errors/CLIError");
+	jest.dontMock("Shared/classes/LogService");
+});
+
+function loadCli() {
+	const catchError = jest.fn();
+	const parser = {
+		usage: jest.fn().mockReturnThis(),
+		help: jest.fn().mockReturnThis(),
+		alias: jest.fn().mockReturnThis(),
+		describe: jest.fn().mockReturnThis(),
+		version: jest.fn().mockReturnThis(),
+		commandDir: jest.fn().mockReturnThis(),
+		recommendCommands: jest.fn().mockReturnThis(),
+		strict: jest.fn().mockReturnThis(),
+		wrap: jest.fn().mockReturnThis(),
+		terminalWidth: jest.fn().mockReturnValue(80),
+		fail: jest.fn().mockReturnThis(),
+		parseAsync: jest.fn().mockReturnValue({ catch: catchError }),
+	};
+	const createParser = jest.fn().mockReturnValue(parser);
+	jest.isolateModules(() => {
+		// native CLI tests exercise real yargs; isolate its ESM entry point for error-handler tests
+		jest.doMock("yargs/yargs", () => createParser);
+		jest.doMock("yargs/helpers", () => ({ hideBin: (argv: Array<string>) => argv.slice(2) }));
+		jest.doMock("CLI/errors/CLIError", () => ({ CLIError }));
+		jest.doMock("Shared/classes/LogService", () => ({ LogService }));
+		jest.requireActual("CLI/cli");
+	});
+	return {
+		parser,
+		createParser,
+		fail: parser.fail.mock.calls[0][0] as (message?: string) => void,
+		catchError: catchError.mock.calls[0][0] as (error: unknown) => void,
+	};
+}
+
+it("configures strict command discovery, help, version, and asynchronous parsing", () => {
+	const { parser, createParser } = loadCli();
+
+	expect(createParser).toHaveBeenCalledWith(process.argv.slice(2));
+	expect(parser.commandDir).toHaveBeenCalledWith(`${PACKAGE_ROOT}/out/CLI/commands`);
+	expect(parser.version).toHaveBeenCalledWith(COMPILER_VERSION);
+	expect(parser.help).toHaveBeenCalledWith("help");
+	expect(parser.strict).toHaveBeenCalledTimes(1);
+	expect(parser.wrap).toHaveBeenCalledWith(80);
+	expect(parser.parseAsync).toHaveBeenCalledTimes(1);
+});
+
+it.each([undefined, "invalid flag"])("marks parser failures unsuccessful with message %s", message => {
+	const fatal = jest.spyOn(LogService, "fatal").mockImplementation(() => {
+		throw new Error("exit");
+	});
+	const { fail } = loadCli();
+	if (message) {
+		expect(() => fail(message)).toThrow("exit");
+		expect(fatal).toHaveBeenCalledWith(message);
+	} else {
+		fail(message);
+		expect(fatal).not.toHaveBeenCalled();
+	}
+	expect(process.exitCode).toBe(1);
+});
+
+it("logs CLI errors rejected by the parser", () => {
+	const error = new CLIError("invalid command");
+	const log = jest.spyOn(error, "log").mockImplementation(() => {});
+	const { catchError } = loadCli();
+
+	catchError(error);
+
+	expect(log).toHaveBeenCalledTimes(1);
+	expect(error.toString()).toContain("invalid command");
+});
+
+it("rethrows unexpected parser failures", () => {
+	const error = new Error("unexpected parser failure");
+	const { catchError } = loadCli();
+
+	expect(() => catchError(error)).toThrow(error);
+});

--- a/tests/compiler/cli/entryPoints.test.ts
+++ b/tests/compiler/cli/entryPoints.test.ts
@@ -1,0 +1,17 @@
+import * as browser from "CLI/browser";
+import * as node from "CLI/index";
+import * as project from "Project";
+import { COMPILER_VERSION } from "Shared/constants";
+
+it("exposes the project API and compiler version from the Node entry point", () => {
+	for (const [name, value] of Object.entries(project)) {
+		expect(node).toHaveProperty(name, value);
+	}
+	expect(node.COMPILER_VERSION).toBe(COMPILER_VERSION);
+});
+
+it("exposes the virtual compiler and version from the browser entry point", () => {
+	expect(browser.VirtualProject).toBe(project.VirtualProject);
+	expect(browser.COMPILER_VERSION).toBe(COMPILER_VERSION);
+	expect(Object.keys(browser).sort()).toEqual(["COMPILER_VERSION", "VirtualProject"]);
+});

--- a/tests/compiler/cli/native.test.ts
+++ b/tests/compiler/cli/native.test.ts
@@ -1,0 +1,98 @@
+import { spawnSync } from "child_process";
+import fs from "fs-extra";
+import path from "path";
+import { COMPILER_VERSION, PACKAGE_ROOT } from "Shared/constants";
+
+import { ReferenceFixture } from "../referenceFixture";
+
+jest.setTimeout(30000);
+
+function run(args: Array<string>, cwd = PACKAGE_ROOT) {
+	const result = spawnSync(process.execPath, [path.join(PACKAGE_ROOT, "out/CLI/cli.js"), ...args], {
+		cwd,
+		encoding: "utf8",
+		timeout: 20000,
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	expect(result.signal).toBeNull();
+	return { status: result.status, output: result.stdout + result.stderr };
+}
+
+it("prints help with public flags and hides internal options", () => {
+	const result = run(["--help"]);
+
+	expect(result.status).toBe(0);
+	expect(result.output).toContain("A TypeScript-to-Luau Compiler for Roblox");
+	expect(result.output).toContain("--project");
+	expect(result.output).toContain("--usePolling");
+	expect(result.output).not.toContain("--writeTransformedFiles");
+});
+
+it("prints the compiler version", () => {
+	const result = run(["-v"]);
+
+	expect(result.status).toBe(0);
+	expect(result.output.trim()).toBe(COMPILER_VERSION);
+});
+
+it.each([
+	[["--invalid-option"], "Unknown argument"],
+	[["--usePolling"], "watch"],
+	[["--type", "invalid"], "Invalid values"],
+])("rejects invalid command arguments %j", (args, message) => {
+	const result = run(args);
+
+	expect(result.status).toBe(1);
+	expect(result.output).toContain(message);
+});
+
+it.each([false, true])("builds a project through the native CLI (explicit command: %s)", explicit => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game");
+		const result = run(
+			[
+				...(explicit ? ["build", "-p", fixture.file("game/tsconfig.json")] : []),
+				"--rojo",
+				fixture.file("default.project.json"),
+				"-i",
+				fixture.file("include"),
+				"--noInclude",
+				"--luau=false",
+			],
+			fixture.file("game"),
+		);
+
+		expect(result.status).toBe(0);
+		expect(fixture.read("out/game/init.lua")).toContain("local value = 1");
+		expect(fs.existsSync(fixture.file("include/RuntimeLib.lua"))).toBe(false);
+	} finally {
+		fixture.close();
+	}
+});
+
+it.each([false, true])("prints build errors and exits unsuccessfully (missing configuration: %s)", missing => {
+	const fixture = new ReferenceFixture();
+	try {
+		fixture.project("game");
+		fixture.write("game/src/index.ts", 'export const value: number = "invalid";');
+		const result = run([
+			"-p",
+			fixture.file(missing ? "missing" : "game"),
+			"--rojo",
+			fixture.file("default.project.json"),
+			"-i",
+			fixture.file("include"),
+		]);
+
+		expect(result.status).toBe(1);
+		expect(result.output).toContain(
+			missing ? "Unable to find tsconfig.json!" : "Type 'string' is not assignable to type 'number'",
+		);
+		expect(fs.existsSync(fixture.file("out/game/init.luau"))).toBe(false);
+	} finally {
+		fixture.close();
+	}
+});

--- a/tests/compiler/cli/patchFs.test.ts
+++ b/tests/compiler/cli/patchFs.test.ts
@@ -1,0 +1,43 @@
+import fs from "fs-extra";
+
+afterEach(() => {
+	jest.dontMock("fs-extra");
+});
+
+function patch(filesystem: Record<string, unknown>) {
+	jest.isolateModules(() => {
+		jest.doMock("fs-extra", () => filesystem);
+		jest.requireActual("CLI/util/patchFs");
+	});
+	return filesystem as unknown as typeof fs;
+}
+
+it("preserves every existing filesystem implementation", () => {
+	const original = { ...fs };
+	const filesystem = { ...original };
+
+	patch(filesystem);
+
+	expect(filesystem).toEqual(original);
+});
+
+it("provides callable filesystem fallbacks for the browser", async () => {
+	const filesystem = patch({});
+
+	await expect(filesystem.copy("source", "target")).resolves.toBeUndefined();
+	expect(filesystem.copySync("source", "target")).toBeUndefined();
+	expect(filesystem.existsSync("missing")).toBe(false);
+	await expect(filesystem.outputFile("file", "text")).resolves.toBeUndefined();
+	expect(filesystem.outputFileSync("file", "text")).toBeUndefined();
+	await expect(filesystem.pathExists("missing")).resolves.toBe(false);
+	expect(filesystem.pathExistsSync("missing")).toBe(false);
+	await expect(filesystem.readdir("directory")).resolves.toEqual([]);
+	expect(filesystem.readdirSync("directory")).toEqual([]);
+	expect(filesystem.readFileSync("file")).toEqual(Buffer.from(""));
+	await expect(filesystem.readJson("file")).resolves.toBeUndefined();
+	expect(filesystem.readJSONSync("file")).toBeUndefined();
+	expect(filesystem.realpathSync("directory/file")).toBe("directory/file");
+	expect(filesystem.removeSync("file")).toBeUndefined();
+	expect(filesystem.stat("file")).toEqual({});
+	expect(filesystem.statSync("file")).toEqual({});
+});

--- a/tests/compiler/logService.test.ts
+++ b/tests/compiler/logService.test.ts
@@ -1,0 +1,78 @@
+import kleur from "kleur";
+import { LogService } from "Shared/classes/LogService";
+
+const originalVerbose = LogService.verbose;
+const originalColors = kleur.enabled;
+let stdout: jest.SpyInstance;
+
+beforeEach(() => {
+	stdout = jest.spyOn(process.stdout, "write").mockReturnValue(true);
+	LogService.verbose = false;
+	LogService.write("\n");
+	stdout.mockClear();
+});
+
+afterEach(() => {
+	LogService.write("\n");
+	LogService.verbose = originalVerbose;
+	kleur.enabled = originalColors;
+	jest.restoreAllMocks();
+});
+
+function output() {
+	return stdout.mock.calls.map(([message]) => message).join("");
+}
+
+it("separates raw writes and formatted messages without adding extra blank lines", () => {
+	LogService.write("first");
+	LogService.write(" second");
+	LogService.writeLine(42, false, undefined, null, { toString: () => "object" }, "");
+	LogService.write("complete\n");
+	LogService.writeLine("next");
+
+	expect(output()).toBe("first second\n42\nfalse\nundefined\nnull\nobject\n\ncomplete\nnext\n");
+});
+
+it("only finishes a pending partial line when called without messages", () => {
+	LogService.writeLine();
+	expect(stdout).not.toHaveBeenCalled();
+
+	LogService.write("partial");
+	LogService.writeLine();
+	LogService.writeLine();
+
+	expect(output()).toBe("partial\n");
+});
+
+it("only interrupts a partial line for verbose messages when enabled", () => {
+	LogService.write("progress");
+	LogService.writeLineIfVerbose("hidden");
+	expect(output()).toBe("progress");
+
+	LogService.verbose = true;
+	LogService.writeLineIfVerbose("first", 42);
+
+	expect(output()).toBe("progress\nfirst\n42\n");
+});
+
+it("formats warnings with and without terminal colors", () => {
+	kleur.enabled = false;
+	LogService.warn("plain");
+	kleur.enabled = true;
+	LogService.warn("warning message");
+
+	expect(output()).toBe("Compiler Warning: plain\n\u001b[33mCompiler Warning:\u001b[39m warning message\n");
+});
+
+it("writes a fatal message before exiting with status one", () => {
+	const exitSignal = new Error("process exited");
+	const exit = jest.spyOn(process, "exit").mockImplementation(() => {
+		expect(output()).toBe("progress\nfatal message\n");
+		throw exitSignal;
+	});
+	LogService.write("progress");
+
+	expect(() => LogService.fatal("fatal message")).toThrow(exitSignal);
+	expect(exit).toHaveBeenCalledTimes(1);
+	expect(exit).toHaveBeenCalledWith(1);
+});


### PR DESCRIPTION
- Remove the CLI and LogService coverage exclusions. Add tests for command dispatch, project discovery, diagnostics, watch options, entry-point exports, browser filesystem fallbacks, and logging behavior.
- Exercise the native executable's help/version output, flag validation, builds, and failure exit codes.
- Reach 100% statement, branch, function, and line coverage for all six CLI source files and LogService without implementation changes. Build and 44 focused tests pass; changed files pass lint and formatting checks. Full local lint reports two existing formatting warnings in unrelated files.
