### PR TITLE
Reject enum and namespace merging

### DIFF
--- a/src/TSTransformer/nodes/statements/transformModuleDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformModuleDeclaration.ts
@@ -23,7 +23,7 @@ function isDeclarationOfNamespace(declaration: ts.Declaration) {
 		return true;
 	} else if (ts.isFunctionDeclaration(declaration) && declaration.body) {
 		return true;
-	} else if (ts.isClassDeclaration(declaration)) {
+	} else if (ts.isClassDeclaration(declaration) || ts.isEnumDeclaration(declaration)) {
 		return true;
 	}
 	return false;

--- a/tests/src/diagnostics/noNamespaceMerging.3.ts
+++ b/tests/src/diagnostics/noNamespaceMerging.3.ts
@@ -1,0 +1,7 @@
+enum Merged {
+	Value,
+}
+
+namespace Merged {
+	export const extra = 1;
+}

--- a/tests/src/diagnostics/noNamespaceMerging.4.ts
+++ b/tests/src/diagnostics/noNamespaceMerging.4.ts
@@ -1,0 +1,7 @@
+namespace Merged {
+	export const extra = 1;
+}
+
+enum Merged {
+	Value,
+}

--- a/tests/src/tests/namespace.spec.ts
+++ b/tests/src/tests/namespace.spec.ts
@@ -66,7 +66,32 @@ namespace Nested.Self {
 	}
 }
 
+enum EnumBeforeNamespace {
+	Value = 3,
+}
+namespace EnumBeforeNamespace {
+	export interface Shape {
+		value: number;
+	}
+}
+
+namespace NamespaceBeforeEnum {
+	export type Label = string;
+}
+enum NamespaceBeforeEnum {
+	Value = 4,
+}
+
 export = () => {
+	it("should preserve enums merged with namespaces containing only types", () => {
+		const shape: EnumBeforeNamespace.Shape = { value: EnumBeforeNamespace.Value };
+		const label: NamespaceBeforeEnum.Label = NamespaceBeforeEnum[NamespaceBeforeEnum.Value];
+
+		expect(shape.value).to.equal(3);
+		expect(EnumBeforeNamespace[3]).to.equal("Value");
+		expect(label).to.equal("Value");
+	});
+
 	it("should execute namespaces without exports", () => {
 		expect(namespaceEffects).to.equal(1);
 		expect(WithFunction.value()).to.equal(42);


### PR DESCRIPTION
- Report `noNamespaceMerging` when a runtime enum and namespace share a name, in either declaration order. Previously, each declaration emitted a separate table, discarding the earlier declaration's members.
- Preserve enum merges with namespaces containing only types, with runtime coverage for both declaration orders.
- Validation: both new diagnostic regressions fail before the fix and pass afterward; `npm test` and lint pass, with complete branch coverage on the changed production line.
