### PR TITLE
Resolve declaration aliases when registering macros

### DIFF
--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -112,7 +112,10 @@ export class MacroManager {
 
 		for (const [className, macro] of Object.entries(CONSTRUCTOR_MACROS)) {
 			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, className, ts.SymbolFlags.Interface);
-			const interfaceDec = getFirstDeclarationOrThrow(symbol, ts.isInterfaceDeclaration);
+			const interfaceDec = getFirstDeclarationOrThrow(
+				ts.skipAlias(symbol, typeChecker),
+				ts.isInterfaceDeclaration,
+			);
 			const constructSymbol = getConstructorSymbol(interfaceDec);
 			this.constructorMacros.set(constructSymbol, macro);
 		}

--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -74,7 +74,7 @@ function getFirstDeclarationOrThrow<T extends ts.Node>(symbol: ts.Symbol, check:
 function getGlobalSymbolByNameOrThrow(typeChecker: ts.TypeChecker, name: string, meaning: ts.SymbolFlags) {
 	const symbol = typeChecker.resolveName(name, undefined, meaning, false);
 	if (symbol) {
-		return symbol;
+		return ts.skipAlias(symbol, typeChecker);
 	}
 	throw new ProjectError(`MacroManager could not find symbol for ${name}` + TYPES_NOTICE);
 }
@@ -94,6 +94,7 @@ function getConstructorSymbol(node: ts.InterfaceDeclaration) {
  */
 export class MacroManager {
 	private symbols = new Map<string, ts.Symbol>();
+	private macroOnlyClasses = new Set<ts.Symbol>();
 	private identifierMacros = new Map<ts.Symbol, IdentifierMacro>();
 	private callMacros = new Map<ts.Symbol, CallMacro>();
 	private constructorMacros = new Map<ts.Symbol, ConstructorMacro>();
@@ -112,10 +113,7 @@ export class MacroManager {
 
 		for (const [className, macro] of Object.entries(CONSTRUCTOR_MACROS)) {
 			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, className, ts.SymbolFlags.Interface);
-			const interfaceDec = getFirstDeclarationOrThrow(
-				ts.skipAlias(symbol, typeChecker),
-				ts.isInterfaceDeclaration,
-			);
+			const interfaceDec = getFirstDeclarationOrThrow(symbol, ts.isInterfaceDeclaration);
 			const constructSymbol = getConstructorSymbol(interfaceDec);
 			this.constructorMacros.set(constructSymbol, macro);
 		}
@@ -148,11 +146,10 @@ export class MacroManager {
 		}
 
 		for (const symbolName of Object.values(SYMBOL_NAMES)) {
-			const symbol = typeChecker.resolveName(symbolName, undefined, ts.SymbolFlags.All, false);
-			if (symbol) {
-				this.symbols.set(symbolName, symbol);
-			} else {
-				throw new ProjectError(`MacroManager could not find symbol for ${symbolName}` + TYPES_NOTICE);
+			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, symbolName, ts.SymbolFlags.All);
+			this.symbols.set(symbolName, symbol);
+			if (MACRO_ONLY_CLASSES.has(symbolName)) {
+				this.macroOnlyClasses.add(symbol);
 			}
 		}
 
@@ -176,15 +173,15 @@ export class MacroManager {
 	}
 
 	public isMacroOnlyClass(symbol: ts.Symbol) {
-		return this.symbols.get(symbol.name) === symbol && MACRO_ONLY_CLASSES.has(symbol.name);
+		return this.macroOnlyClasses.has(symbol);
 	}
 
 	public getIdentifierMacro(symbol: ts.Symbol) {
-		return this.identifierMacros.get(symbol);
+		return this.identifierMacros.get(ts.skipAlias(symbol, this.typeChecker));
 	}
 
 	public getCallMacro(symbol: ts.Symbol) {
-		return this.callMacros.get(symbol);
+		return this.callMacros.get(ts.skipAlias(symbol, this.typeChecker));
 	}
 
 	public getConstructorMacro(symbol: ts.Symbol) {
@@ -196,7 +193,7 @@ export class MacroManager {
 		if (!macro && symbol.parent) {
 			// augmented interface members retain their original, unmerged parent symbol
 			const parent = this.typeChecker.getMergedSymbol(symbol.parent);
-			if (this.symbols.get(parent.name) === parent && this.isMacroOnlyClass(parent)) {
+			if (this.isMacroOnlyClass(parent)) {
 				assert(false, `Macro ${parent.name}.${symbol.name}() is not implemented!`);
 			}
 		}

--- a/tests/compiler/transformer/macroTypes.test.ts
+++ b/tests/compiler/transformer/macroTypes.test.ts
@@ -14,26 +14,73 @@ function changeCompilerTypes(file: string, rewrite: (source: string) => string) 
 	return project;
 }
 
-it("resolves an aliased constructor interface", () => {
-	const source = "export const values = new Array<number>();";
-	const expected = createTestProject().compileSource(source);
-	const project = changeCompilerTypes("Array", source => {
-		const sourceFile = ts.createSourceFile("Array.d.ts", source, ts.ScriptTarget.Latest, true);
-		const declaration = sourceFile.statements.find(
-			statement => ts.isInterfaceDeclaration(statement) && statement.name.text === "ArrayConstructor",
+function aliasCompilerType(file: string, name: string, targetName = name) {
+	return changeCompilerTypes(file, source => {
+		const sourceFile = ts.createSourceFile(`${file}.d.ts`, source, ts.ScriptTarget.Latest, true);
+		const declarations = sourceFile.statements.filter(statement => {
+			if (ts.isVariableStatement(statement)) {
+				return statement.declarationList.declarations.some(
+					declaration => ts.isIdentifier(declaration.name) && declaration.name.text === name,
+				);
+			}
+			return (
+				(ts.isInterfaceDeclaration(statement) ||
+					ts.isFunctionDeclaration(statement) ||
+					ts.isModuleDeclaration(statement) ||
+					ts.isTypeAliasDeclaration(statement)) &&
+				statement.name?.text === name
+			);
+		});
+
+		expect(declarations.length).toBeGreaterThan(0);
+
+		const moved = declarations.map(
+			declaration =>
+				`export ${declaration
+					.getText()
+					.replace(/^declare /, "")
+					.replace(name, targetName)}`,
 		);
-		assert(declaration);
-		const start = declaration.getStart();
-		const end = declaration.getEnd();
-		return (
-			source.slice(0, start) +
-			`declare namespace Constructors { export ${source.slice(start, end)} }\n` +
-			"import ArrayConstructor = Constructors.ArrayConstructor;" +
-			source.slice(end)
-		);
+		for (const declaration of declarations.reverse()) {
+			source = source.slice(0, declaration.getStart()) + source.slice(declaration.getEnd());
+		}
+
+		return `${source}\ndeclare namespace AliasedTypes { ${moved.join("\n")} }\nimport ${name} = AliasedTypes.${targetName};`;
 	});
+}
+
+it.each([
+	["Array", "ArrayConstructor", "export const values = new Array<number>();"],
+	["Set", "ReadonlySet", "declare const values: ReadonlySet<number>; print(values.size());"],
+	["callMacros", "identity", "export const value = identity(123);"],
+	["callMacros", "$tuple", "export function values() { return $tuple(1, 2); }"],
+	["core", "LuaTuple", "declare function values(): LuaTuple<[number, string]>; export const [a, b] = values();"],
+	["Promise", "Promise", "export const value = Promise.resolve(1);"],
+])("resolves aliased %s declarations for %s", (file, name, source) => {
+	const expected = createTestProject().compileSource(source);
+	const project = aliasCompilerType(file, name);
 
 	expect(project.compileSource(source)).toBe(expected);
+});
+
+it("rejects unimplemented methods through a renamed interface alias", () => {
+	const project = aliasCompilerType("Set", "ReadonlySet", "RenamedReadonlySet");
+	project.vfs.writeFile(
+		"/src/augmentation.d.ts",
+		"declare namespace AliasedTypes { interface RenamedReadonlySet<T> { custom(): void; } }",
+	);
+
+	expect(() => project.compileSource("declare const values: ReadonlySet<number>; values.custom();")).toThrow(
+		"Macro RenamedReadonlySet.custom() is not implemented!",
+	);
+});
+
+it("rejects references to an aliased call-only macro", () => {
+	const project = aliasCompilerType("callMacros", "identity");
+
+	expect(() => project.compileSource("const callback = identity;")).toThrow(
+		"Cannot index a method without calling it!",
+	);
 });
 
 it.each([

--- a/tests/compiler/transformer/macroTypes.test.ts
+++ b/tests/compiler/transformer/macroTypes.test.ts
@@ -1,4 +1,5 @@
 import { assert } from "Shared/util/assert";
+import ts from "typescript";
 
 import { createTestProject } from "../createTestProject";
 
@@ -12,6 +13,28 @@ function changeCompilerTypes(file: string, rewrite: (source: string) => string) 
 	project.vfs.writeFile(path, changed);
 	return project;
 }
+
+it("resolves an aliased constructor interface", () => {
+	const source = "export const values = new Array<number>();";
+	const expected = createTestProject().compileSource(source);
+	const project = changeCompilerTypes("Array", source => {
+		const sourceFile = ts.createSourceFile("Array.d.ts", source, ts.ScriptTarget.Latest, true);
+		const declaration = sourceFile.statements.find(
+			statement => ts.isInterfaceDeclaration(statement) && statement.name.text === "ArrayConstructor",
+		);
+		assert(declaration);
+		const start = declaration.getStart();
+		const end = declaration.getEnd();
+		return (
+			source.slice(0, start) +
+			`declare namespace Constructors { export ${source.slice(start, end)} }\n` +
+			"import ArrayConstructor = Constructors.ArrayConstructor;" +
+			source.slice(end)
+		);
+	});
+
+	expect(project.compileSource(source)).toBe(expected);
+});
 
 it.each([
 	["Promise", "Promise", "declare const Promise: PromiseConstructor;", ""],


### PR DESCRIPTION
Resolve declaration aliases consistently when registering and looking up macros. Aliased compiler types previously caused setup errors, emitted calls to nonexistent macro functions such as `identity`, or failed to recognize `LuaTuple` returns.

Track macro-only interfaces by resolved symbol identity so renamed aliases retain the unimplemented-method diagnostic. Regression cases cover constructor, method, identifier, call, and tuple declarations, plus invalid macro references.

Validation: the full suite passes (730 compiler tests, 121 snapshots, 768 runtime tests), followed by all 18 focused macro-type tests including the additional diagnostic regression. Lint passes and all 69 runtime output files are unchanged.
