### PR TITLE
Assert binding and export invariants

### DIFF
--- a/src/TSTransformer/nodes/statements/transformForStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformForStatement.ts
@@ -354,9 +354,7 @@ function transformForStatementOptimized(state: TransformState, node: ts.ForState
 	}
 
 	const idSymbol = state.typeChecker.getSymbolAtLocation(decName);
-	if (!idSymbol) {
-		return undefined;
-	}
+	assert(idSymbol);
 
 	const startValue = getIntegerLiteral(decInit);
 	if (startValue === undefined) {

--- a/src/TSTransformer/nodes/statements/transformModuleDeclaration.ts
+++ b/src/TSTransformer/nodes/statements/transformModuleDeclaration.ts
@@ -14,32 +14,46 @@ import { validateIdentifier } from "TSTransformer/util/validateIdentifier";
 import ts from "typescript";
 
 function isDeclarationOfNamespace(declaration: ts.Declaration) {
-	const modifiers = ts.canHaveModifiers(declaration) ? ts.getModifiers(declaration) : undefined;
+	if (
+		!ts.isModuleDeclaration(declaration) &&
+		!ts.isFunctionDeclaration(declaration) &&
+		!ts.isClassDeclaration(declaration) &&
+		!ts.isEnumDeclaration(declaration)
+	) {
+		return false;
+	}
+
+	const modifiers = ts.getModifiers(declaration);
 	if (modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword)) {
 		return false;
 	}
 
-	if (ts.isModuleDeclaration(declaration) && ts.isInstantiatedModule(declaration, false)) {
-		return true;
-	} else if (ts.isFunctionDeclaration(declaration) && declaration.body) {
-		return true;
-	} else if (ts.isClassDeclaration(declaration) || ts.isEnumDeclaration(declaration)) {
-		return true;
+	if (ts.isModuleDeclaration(declaration)) {
+		return ts.isInstantiatedModule(declaration, false);
+	} else if (ts.isFunctionDeclaration(declaration)) {
+		return declaration.body !== undefined;
 	}
-	return false;
+	return true;
 }
 
 function getValueDeclarationStatement(symbol: ts.Symbol) {
 	for (const declaration of symbol.getDeclarations() ?? []) {
 		const statement = getAncestor(declaration, ts.isStatement);
-		if (statement) {
-			const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
-			if (ts.isFunctionDeclaration(statement) && !statement.body) continue;
-			if (ts.isTypeAliasDeclaration(statement)) continue;
-			if (ts.isInterfaceDeclaration(statement)) continue;
-			if (modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword)) continue;
-			return statement;
+		assert(statement);
+		const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
+		if (ts.isFunctionDeclaration(statement) && !statement.body) {
+			continue;
 		}
+		if (ts.isTypeAliasDeclaration(statement)) {
+			continue;
+		}
+		if (ts.isInterfaceDeclaration(statement)) {
+			continue;
+		}
+		if (modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword)) {
+			continue;
+		}
+		return statement;
 	}
 }
 

--- a/src/TSTransformer/nodes/transformSourceFile.ts
+++ b/src/TSTransformer/nodes/transformSourceFile.ts
@@ -13,12 +13,18 @@ import { isSymbolOfValue } from "TSTransformer/util/isSymbolOfValue";
 import { getAncestor } from "TSTransformer/util/traversal";
 import ts from "typescript";
 
+function getExportDeclarations(exportSymbol: ts.Symbol) {
+	const declarations = exportSymbol.getDeclarations();
+	assert(declarations && declarations.length > 0);
+	return declarations;
+}
+
 function getExportPair(
 	state: TransformState,
 	exportSymbol: ts.Symbol,
 ): [name: luau.Expression, id: luau.AnyIdentifier] {
-	const declaration = exportSymbol.getDeclarations()?.[0];
-	if (declaration && ts.isExportSpecifier(declaration)) {
+	const declaration = getExportDeclarations(exportSymbol)[0];
+	if (ts.isExportSpecifier(declaration)) {
 		const exportName = declaration.propertyName ?? declaration.name;
 		// exportName is only a StringLiteral for re-exports, which are filtered out in handleExports
 		assert(ts.isIdentifier(exportName));
@@ -30,7 +36,6 @@ function getExportPair(
 		let name = exportSymbol.name;
 		if (
 			exportSymbol.name === "default" &&
-			declaration &&
 			(ts.isFunctionDeclaration(declaration) || ts.isClassDeclaration(declaration)) &&
 			declaration.name
 		) {
@@ -42,13 +47,11 @@ function getExportPair(
 }
 
 function isExportSymbolFromExportFrom(exportSymbol: ts.Symbol) {
-	if (exportSymbol.declarations) {
-		for (const exportSpecifier of exportSymbol.declarations) {
-			if (ts.isExportSpecifier(exportSpecifier)) {
-				const exportDec = exportSpecifier.parent.parent;
-				if (ts.isExportDeclaration(exportDec) && exportDec.moduleSpecifier) {
-					return true;
-				}
+	for (const exportSpecifier of getExportDeclarations(exportSymbol)) {
+		if (ts.isExportSpecifier(exportSpecifier)) {
+			const exportDec = exportSpecifier.parent.parent;
+			if (ts.isExportDeclaration(exportDec) && exportDec.moduleSpecifier) {
+				return true;
 			}
 		}
 	}
@@ -68,9 +71,8 @@ function getIgnoredExportSymbols(state: TransformState, sourceFile: ts.SourceFil
 			} else if (ts.isNamespaceExport(statement.exportClause)) {
 				// export * as id from "./module";
 				const idSymbol = state.typeChecker.getSymbolAtLocation(statement.exportClause.name);
-				if (idSymbol) {
-					ignoredSymbols.add(idSymbol);
-				}
+				assert(idSymbol);
+				ignoredSymbols.add(idSymbol);
 			}
 		}
 	}
@@ -87,13 +89,11 @@ function getIgnoredExportSymbols(state: TransformState, sourceFile: ts.SourceFil
  * this mimics TypeScript behavior
  */
 function isExportSymbolOnlyFromDeclare(exportSymbol: ts.Symbol): boolean {
-	return (
-		exportSymbol.declarations?.every(declaration => {
-			const statement = getAncestor(declaration, ts.isStatement);
-			const modifiers = statement && ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined;
-			return modifiers?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword);
-		}) ?? false
-	);
+	return getExportDeclarations(exportSymbol).every(declaration => {
+		const statement = getAncestor(declaration, ts.isStatement);
+		assert(statement && ts.canHaveModifiers(statement));
+		return ts.getModifiers(statement)?.some(v => v.kind === ts.SyntaxKind.DeclareKeyword);
+	});
 }
 
 /**
@@ -119,9 +119,6 @@ function handleExports(
 	if (!hasExportEquals) {
 		for (const exportSymbol of state.getModuleExports(symbol)) {
 			if (ignoredExportSymbols.has(exportSymbol)) continue;
-
-			// ignore prototype exports
-			if (!!(exportSymbol.flags & ts.SymbolFlags.Prototype)) continue;
 
 			// export { default as x } from "./module";
 			if (isExportSymbolFromExportFrom(exportSymbol)) continue;

--- a/src/TSTransformer/util/arrayBindingPatternContainsHoists.ts
+++ b/src/TSTransformer/util/arrayBindingPatternContainsHoists.ts
@@ -1,3 +1,4 @@
+import { assert } from "Shared/util/assert";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { checkVariableHoist } from "TSTransformer/util/checkVariableHoist";
 import ts from "typescript";
@@ -22,4 +23,3 @@ export function arrayBindingPatternContainsHoists(
 	}
 	return false;
 }
-import { assert } from "Shared/util/assert";

--- a/src/TSTransformer/util/arrayBindingPatternContainsHoists.ts
+++ b/src/TSTransformer/util/arrayBindingPatternContainsHoists.ts
@@ -12,14 +12,14 @@ export function arrayBindingPatternContainsHoists(
 		// For those cases, the hoisting logic is handled elsewhere and the variable here will be a tempId.
 		if (ts.isBindingElement(element) && ts.isIdentifier(element.name)) {
 			const symbol = state.typeChecker.getSymbolAtLocation(element.name);
-			if (symbol) {
-				// isHoisted is marked inside checkVariableHoist
-				checkVariableHoist(state, element.name, symbol);
-				if (state.isHoisted.get(symbol)) {
-					return true;
-				}
+			assert(symbol);
+			// isHoisted is marked inside checkVariableHoist
+			checkVariableHoist(state, element.name, symbol);
+			if (state.isHoisted.get(symbol)) {
+				return true;
 			}
 		}
 	}
 	return false;
 }
+import { assert } from "Shared/util/assert";

--- a/src/TSTransformer/util/checkVariableHoist.ts
+++ b/src/TSTransformer/util/checkVariableHoist.ts
@@ -9,9 +9,7 @@ export function checkVariableHoist(state: TransformState, node: ts.Identifier, s
 	}
 
 	const statement = getAncestor(node, ts.isStatement);
-	if (!statement) {
-		return;
-	}
+	assert(statement);
 
 	const caseClause = statement.parent;
 	if (!ts.isCaseClause(caseClause)) {
@@ -37,3 +35,4 @@ export function checkVariableHoist(state: TransformState, node: ts.Identifier, s
 		state.isHoisted.set(symbol, true);
 	}
 }
+import { assert } from "Shared/util/assert";

--- a/src/TSTransformer/util/checkVariableHoist.ts
+++ b/src/TSTransformer/util/checkVariableHoist.ts
@@ -1,3 +1,4 @@
+import { assert } from "Shared/util/assert";
 import { getOrSetDefault } from "Shared/util/getOrSetDefault";
 import { TransformState } from "TSTransformer/classes/TransformState";
 import { getAncestor, isAncestorOf } from "TSTransformer/util/traversal";
@@ -35,4 +36,3 @@ export function checkVariableHoist(state: TransformState, node: ts.Identifier, s
 		state.isHoisted.set(symbol, true);
 	}
 }
-import { assert } from "Shared/util/assert";

--- a/src/TSTransformer/util/types.ts
+++ b/src/TSTransformer/util/types.ts
@@ -200,8 +200,8 @@ export function isRobloxType(state: TransformState): TypeCheck {
 	const typesPath = path.join(state.data.nodeModulesPath, RBXTS_SCOPE, "types");
 	return type =>
 		type.symbol?.declarations?.some(d => {
-			const filePath = d.getSourceFile()?.fileName;
-			return filePath !== undefined && isPathDescendantOf(filePath, typesPath);
+			const filePath = d.getSourceFile().fileName;
+			return isPathDescendantOf(filePath, typesPath);
 		}) ?? false;
 }
 


### PR DESCRIPTION
Make binding and export invariants explicit without changing emitted Luau:

- Bound variable names have symbols and statement ancestors; declaration nodes belong to a source file.
- Named module exports have source declarations, and namespace-export aliases have bound symbols. Reuse the declaration check across export handling.
- Filter namespace-merging candidates by declaration kind before reading modifiers, and remove the prototype-export check already made unreachable by export-assignment handling.

All 723 compiler tests, 121 snapshots, 768 runtime tests, and lint pass. All 69 runtime output files are unchanged. Thirteen unreachable branch outcomes are removed; no coverage exclusions are added.
