### PR TITLE
Remove redundant tests and repeated fixture compilations

### DIFF
--- a/tests/compiler/__snapshots__/callbacksVsMethods.test.ts.snap
+++ b/tests/compiler/__snapshots__/callbacksVsMethods.test.ts.snap
@@ -65,17 +65,6 @@ return nil
 "
 `;
 
-exports[`documented void this overrides a method declaration 1`] = `
-"local object = {
-	foo = function(value)
-		return value
-	end,
-}
-object.foo(123)
-return nil
-"
-`;
-
 exports[`function declarations and expressions honor explicit receivers 1`] = `
 "local function callback(value)
 	return value

--- a/tests/compiler/callbacksVsMethods.test.ts
+++ b/tests/compiler/callbacksVsMethods.test.ts
@@ -42,15 +42,6 @@ it.each([
 		`,
 	},
 	{
-		name: "documented void this overrides a method declaration",
-		source: `
-			const object = {
-				foo(this: void, value: number) { return value; },
-			};
-			object.foo(123);
-		`,
-	},
-	{
 		name: "function declarations and expressions honor explicit receivers",
 		source: `
 			type Receiver = { value: number };

--- a/tests/compiler/prereqs.test.ts
+++ b/tests/compiler/prereqs.test.ts
@@ -84,11 +84,8 @@ it.each([
 		print(read(false));`,
 	],
 ])("preserves prerequisites for %s", (name, source) => {
-	const outputs = [false, true].map(optimizedLoops => {
-		const project = createTestProject({ optimizedLoops });
-		return project.compileSource(source).replace(/^-- Compiled with.*\n/, "");
-	});
+	const project = createTestProject();
+	const output = project.compileSource(source).replace(/^-- Compiled with.*\n/, "");
 
-	expect(outputs[0]).toBe(outputs[1]);
-	expect(outputs[0]).toMatchSnapshot();
+	expect(output).toMatchSnapshot();
 });

--- a/tests/compiler/projectReference/rojo.test.ts
+++ b/tests/compiler/projectReference/rojo.test.ts
@@ -91,19 +91,6 @@ it("discovers project files through optional directory paths and junctions", () 
 	);
 });
 
-it("preserves output when a Rojo config has an invalid tree", () => {
-	expectSuccess(fixture.createBuild().build());
-	const before = fixture.read("out/game/init.luau");
-	fixture.json("default.project.json", { name: "invalid", tree: false });
-	const warn = jest.spyOn(LogService, "warn").mockImplementation(() => {});
-	try {
-		expect(fixture.createBuild().build().emitSkipped).toBe(true);
-		expect(fixture.read("out/game/init.luau")).toBe(before);
-	} finally {
-		warn.mockRestore();
-	}
-});
-
 it.each([false, true])("recovers when a newly selected child Rojo file is created (polling=%s)", async usePolling => {
 	const watch = await startWatch(fixture, usePolling);
 	try {
@@ -209,7 +196,7 @@ it.each([false, true])(
 	},
 );
 
-it.each([null, { name: "invalid", tree: { $path: null } }])(
+it.each([null, { name: "invalid", tree: false }, { name: "invalid", tree: { $path: null } }])(
 	"preserves output when a Rojo project has no usable tree: %j",
 	config => {
 		expectSuccess(fixture.createBuild().build());

--- a/tests/compiler/stringIndexing.test.ts
+++ b/tests/compiler/stringIndexing.test.ts
@@ -1,6 +1,4 @@
 // keep tests alphabetized by name to match Jest's snapshot ordering
-import { DiagnosticError } from "Shared/errors/DiagnosticError";
-
 import { createTestProject } from "./createTestProject";
 
 function compile(source: string) {
@@ -78,12 +76,6 @@ it("preserves effects when an indexed value is discarded", () => {
 			value()[index()];
 		`),
 	).toMatchSnapshot();
-});
-
-it("rejects indexing a union of strings and arrays", () => {
-	expect(() => compile("export function read(value: string | Array<string>) { return value[0]; }")).toThrow(
-		DiagnosticError,
-	);
 });
 
 it("reuses one string iterator for bindings and rest", () => {

--- a/tests/src/tests/array.spec.ts
+++ b/tests/src/tests/array.spec.ts
@@ -153,6 +153,8 @@ export = () => {
 	});
 
 	it("should support.size()", () => {
+		[1, 2, 3].size();
+
 		expect([].size()).to.equal(0);
 		expect([1].size()).to.equal(1);
 		expect([1, 2].size()).to.equal(2);

--- a/tests/src/tests/binary.spec.ts
+++ b/tests/src/tests/binary.spec.ts
@@ -1,12 +1,4 @@
 export = () => {
-	it("should support binary expressions on properties", () => {
-		const foo = {
-			bar: 1,
-		};
-		foo.bar++;
-		expect(foo.bar).to.equal(2);
-	});
-
 	it("should support binary assignment on properties", () => {
 		const foo = {
 			bar: 1,

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -586,11 +586,6 @@ export = () => {
 		expect(bar()[2]).to.equal(6);
 	});
 
-	it("should support accessing the size method", () => {
-		[1, 2, 3].size();
-		expect([1, 2, 3].size()).to.equal(3);
-	});
-
 	it("should destructure properly into already declared variables", () => {
 		let a: number;
 		[a] = new Set([4]);

--- a/tests/src/tests/literal.spec.ts
+++ b/tests/src/tests/literal.spec.ts
@@ -15,13 +15,6 @@ export = () => {
 		expect(1_0_0_0_0).to.equal(10000);
 	});
 
-	it("should add numbers", () => {
-		expect(1 + 1).to.equal(2);
-		const a = 1;
-		const b = 1;
-		expect(a + b).to.equal(2);
-	});
-
 	// prettier-ignore
 	it("should understand string literals", () => {
 		expect("foo").to.equal("foo");

--- a/tests/src/tests/loop.spec.ts
+++ b/tests/src/tests/loop.spec.ts
@@ -306,20 +306,6 @@ export = () => {
 		expect(hit.has(3)).to.equal(true);
 	});
 
-	it("should support optimized simple loops #6", () => {
-		const hit = new Set<number>();
-		const limit = 1;
-		let n = 0;
-		for (let i = 3; i >= limit; i -= 1) {
-			hit.add(i);
-			n++;
-		}
-		expect(n).to.equal(3);
-		expect(hit.has(1)).to.equal(true);
-		expect(hit.has(2)).to.equal(true);
-		expect(hit.has(3)).to.equal(true);
-	});
-
 	it("should support optimized simple loops #7", () => {
 		const hit = new Set<number>();
 		const limit = 1;

--- a/tests/src/tests/math.spec.ts
+++ b/tests/src/tests/math.spec.ts
@@ -3,6 +3,10 @@ export = () => {
 		it("should add numbers", () => {
 			expect(1 + 5).to.equal(6);
 			expect(22 + 44).to.equal(66);
+
+			const a = 1;
+			const b = 1;
+			expect(a + b).to.equal(2);
 		});
 
 		it("should subtract numbers", () => {

--- a/tests/src/tests/tuple.spec.ts
+++ b/tests/src/tests/tuple.spec.ts
@@ -37,15 +37,6 @@ export = () => {
 		expect(foo()[1]).to.equal(203);
 	});
 
-	it("should support wrapping function results", () => {
-		function foo() {
-			return [1, 2, 3];
-		}
-		expect(foo()[0]).to.equal(1);
-		expect(foo()[1]).to.equal(2);
-		expect(foo()[2]).to.equal(3);
-	});
-
 	it("should support functions returning tuple calls", () => {
 		function foo(): [number, string] {
 			return [1, "2"];


### PR DESCRIPTION
- Remove seven redundant test cases and one snapshot already covered by retained tests. Preserve distinct assertions by moving identifier-based addition and discarded `.size()` calls into the corresponding suites.
- Compile each of the eight prerequisite snapshot fixtures once: none can use numeric-loop optimization. The dedicated loop suite still checks both optimization modes.
- Consolidate invalid Rojo configurations into the existing parameterized test, retaining all three configurations.
- Local validation: `npm test` and `npm run eslint` pass (759 compiler tests, 127 snapshots, 780 runtime tests). Lines, statements, functions, and branches remain at 100% with identical coverage scope and totals.
