### PR TITLE
Preserve receiver slots in direct calls

### DIFF
--- a/src/TSTransformer/nodes/expressions/transformCallExpression.ts
+++ b/src/TSTransformer/nodes/expressions/transformCallExpression.ts
@@ -10,7 +10,7 @@ import { convertToIndexableExpression } from "TSTransformer/util/convertToIndexa
 import { ensureTransformOrder } from "TSTransformer/util/ensureTransformOrder";
 import { isStableBuiltinMember, tryMarkBuiltinMember } from "TSTransformer/util/evaluation/builtins";
 import { effectsCommute, getEffects, isLateRead, joinEffects, NO_EFFECTS } from "TSTransformer/util/evaluation/effects";
-import { isMethod } from "TSTransformer/util/isMethod";
+import { isMethod, isMethodFromType } from "TSTransformer/util/isMethod";
 import { getFirstDefinedSymbol, isPossiblyType, isRobloxType, isUndefinedType } from "TSTransformer/util/types";
 import { validateNotAnyType } from "TSTransformer/util/validateNotAny";
 import { wrapReturnIfLuaTuple } from "TSTransformer/util/wrapReturnIfLuaTuple";
@@ -84,6 +84,11 @@ export function transformCallExpressionInner(
 		expression = prereqs.pushToVar(expression, "fn");
 	}
 	prereqs.pushList(argsPrereqs.statements);
+
+	if (isMethodFromType(state, node.expression, expType)) {
+		// direct calls have no receiver, but the implementation still expects its slot
+		args.unshift(luau.nil());
+	}
 
 	const exp = luau.call(convertToIndexableExpression(expression), args);
 

--- a/tests/compiler/__snapshots__/directCallReceivers.test.ts.snap
+++ b/tests/compiler/__snapshots__/directCallReceivers.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`supplies receiver slots only for direct calls that require them 1`] = `
+"local function original(value)
+	return value + 1
+end
+local callback = original
+callback(41)
+local function method(self, value)
+	return value + 1
+end
+method(nil, 41)
+local optional = (function()
+	return method
+end)()
+local _result = optional
+if _result ~= nil then
+	_result(nil, 41)
+end
+local adapted = function(value)
+	return method(nil, value)
+end
+adapted(41)
+return nil
+"
+`;

--- a/tests/compiler/directCallReceivers.test.ts
+++ b/tests/compiler/directCallReceivers.test.ts
@@ -1,0 +1,18 @@
+import { createTestProject } from "./createTestProject";
+
+it("supplies receiver slots only for direct calls that require them", () => {
+	const output = createTestProject().compileSource(`
+		type Callable<T> = (this: T, value: number) => number;
+		function original(value: number) { return value + 1; }
+		const callback: Callable<void> = original;
+		callback(41);
+		function method(this: defined | void, value: number) { return value + 1; }
+		method(41);
+		const optional: typeof method | undefined = (() => method)();
+		optional?.(41);
+		const adapted: Callable<void> = value => method(value);
+		adapted(41);
+	`);
+
+	expect(output.replace(/^-- Compiled with.*\n/, "")).toMatchSnapshot();
+});

--- a/tests/src/tests/directCallReceivers.spec.ts
+++ b/tests/src/tests/directCallReceivers.spec.ts
@@ -1,0 +1,38 @@
+export = () => {
+	it("should supply an undefined receiver to direct receiver calls", () => {
+		function callback(this: defined | void, value: number) {
+			expect(this).to.equal(undefined);
+			return value + 1;
+		}
+
+		expect(callback(41)).to.equal(42);
+		const optional: typeof callback | undefined = (() => callback)();
+		expect(optional?.(41)).to.equal(42);
+
+		const adapted: (this: void, value: number) => number = value => callback(value);
+		expect(adapted(41)).to.equal(42);
+	});
+
+	it("should preserve receiver slots and evaluation order with spread arguments", () => {
+		const order = new Array<string>();
+		function callback(this: defined | void, ...values: Array<number>) {
+			expect(this).to.equal(undefined);
+			return values[0] + values[1];
+		}
+		function getCallback() {
+			order.push("callee");
+			return callback;
+		}
+		function getValues(): LuaTuple<[number, number]> {
+			order.push("arguments");
+			return $tuple(20, 22);
+		}
+
+		expect(getCallback()(...getValues())).to.equal(42);
+		expect(order.join(",")).to.equal("callee,arguments");
+
+		const absent = ((): typeof callback | undefined => undefined)();
+		expect(absent?.(...getValues())).to.equal(undefined);
+		expect(order.join(",")).to.equal("callee,arguments");
+	});
+};


### PR DESCRIPTION
Direct calls to functions with a receiver parameter now pass `nil` in that slot, preserving the ordinary arguments. Stacked on #3078 for correct instantiated receiver classification.

```ts
function callback(this: defined | void, value: number) {
	return value + 1;
}

callback(41);
```

```luau
local function callback(self, value)
	return value + 1
end

-- before
callback(41)

-- after
callback(nil, 41)
```

- Preserve the same receiver slot for optional calls and spread arguments.
- Keep `this: void` callbacks free of the extra argument.

Validation: `npm test` and lint pass (739 compiler tests, 127 snapshots, 784 runtime tests). Patch coverage is 100%: 3/3 executable lines and 2/2 branches.

