### PR TITLE
Explain incompatible macro constructor declarations

### DIFF
--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -62,13 +62,14 @@ const MACRO_ONLY_CLASSES = new Set<string>([
 	SYMBOL_NAMES.String,
 ]);
 
-function getFirstDeclarationOrThrow<T extends ts.Node>(symbol: ts.Symbol, check: (value: ts.Node) => value is T): T {
+function getConstructorInterface(typeChecker: ts.TypeChecker, name: string) {
+	const symbol = getGlobalSymbolByNameOrThrow(typeChecker, name, ts.SymbolFlags.Interface);
 	for (const declaration of symbol.declarations ?? []) {
-		if (check(declaration)) {
+		if (ts.isInterfaceDeclaration(declaration)) {
 			return declaration;
 		}
 	}
-	throw new ProjectError("");
+	throw new ProjectError(`MacroManager could not find interface for ${name}` + TYPES_NOTICE);
 }
 
 function getGlobalSymbolByNameOrThrow(typeChecker: ts.TypeChecker, name: string, meaning: ts.SymbolFlags) {
@@ -112,8 +113,7 @@ export class MacroManager {
 		}
 
 		for (const [className, macro] of Object.entries(CONSTRUCTOR_MACROS)) {
-			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, className, ts.SymbolFlags.Interface);
-			const interfaceDec = getFirstDeclarationOrThrow(symbol, ts.isInterfaceDeclaration);
+			const interfaceDec = getConstructorInterface(typeChecker, className);
 			const constructSymbol = getConstructorSymbol(interfaceDec);
 			this.constructorMacros.set(constructSymbol, macro);
 		}
@@ -153,9 +153,9 @@ export class MacroManager {
 			}
 		}
 
-		const luaTupleTypeDec = this.symbols
-			.get(SYMBOL_NAMES.LuaTuple)
-			?.declarations?.find(v => ts.isTypeAliasDeclaration(v));
+		const luaTupleTypeDec = this.getSymbolOrThrow(SYMBOL_NAMES.LuaTuple).declarations?.find(v =>
+			ts.isTypeAliasDeclaration(v),
+		);
 		if (luaTupleTypeDec) {
 			const nominalLuaTupleSymbol = typeChecker
 				.getTypeAtLocation(luaTupleTypeDec)

--- a/tests/compiler/transformer/macroTypes.test.ts
+++ b/tests/compiler/transformer/macroTypes.test.ts
@@ -103,6 +103,26 @@ it("explains a missing constructor signature", () => {
 	);
 });
 
+it.each(["Metadata.create", "MissingConstructor"])("explains an incompatible constructor alias to %s", target => {
+	const project = changeCompilerTypes(
+		"Array",
+		source =>
+			`${source}\ndeclare namespace Metadata { function create(): void; }\nimport ArrayConstructor = ${target};`,
+	);
+
+	expect(() => project.compileSource("export const value = 1;")).toThrow(
+		"MacroManager could not find interface for ArrayConstructor",
+	);
+});
+
+it("explains an unresolved alias in macro method declarations", () => {
+	const project = changeCompilerTypes("Array", source => `${source}\nimport ReadonlyArray = MissingArray;`);
+
+	expect(() => project.compileSource("export const value = 1;")).toThrow(
+		"MacroManager could not find method for ReadonlyArray.isEmpty",
+	);
+});
+
 it("explains a missing macro method", () => {
 	const project = changeCompilerTypes("Array", source => source.replace("push(", "missingPush("));
 
@@ -144,6 +164,7 @@ it("finds a constructor interface after its merged namespace", () => {
 it.each([
 	["an interface", "interface LuaTuple<T extends Array<any>> {}"],
 	["an unbranded alias", "type LuaTuple<T extends Array<any>> = T;"],
+	["an unresolved import alias", "import LuaTuple = MissingLuaTuple;"],
 ])("allows unrelated compilation when LuaTuple is %s", (description, declaration) => {
 	const project = changeCompilerTypes("core", source =>
 		source.replace(/type LuaTuple<T extends Array<any>> = T & \{[^}]*\};/, declaration),


### PR DESCRIPTION
Explain incompatible constructor declarations instead of reporting an empty compiler error. Regression cases cover aliases targeting a function or an unresolved name, unresolved method metadata, and unrelated compilation with an unresolved `LuaTuple` alias.

Keep the declaration-absence guards these cases exercise. Use the checked registry accessor for `LuaTuple`, whose entry is populated before this lookup.

Depends on #3075 and targets its branch. All 735 compiler tests, 121 snapshots, 768 runtime tests, and lint pass; all 69 runtime output files are unchanged. `MacroManager` reaches 100% statement, branch, function, and line coverage without exclusions.
