### PR TITLE
Omit blank lines left by block comment delimiters

### DIFF
--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -104,16 +104,24 @@ export class TransformState {
 	public getLeadingComments(node: ts.Node) {
 		const commentRanges = ts.getLeadingCommentRanges(this.sourceFileText, node.pos) ?? [];
 		return luau.list.make(
-			...commentRanges.map(commentRange =>
-				luau.comment(
-					this.sourceFileText.substring(
-						commentRange.pos + 2,
-						commentRange.kind === ts.SyntaxKind.SingleLineCommentTrivia
-							? commentRange.end
-							: commentRange.end - 2,
-					),
-				),
-			),
+			...commentRanges.map(commentRange => {
+				if (commentRange.kind === ts.SyntaxKind.SingleLineCommentTrivia) {
+					return luau.comment(this.sourceFileText.substring(commentRange.pos + 2, commentRange.end));
+				}
+
+				const source = this.sourceFileText.substring(commentRange.pos + 2, commentRange.end - 2);
+
+				// drop edge lines left by delimiters on their own lines, e.g. the " " before " */" in a JSDoc comment
+				let text = source.replace(/^[ \t]*\r?\n/, "");
+				text = text.replace(/\r?\n[ \t]*$/, "");
+
+				// one line renders as `--text`, where `--!` is a Luau directive and `--[[` comments out later code
+				if (!text.includes("\n") && /^(!|\[=*\[)/.test(text)) {
+					return luau.comment(source);
+				}
+
+				return luau.comment(text);
+			}),
 		);
 	}
 

--- a/tests/compiler/__snapshots__/emit.test.ts.snap
+++ b/tests/compiler/__snapshots__/emit.test.ts.snap
@@ -8,6 +8,28 @@ return {
 "
 `;
 
+exports[`omits blank lines left by block comment delimiters 1`] = `
+"--[[
+	*
+	 * indented closing delimiter
+]]
+print(1)
+--[[
+	*
+	* unindented closing delimiter
+]]
+print(2)
+--[[
+		opening delimiter on its own line
+		second line
+]]
+print(3)
+--single line
+print(4)
+return nil
+"
+`;
+
 exports[`places Luau directives before the compiler header 1`] = `
 "--!strict
 --!native

--- a/tests/compiler/emit.test.ts
+++ b/tests/compiler/emit.test.ts
@@ -8,6 +8,46 @@ it("emits a module export", () => {
 	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
 });
 
+it.each(["!strict", "[[ note"])("keeps a block comment starting with %s multi-line", text => {
+	const project = createTestProject();
+	const output = project.compileSource(`/*\n${text}\n*/\nprint(1);`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toBe(`--[[\n\t\n\t${text}\n\t\n]]\nprint(1)\nreturn nil\n`);
+});
+
+it("omits blank lines left by block comment delimiters", () => {
+	const project = createTestProject();
+	const output = project.compileSource(
+		[
+			"/**",
+			" * indented closing delimiter",
+			" */",
+			"print(1);",
+			"/**",
+			"* unindented closing delimiter",
+			"*/",
+			"print(2);",
+			"/*",
+			"\topening delimiter on its own line",
+			"\tsecond line",
+			"*/",
+			"print(3);",
+			"/*single line*/",
+			"print(4);",
+		].join("\n"),
+	);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});
+
+it("omits blank lines left by block comment delimiters with CRLF line endings", () => {
+	const project = createTestProject();
+	const output = project.compileSource("/**\r\n * comment\r\n */\r\nprint(1);\r\n");
+
+	// snapshots normalize line endings, which would hide a leftover \r
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toBe("--[[\n\t*\r\n\t * comment\n]]\nprint(1)\nreturn nil\n");
+});
+
 it("places Luau directives before the compiler header", () => {
 	const project = createTestProject();
 	const output = project.compileSource("//!strict\n//!native\nexport const value = 1;");


### PR DESCRIPTION
- Drop the whitespace-only first and last lines that `/*` or `*/` on their own lines leave in block comments. These previously rendered as blank (tab-only) lines inside the emitted `--[[ ]]` comment. CRLF line endings are handled too.
- Keep the untrimmed text when trimming would collapse the comment to one line starting with `!` or a long bracket. A single line renders as `--text`, so `--!strict` would become a Luau directive and `--[[ note` would comment out the code that follows.

```ts
/**
 * Hi
 */
type Y = 5;
```

Before:

```lua
--[[
	*
	 * Hi
	 
]]
return nil
```

After:

```lua
--[[
	*
	 * Hi
]]
return nil
```

`npm test` passes (618 compiler tests, 122 snapshots, and 767 runtime tests), along with lint and formatting checks.
