### PR TITLE
Remove redundant transformer branches

### DIFF
--- a/src/TSTransformer/macros/propertyCallMacros.ts
+++ b/src/TSTransformer/macros/propertyCallMacros.ts
@@ -433,7 +433,6 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 	reduce: (state, prereqs, node, expression, args) => {
 		let start: luau.Expression = luau.number(1);
 		const end = luau.unary("#", expression);
-		const step = 1;
 
 		const lengthExp = luau.unary("#", expression);
 
@@ -462,7 +461,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 				}),
 				"result",
 			);
-			start = offset(start, step);
+			start = offset(start, 1);
 		} else {
 			resultId = prereqs.pushToVar(args[1], "result");
 		}
@@ -474,7 +473,7 @@ const READONLY_ARRAY_METHODS: MacroList<PropertyCallMacro> = {
 				id: iteratorId,
 				start,
 				end,
-				step: step === 1 ? undefined : luau.number(step),
+				step: undefined,
 				statements: luau.list.make(
 					luau.create(luau.SyntaxKind.Assignment, {
 						left: resultId,

--- a/src/TSTransformer/nodes/expressions/transformUnaryExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformUnaryExpression.ts
@@ -1,15 +1,20 @@
 import luau from "@roblox-ts/luau-ast";
 import { errors } from "Shared/diagnostics";
+import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { transformWritableExpression } from "TSTransformer/nodes/transformWritable";
-import { assertNever } from "TSTransformer/util/assertNever";
 import { createTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
 import { isDefinitelyType, isNumberType } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 import ts from "typescript";
+
+const UPDATE_OPERATORS = {
+	[ts.SyntaxKind.PlusPlusToken]: "+=",
+	[ts.SyntaxKind.MinusMinusToken]: "-=",
+} satisfies Record<ts.PostfixUnaryOperator, luau.AssignmentOperator>;
 
 export function transformPostfixUnaryExpression(
 	state: TransformState,
@@ -20,6 +25,8 @@ export function transformPostfixUnaryExpression(
 
 	const writable = transformWritableExpression(state, prereqs, node.operand, true);
 	const origValue = luau.tempId("original");
+	const operator = UPDATE_OPERATORS[node.operator];
+	assert(operator, "Unexpected postfix unary operator");
 
 	prereqs.push(
 		luau.create(luau.SyntaxKind.VariableDeclaration, {
@@ -31,12 +38,7 @@ export function transformPostfixUnaryExpression(
 	prereqs.push(
 		luau.create(luau.SyntaxKind.Assignment, {
 			left: writable,
-			operator:
-				node.operator === ts.SyntaxKind.PlusPlusToken
-					? "+="
-					: node.operator === ts.SyntaxKind.MinusMinusToken
-						? "-="
-						: assertNever(node.operator, "transformPostfixUnaryExpression"),
+			operator,
 			right: luau.number(1),
 		}),
 	);
@@ -53,7 +55,7 @@ export function transformPrefixUnaryExpression(
 
 	if (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) {
 		const writable = transformWritableExpression(state, prereqs, node.operand, true);
-		const operator: luau.AssignmentOperator = node.operator === ts.SyntaxKind.PlusPlusToken ? "+=" : "-=";
+		const operator = UPDATE_OPERATORS[node.operator];
 		prereqs.push(
 			luau.create(luau.SyntaxKind.Assignment, {
 				left: writable,
@@ -78,10 +80,9 @@ export function transformPrefixUnaryExpression(
 			node.operand,
 		);
 		return luau.unary("not", checks);
-	} else if (node.operator === ts.SyntaxKind.TildeToken) {
-		return luau.call(luau.property(luau.globals.bit32, "bnot"), [
-			transformExpression(state, prereqs, node.operand),
-		]);
 	}
-	return assertNever(node.operator, "transformPrefixUnaryExpression");
+
+	const operator: ts.SyntaxKind.TildeToken = node.operator;
+	assert(operator === ts.SyntaxKind.TildeToken, "Unexpected prefix unary operator");
+	return luau.call(luau.property(luau.globals.bit32, "bnot"), [transformExpression(state, prereqs, node.operand)]);
 }

--- a/src/TSTransformer/nodes/statements/transformForStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForStatement.ts
@@ -47,7 +47,8 @@ function addFinalizers(
 
 		if (node.prev) {
 			node.prev.next = finalizersClone.head;
-		} else if (node === list.head) {
+		} else {
+			assert(node === list.head);
 			list.head = finalizersClone.head;
 		}
 

--- a/src/TSTransformer/nodes/statements/transformReturnStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformReturnStatement.ts
@@ -16,12 +16,10 @@ function isTupleReturningCall(state: TransformState, tsExpression: ts.Expression
 	);
 }
 
-function isTupleMacro(state: TransformState, expression: ts.Expression) {
-	if (ts.isCallExpression(expression)) {
-		const symbol = getFirstDefinedSymbol(state, state.getType(expression.expression));
-		if (symbol && symbol === state.services.macroManager.getSymbolOrThrow(SYMBOL_NAMES.$tuple)) {
-			return true;
-		}
+function isTupleMacro(state: TransformState, expression: ts.CallExpression) {
+	const symbol = getFirstDefinedSymbol(state, state.getType(expression.expression));
+	if (symbol && symbol === state.services.macroManager.getSymbolOrThrow(SYMBOL_NAMES.$tuple)) {
+		return true;
 	}
 	return false;
 }

--- a/src/TSTransformer/nodes/statements/transformThrowStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformThrowStatement.ts
@@ -7,10 +7,8 @@ import ts from "typescript";
 export function transformThrowStatement(state: TransformState, node: ts.ThrowStatement) {
 	const statements = luau.list.make<luau.Statement>();
 	const prereqs = new Prereqs();
-	const args = new Array<luau.Expression>();
-	if (node.expression !== undefined) {
-		args.push(transformExpression(state, prereqs, node.expression));
-	}
+	const args = [transformExpression(state, prereqs, node.expression)];
+
 	luau.list.pushList(statements, prereqs.statements);
 	luau.list.push(
 		statements,

--- a/src/TSTransformer/nodes/statements/transformTryStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformTryStatement.ts
@@ -84,7 +84,7 @@ function createFlowControlCondition(
 	return luau.binary(exitTypeId, "==", state.TS(node, flowControlConstant));
 }
 
-type FlowControlCase = { condition?: luau.Expression; statements: luau.List<luau.Statement> };
+type FlowControlCase = { condition: luau.Expression; statements: luau.List<luau.Statement> };
 
 function collapseFlowControlCases(exitTypeId: luau.TemporaryIdentifier, cases: Array<FlowControlCase>) {
 	assert(cases.length > 0);
@@ -97,7 +97,7 @@ function collapseFlowControlCases(exitTypeId: luau.TemporaryIdentifier, cases: A
 
 	for (let i = cases.length - 2; i >= 0; i--) {
 		nextStatements = luau.create(luau.SyntaxKind.IfStatement, {
-			condition: cases[i].condition || exitTypeId,
+			condition: cases[i].condition,
 			statements: cases[i].statements,
 			elseBody: nextStatements,
 		});
@@ -160,6 +160,7 @@ function transformFlowControl(
 	if (tryUses.usesBreak || tryUses.usesContinue) {
 		if (breakBlocked) {
 			flowControlCases.push({
+				condition: exitTypeId,
 				statements: luau.list.make(
 					luau.create(luau.SyntaxKind.ReturnStatement, {
 						expression: exitTypeId,

--- a/src/TSTransformer/util/arrayLikeExpressionContainsSpread.ts
+++ b/src/TSTransformer/util/arrayLikeExpressionContainsSpread.ts
@@ -2,8 +2,9 @@ import ts from "typescript";
 
 export function arrayLikeExpressionContainsSpread(exp: ts.ArrayBindingPattern | ts.ArrayLiteralExpression): boolean {
 	for (const element of exp.elements) {
-		if ((ts.isBindingElement(element) && element.dotDotDotToken) || ts.isSpreadElement(element)) return true;
-		if (ts.isArrayBindingPattern(element) && arrayLikeExpressionContainsSpread(element)) return true;
+		if ((ts.isBindingElement(element) && element.dotDotDotToken) || ts.isSpreadElement(element)) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/src/TSTransformer/util/binding/objectAccessor.ts
+++ b/src/TSTransformer/util/binding/objectAccessor.ts
@@ -7,7 +7,6 @@ import { Prereqs } from "TSTransformer/classes/Prereqs";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
 import { addIndexDiagnostics } from "TSTransformer/util/addIndexDiagnostics";
 import { addOneIfArrayType } from "TSTransformer/util/addOneIfArrayType";
-import { assertNever } from "TSTransformer/util/assertNever";
 import { createStringIndexExpression } from "TSTransformer/util/createStringIndexExpression";
 import { isDefinitelyType, isMixedStringType, isStringType } from "TSTransformer/util/types";
 import ts from "typescript";
@@ -55,9 +54,10 @@ export const objectAccessor = (
 			expression: parentId,
 			index: transformExpression(state, prereqs, name),
 		});
-	} else if (ts.isPrivateIdentifier(name)) {
-		DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(name));
-		return luau.none();
 	}
-	return assertNever(name, "objectAccessor");
+
+	const privateName: ts.PrivateIdentifier = name;
+	assert(ts.isPrivateIdentifier(privateName));
+	DiagnosticService.addDiagnostic(errors.noPrivateIdentifier(privateName));
+	return luau.none();
 };

--- a/src/TSTransformer/util/getDeclaredVariables.ts
+++ b/src/TSTransformer/util/getDeclaredVariables.ts
@@ -7,7 +7,7 @@ function getDeclaredVariablesFromBindingName(node: ts.BindingName, list: Array<t
 		for (const element of node.elements) {
 			getDeclaredVariablesFromBindingName(element.name, list);
 		}
-	} else if (ts.isArrayBindingPattern(node)) {
+	} else {
 		for (const element of node.elements) {
 			if (!ts.isOmittedExpression(element)) {
 				getDeclaredVariablesFromBindingName(element.name, list);

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -254,5 +254,5 @@ export function getFirstDefinedSymbol(state: TransformState, type: ts.Type) {
 }
 
 export function getTypeArguments(state: TransformState, type: ts.Type) {
-	return state.typeChecker.getTypeArguments(type as ts.TypeReference) ?? [];
+	return state.typeChecker.getTypeArguments(type as ts.TypeReference);
 }

--- a/tests/compiler/destructuring/__snapshots__/rest.test.ts.snap
+++ b/tests/compiler/destructuring/__snapshots__/rest.test.ts.snap
@@ -256,3 +256,12 @@ _exp_1.rest = _rest
 return nil
 "
 `;
+
+exports[`keeps nested rest within a LuaTuple value 1`] = `
+"local _binding, last = values()
+local first = _binding[1]
+local rest = table.move(_binding, 2, #_binding, 1, {})
+print(first, rest, last)
+return nil
+"
+`;

--- a/tests/compiler/destructuring/rest.test.ts
+++ b/tests/compiler/destructuring/rest.test.ts
@@ -65,3 +65,13 @@ it.each(["number", "LuaTuple<[number, string]>"])("guards iterator assignment ta
 
 	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
 });
+
+it("keeps nested rest within a LuaTuple value", () => {
+	const output = createTestProject().compileSource(`
+		declare function values(): LuaTuple<[Array<number>, number]>;
+		const [[first, ...rest], last] = values();
+		print(first, rest, last);
+	`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});

--- a/tests/src/tests/tuple.spec.ts
+++ b/tests/src/tests/tuple.spec.ts
@@ -224,6 +224,33 @@ export = () => {
 		expect(b).to.equal(345);
 	});
 
+	it("should keep nested rest within one LuaTuple value", () => {
+		let calls = 0;
+		function values(): LuaTuple<[Array<number>, number]> {
+			calls++;
+			return $tuple([1, 2, 3], 4);
+		}
+
+		const [[first, ...rest], last] = values();
+		expect(first).to.equal(1);
+		expect(rest.size()).to.equal(2);
+		expect(rest[0]).to.equal(2);
+		expect(rest[1]).to.equal(3);
+		expect(last).to.equal(4);
+		expect(calls).to.equal(1);
+
+		let assignedFirst = 0;
+		let assignedRest = new Array<number>();
+		let assignedLast = 0;
+		[[assignedFirst, ...assignedRest], assignedLast] = values();
+		expect(assignedFirst).to.equal(1);
+		expect(assignedRest.size()).to.equal(2);
+		expect(assignedRest[0]).to.equal(2);
+		expect(assignedRest[1]).to.equal(3);
+		expect(assignedLast).to.equal(4);
+		expect(calls).to.equal(2);
+	});
+
 	it("should support nested assigning from LuaTuples 2", () => {
 		function foo(): LuaTuple<[number, { a: number; b: number }]> {
 			return [101, { a: 203, b: 345 }] as LuaTuple<[number, { a: number; b: number }]>;


### PR DESCRIPTION
Remove redundant transformer branches whose outcomes are fixed by AST types, callers, or local construction:

- Restrict the tuple-call helper to calls, use the required throw operand, and handle the remaining array binding directly.
- Remove the impossible nested `ArrayBindingPattern` element check and the fallback around TypeScript's array-returning `getTypeArguments()`.
- Make unary operators and object property names exhaustive, with assertions for malformed AST nodes.
- Use `reduce`'s constant step directly; require try-flow conditions and assert the loop-list head invariant.

Nested tuple-rest runtime and output tests pass before and after the cleanup. All 724 compiler tests, 122 snapshots, 769 runtime tests, and lint pass; existing runtime output is unchanged apart from the added test. Transformer branch coverage rises from 98.72% to 99.06%, with twelve unreachable branch outcomes removed.
