### PR TITLE
Remove duplicate test cases and consolidate fixtures

### DIFF
--- a/tests/compiler/projectReference/lifecycle.test.ts
+++ b/tests/compiler/projectReference/lifecycle.test.ts
@@ -65,34 +65,48 @@ const sourceFile = process.argv[5];
 	expect(output.trim()).toBe("previous program released");
 });
 
-it.each([false, true])("preserves nested bundled runtime files while cleaning generated output (luau=%s)", luau => {
-	fixture.project("game");
-	fixture.write("game/src/orphan.ts", "export const orphan = 1;");
-	fixture.rojo({ include: { $path: "out/game" } });
-	const runtime = fixture.file("runtime");
-	fs.copySync(constants.INCLUDE_PATH, runtime);
-	fixture.write("runtime/helpers/nested.luau", "return 42");
-	fixture.write("runtime/helpers/legacy.lua", "return 24");
-	fixture.write("runtime/helpers/data.json", '{"value": 42}');
-	const installation = jest.replaceProperty(constants, "INCLUDE_PATH", runtime);
+it.each([
+	{ includePath: "out/game/include", luau: false },
+	{ includePath: "out/game/include", luau: true },
+	{ includePath: "out/game", luau: false },
+	{ includePath: "out/game", luau: true },
+])(
+	"preserves bundled runtime files at $includePath while cleaning stale output (luau=$luau)",
+	({ includePath, luau }) => {
+		fixture.project("game");
+		fixture.write("game/src/orphan.ts", "export const orphan = 1;");
+		fixture.rojo({ include: { $path: includePath } });
+		const runtime = fixture.file("runtime");
+		fs.copySync(constants.INCLUDE_PATH, runtime);
+		fixture.write("runtime/helpers/nested.luau", "return 42");
+		fixture.write("runtime/helpers/legacy.lua", "return 24");
+		fixture.write("runtime/helpers/data.json", '{"value": 42}');
+		const installation = jest.replaceProperty(constants, "INCLUDE_PATH", runtime);
 
-	try {
-		const build = fixture.createBuild({ includePath: fixture.file("out/game"), luau });
-		const extension = luau ? "luau" : "lua";
-		expectSuccess(build.build());
+		try {
+			const build = fixture.createBuild({ includePath: fixture.file(includePath), luau });
+			const extension = luau ? "luau" : "lua";
+			expectSuccess(build.build());
 
-		fs.removeSync(fixture.file("game/src/orphan.ts"));
+			for (const name of ["Promise", "RuntimeLib"]) {
+				expect(fs.existsSync(fixture.file(`${includePath}/${name}.${extension}`))).toBe(true);
+			}
 
-		expectSuccess(build.build());
-		expect(fixture.read(`out/game/helpers/nested.${extension}`)).toBe("return 42");
-		expect(fixture.read("out/game/helpers/legacy.lua")).toBe("return 24");
-		expect(fixture.read("out/game/helpers/data.json")).toBe('{"value": 42}');
-		expect(fs.existsSync(fixture.file(`out/game/orphan.${extension}`))).toBe(false);
-		expect(fs.existsSync(fixture.file(`out/game/RuntimeLib.${extension}`))).toBe(true);
-	} finally {
-		installation.restore();
-	}
-});
+			fs.removeSync(fixture.file("game/src/orphan.ts"));
+
+			expectSuccess(build.build());
+			expect(fixture.read(`${includePath}/helpers/nested.${extension}`)).toBe("return 42");
+			expect(fixture.read(`${includePath}/helpers/legacy.lua`)).toBe("return 24");
+			expect(fixture.read(`${includePath}/helpers/data.json`)).toBe('{"value": 42}');
+			expect(fs.existsSync(fixture.file(`out/game/orphan.${extension}`))).toBe(false);
+			for (const name of ["Promise", "RuntimeLib"]) {
+				expect(fs.existsSync(fixture.file(`${includePath}/${name}.${extension}`))).toBe(true);
+			}
+		} finally {
+			installation.restore();
+		}
+	},
+);
 
 it("reloads transformer options and removes and restores a transformed dependency", () => {
 	fixture.project("shared", [], { plugins: [{ transform: "../plugin.cjs", value: 1 }] });

--- a/tests/compiler/projectReference/plugins.test.ts
+++ b/tests/compiler/projectReference/plugins.test.ts
@@ -51,52 +51,31 @@ it("refreshes declarations imported only by transformed source", () => {
 	expect(result.diagnostics.map(diagnostic => diagnostic.code)).toContain(2322);
 });
 
-it("normalizes aliases introduced by declaration plugins", () => {
-	fixture.project("game", [], {
-		declaration: true,
-		baseUrl: "./src",
-		paths: { "@local/*": ["./*"] },
-		plugins: [{ transform: "../declarations.cjs", afterDeclarations: true }],
-	});
-	fixture.write("game/src/index.ts", 'export { value } from "./target";');
-	fixture.write("game/src/target.ts", "export const value = 1;");
-	fixture.write("game/src/other.ts", "export const value = 2;");
-	fixture.write(
-		"declarations.cjs",
-		`module.exports = (program, config, { ts }) => context => source => {
+it.each([{ target: "./other" }, { target: "@local/other", baseUrl: "./src", paths: { "@local/*": ["./*"] } }])(
+	"applies declaration plugins to $target without changing Luau",
+	({ target, ...options }) => {
+		fixture.project("game", [], {
+			declaration: true,
+			...options,
+			plugins: [{ transform: "../declarations.cjs", afterDeclarations: true }],
+		});
+		fixture.write("game/src/index.ts", 'export { value } from "./target";');
+		fixture.write("game/src/target.ts", "export const value = 1;");
+		fixture.write("game/src/other.ts", "export const value = 2;");
+		fixture.write(
+			"declarations.cjs",
+			`module.exports = (program, config, { ts }) => context => source => {
 		const visit = node => ts.isStringLiteral(node) && node.text === "./target"
-			? ts.factory.createStringLiteral("@local/other") : ts.visitEachChild(node, visit, context);
+			? ts.factory.createStringLiteral(${JSON.stringify(target)}) : ts.visitEachChild(node, visit, context);
 		return ts.visitNode(source, visit);
 	};`,
-	);
+		);
 
-	expectSuccess(fixture.createBuild().build());
-	expect(fixture.read("out/game/index.d.ts")).toContain('"./other"');
-	expect(fixture.read("out/game/init.luau")).toContain('"target"');
-});
-
-it("keeps declaration plugins out of Luau and applies them to declarations", () => {
-	fixture.project("game", [], {
-		declaration: true,
-		plugins: [{ transform: "../declarations.cjs", afterDeclarations: true }],
-	});
-	fixture.write("game/src/index.ts", 'export { value } from "./target";');
-	fixture.write("game/src/target.ts", "export const value = 1;");
-	fixture.write("game/src/other.ts", "export const value = 2;");
-	fixture.write(
-		"declarations.cjs",
-		`module.exports = (program, config, { ts }) => context => source => {
-		const visit = node => ts.isStringLiteral(node) && node.text === "./target"
-			? ts.factory.createStringLiteral("./other") : ts.visitEachChild(node, visit, context);
-		return ts.visitNode(source, visit);
-	};`,
-	);
-
-	expectSuccess(fixture.createBuild().build());
-
-	expect(fixture.read("out/game/init.luau")).toContain('"target"');
-	expect(fixture.read("out/game/index.d.ts")).toContain('"./other"');
-});
+		expectSuccess(fixture.createBuild().build());
+		expect(fixture.read("out/game/index.d.ts")).toContain('"./other"');
+		expect(fixture.read("out/game/init.luau")).toContain('"target"');
+	},
+);
 
 it("resolves transitive types through a pnpm-style symlink with a plugin", () => {
 	fixture.project("game");

--- a/tests/compiler/projectReference/projectReferences.test.ts
+++ b/tests/compiler/projectReference/projectReferences.test.ts
@@ -398,34 +398,6 @@ it("recovers a missing reference introduced while watching", async () => {
 	}
 });
 
-it.each([
-	{ includePath: "out/game/include", luau: false },
-	{ includePath: "out/game/include", luau: true },
-	{ includePath: "out/game", luau: false },
-	{ includePath: "out/game", luau: true },
-])("preserves runtime files at $includePath while cleaning stale output (luau=$luau)", ({ includePath, luau }) => {
-	fixture.project("game");
-	fixture.rojo({ include: { $path: includePath } });
-	fixture.write("game/src/orphan.ts", "export const orphan = 1;");
-
-	const build = fixture.createBuild({ includePath: fixture.file(includePath), luau });
-	const extension = luau ? "luau" : "lua";
-	expectSuccess(build.build());
-
-	for (const name of ["Promise", "RuntimeLib"]) {
-		expect(fs.existsSync(fixture.file(`${includePath}/${name}.${extension}`))).toBe(true);
-	}
-
-	fs.removeSync(fixture.file("game/src/orphan.ts"));
-
-	expectSuccess(build.build());
-
-	for (const name of ["Promise", "RuntimeLib"]) {
-		expect(fs.existsSync(fixture.file(`${includePath}/${name}.${extension}`))).toBe(true);
-	}
-	expect(fs.existsSync(fixture.file(`out/game/orphan.${extension}`))).toBe(false);
-});
-
 it("rebuilds shared output when switching between game deployment contexts", () => {
 	fixture.project("common");
 	fixture.project("shared", ["common"]);

--- a/tests/compiler/projectWatchLifecycle.test.ts
+++ b/tests/compiler/projectWatchLifecycle.test.ts
@@ -2,7 +2,7 @@ import chokidar from "chokidar";
 import { setupProjectWatchProgram } from "Project/functions/setupProjectWatchProgram";
 import ts from "typescript";
 
-import { expectSuccess, ReferenceFixture } from "./referenceFixture";
+import { ReferenceFixture } from "./referenceFixture";
 
 let fixture: ReferenceFixture;
 beforeEach(() => {
@@ -57,12 +57,13 @@ it("propagates unexpected transformer exceptions while watching", async () => {
 	return source;
 };`,
 	);
-	expectSuccess(fixture.createBuild().build());
-	const output = fixture.read("out/game/init.luau");
 	const { events, watch } = createWatch();
 
 	try {
 		events.emit("ready");
+		expect(ts.sys.write).toHaveBeenCalledWith(expect.stringContaining("Found 0 errors"));
+		const output = fixture.read("out/game/init.luau");
+
 		fixture.write("game/src/index.ts", "export const value = 2;");
 		events.emit("change", fixture.file("game/src/index.ts"));
 

--- a/tests/src/tests/array.spec.ts
+++ b/tests/src/tests/array.spec.ts
@@ -511,9 +511,9 @@ export = () => {
 	it("should support Array.unorderedRemove", () => {
 		const arr = [0, 1, 2, 3, 4, 5, 6, 7];
 		let i = 2;
-		let value: number;
 
 		expect(arr.unorderedRemove((i *= 2))).to.equal(4);
+		expect(i).to.equal(4);
 		expect(arr.size()).to.equal(7);
 		expect(arr[4]).to.equal(7);
 		expect(arr[6]).to.equal(6);

--- a/tests/src/tests/class.spec.ts
+++ b/tests/src/tests/class.spec.ts
@@ -70,17 +70,6 @@ export = () => {
 		expect(X.value1).to.equal("ab");
 		expect(X.value2).to.equal("abc");
 	});
-	it("should create a class with a constructor", () => {
-		class Foo {
-			public bar: string;
-			constructor(bar: string) {
-				this.bar = bar;
-			}
-		}
-
-		const foo = new Foo("baz!");
-		expect(foo.bar).to.equal("baz!");
-	});
 
 	it("should construct with default parameters and accessors", () => {
 		class Vector {
@@ -206,16 +195,7 @@ export = () => {
 		expect(foo.bar).to.equal("baz");
 	});
 
-	it("should support toString", () => {
-		class Foo {
-			public toString() {
-				return "Foo";
-			}
-		}
-		expect(tostring(new Foo())).to.equal("Foo");
-	});
-
-	it("should support toString inheritance", () => {
+	it("should support toString on classes and subclasses", () => {
 		class Foo {
 			public toString() {
 				return "Foo";
@@ -223,6 +203,8 @@ export = () => {
 		}
 
 		class Bar extends Foo {}
+
+		expect(tostring(new Foo())).to.equal("Foo");
 		expect(tostring(new Bar())).to.equal("Foo");
 	});
 

--- a/tests/src/tests/destructure.spec.ts
+++ b/tests/src/tests/destructure.spec.ts
@@ -1016,15 +1016,15 @@ export = () => {
 		expect(a).to.equal("h");
 	});
 
-	it("should destructure nested generators", () => {
-		function* foo() {
-			yield 1;
-			yield 2;
-			yield 3;
-		}
+	function* generatorValues() {
+		yield 1;
+		yield 2;
+		yield 3;
+	}
 
+	it("should destructure nested generators", () => {
 		const obj = {
-			x: foo(),
+			x: generatorValues(),
 		};
 		let a = 0;
 		let b = 0;
@@ -1038,13 +1038,7 @@ export = () => {
 	});
 
 	it("should spread destructure generators", () => {
-		function* foo() {
-			yield 1;
-			yield 2;
-			yield 3;
-		}
-
-		const [a, ...rest] = foo();
+		const [a, ...rest] = generatorValues();
 		expect(a).to.equal(1);
 		expect(rest.size()).to.equal(2);
 		expect(rest[0]).to.equal(2);
@@ -1052,14 +1046,8 @@ export = () => {
 	});
 
 	it("should destructure double nested generators", () => {
-		function* foo() {
-			yield 1;
-			yield 2;
-			yield 3;
-		}
-
 		const obj = {
-			x: [foo()],
+			x: [generatorValues()],
 		};
 		let a = 0;
 		let b = 0;
@@ -1224,10 +1212,11 @@ export = () => {
 		expect(x).to.equal(123);
 	});
 
+	function returnsLuaTuple() {
+		return $tuple(1, 2, 3, 4, 5);
+	}
+
 	it("should support array binding pattern with LuaTuple with spread", () => {
-		function returnsLuaTuple() {
-			return $tuple(1, 2, 3, 4, 5);
-		}
 		const [a, b, c, ...rest] = returnsLuaTuple();
 		expect(a).to.equal(1);
 		expect(b).to.equal(2);
@@ -1237,9 +1226,6 @@ export = () => {
 	});
 
 	it("should support array assignment pattern with LuaTuple with spread", () => {
-		function returnsLuaTuple() {
-			return $tuple(1, 2, 3, 4, 5);
-		}
 		let a: number;
 		let b: number;
 		let c: number;
@@ -1253,9 +1239,6 @@ export = () => {
 	});
 
 	it("should support array binding pattern with LuaTuple with optional call", () => {
-		function returnsLuaTuple() {
-			return $tuple(1, 2, 3, 4, 5);
-		}
 		const [a, b, c] = returnsLuaTuple?.();
 		expect(a).to.equal(1);
 		expect(b).to.equal(2);
@@ -1263,9 +1246,6 @@ export = () => {
 	});
 
 	it("should support array assignment pattern with LuaTuple with optional call", () => {
-		function returnsLuaTuple() {
-			return $tuple(1, 2, 3, 4, 5);
-		}
 		let a: number;
 		let b: number;
 		let c: number;

--- a/tests/src/tests/evaluationOrder.spec.ts
+++ b/tests/src/tests/evaluationOrder.spec.ts
@@ -136,19 +136,6 @@ export = () => {
 		expect(seen[1]).to.equal(2);
 	});
 
-	it("should evaluate the object of a macro call before arguments that reassign it", () => {
-		let arr = [1, 2, 3];
-		const original = arr;
-		function swap() {
-			arr = [9];
-			return 4;
-		}
-		arr.push(swap());
-		expect(original.size()).to.equal(4);
-		expect(original[3]).to.equal(4);
-		expect(arr.size()).to.equal(1);
-	});
-
 	it("should evaluate push arguments left-to-right before any insertion", () => {
 		const arr = [10, 20];
 		// both arguments must be read before the first insertion changes the array
@@ -321,15 +308,6 @@ export = () => {
 		);
 		expect(seen[0]).to.equal("y");
 		expect(seen[1]).to.equal(1);
-	});
-
-	it("should keep mutation position for unorderedRemove index expressions", () => {
-		const arr = [0, 1, 2, 3, 4, 5, 6, 7];
-		let i = 2;
-		expect(arr.unorderedRemove((i *= 2))).to.equal(4);
-		expect(i).to.equal(4);
-		expect(arr.size()).to.equal(7);
-		expect(arr[4]).to.equal(7);
 	});
 
 	it("should not mutate the array before a later throwing push argument is evaluated", () => {

--- a/tests/src/tests/generator.spec.ts
+++ b/tests/src/tests/generator.spec.ts
@@ -29,14 +29,6 @@ export = () => {
 		expect(values.join(",")).to.equal("4,5");
 	});
 
-	it("should support generator function declarations", () => {
-		function* foo() {
-			yield 1;
-			return 2;
-		}
-		expect(foo()).to.be.ok();
-	});
-
 	it("should support no return value", () => {
 		function* foo() {
 			yield 1;
@@ -57,20 +49,6 @@ export = () => {
 		expect(result.size()).to.equal(2);
 		expect(result[0]).to.equal(10);
 		expect(result[1]).to.equal(20);
-	});
-
-	it("should support yield with asterisk token", () => {
-		function* foo() {
-			yield 1;
-		}
-
-		function* bar() {
-			yield* foo();
-		}
-
-		const result = [...bar()];
-		expect(result.size()).to.equal(1);
-		expect(result[0]).to.equal(1);
 	});
 
 	it("should not resume finished generator", () => {

--- a/tests/src/tests/roact.spec.tsx
+++ b/tests/src/tests/roact.spec.tsx
@@ -44,16 +44,6 @@ interface FragmentLike {
 
 export = () => {
 	describe("should support Roact.Component", () => {
-		it("should construct a roact class", () => {
-			class RoactClass extends Roact.Component {
-				public render(): Roact.Element {
-					return <frame />;
-				}
-			}
-
-			expect(Type.of(RoactClass)).to.equal(Type.StatefulComponentClass);
-		});
-
 		it("should construct a roact pure component class", () => {
 			class RoactPureClass extends Roact.PureComponent {
 				public render(): Roact.Element {
@@ -103,12 +93,14 @@ export = () => {
 			expect((RoactClass as { getDerivedStateFromProps: unknown }).getDerivedStateFromProps).to.be.a("function");
 		});
 
-		it("should mount a roact object", () => {
+		it("should construct and mount a roact class", () => {
 			class RoactClass extends Roact.Component {
 				public render(): Roact.Element {
 					return <frame />;
 				}
 			}
+
+			expect(Type.of(RoactClass)).to.equal(Type.StatefulComponentClass);
 
 			const element = <RoactClass />;
 			expect(Type.of(element)).to.equal(Type.Element);

--- a/tests/src/tests/string.spec.ts
+++ b/tests/src/tests/string.spec.ts
@@ -49,11 +49,6 @@ export = () => {
 		expect("Hello".gmatch(".")()[0]).to.equal("H");
 	});
 
-	it("should support the spread operator on strings", () => {
-		const array4 = ["H", "i", "y", "a"];
-		expect([..."Hiya"].every((x, i) => x === array4[i])).to.equal(true);
-	});
-
 	it("should support string.find", () => {
 		const data = "Hello".find("H", 1, true);
 		if (data[0]) {
@@ -200,7 +195,7 @@ export = () => {
 		expect(calls).to.equal(1);
 	});
 
-	it("should evaluate a string receiver before its index", () => {
+	it("should preserve string indexing order for used and discarded results", () => {
 		let events = "";
 		function getValue() {
 			events += "s";
@@ -215,6 +210,14 @@ export = () => {
 
 		expect(value).to.equal("a");
 		expect(events).to.equal("si");
+
+		events = "";
+		getValue()[getIndex()];
+		expect(events).to.equal("si");
+
+		events = "";
+		getValue()[-1];
+		expect(events).to.equal("s");
 	});
 
 	it("should preserve a string receiver when the index rebinds it", () => {
@@ -241,25 +244,6 @@ export = () => {
 
 		expect(byte).to.equal("a");
 		expect(index).to.equal(1);
-	});
-
-	it("should preserve side effects of discarded string indexing", () => {
-		let events = "";
-		function getValue() {
-			events += "s";
-			return "abc";
-		}
-		function getIndex() {
-			events += "i";
-			return 0;
-		}
-
-		getValue()[getIndex()];
-		expect(events).to.equal("si");
-
-		events = "";
-		getValue()[-1];
-		expect(events).to.equal("s");
 	});
 
 	it("should stop string indexing after a receiver error", () => {

--- a/tests/src/tests/tuple.spec.ts
+++ b/tests/src/tests/tuple.spec.ts
@@ -37,7 +37,7 @@ export = () => {
 		expect(foo()[1]).to.equal(203);
 	});
 
-	it("should support functions returning tuple calls", () => {
+	it("should support forwarding and wrapping tuple returns", () => {
 		function foo(): [number, string] {
 			return [1, "2"];
 		}
@@ -49,20 +49,14 @@ export = () => {
 		const [a, b] = bar();
 		expect(a).to.equal(1);
 		expect(b).to.equal("2");
-	});
 
-	it("should support wrapping tuple returns in tuple", () => {
-		function foo(): [number, string] {
-			return [1, "2"];
-		}
-
-		function bar(): [[number, string], boolean] {
+		function wrapped(): [[number, string], boolean] {
 			return [foo(), true];
 		}
 
-		const [[a, b], c] = bar();
-		expect(a).to.equal(1);
-		expect(b).to.equal("2");
+		const [[wrappedA, wrappedB], c] = wrapped();
+		expect(wrappedA).to.equal(1);
+		expect(wrappedB).to.equal("2");
 		expect(c).to.equal(true);
 	});
 
@@ -76,7 +70,7 @@ export = () => {
 		expect(itWorked).to.equal(true);
 	});
 
-	it("should support indirect tuple returns", () => {
+	it("should support indirect tuple returns and array methods", () => {
 		function foo(): [number, number, number] {
 			const result: [number, number, number] = [1, 2, 3];
 			return result;
@@ -85,18 +79,10 @@ export = () => {
 		expect(x).to.equal(1);
 		expect(y).to.equal(2);
 		expect(z).to.equal(3);
-	});
-
-	it("should allow tuples access to array functions", () => {
-		function foo(): [number, number, number] {
-			const result: [number, number, number] = [1, 2, 3];
-			return result;
-		}
-
 		expect(foo().pop()).to.equal(3);
 	});
 
-	it("should unpack function return tuples with LuaTuple<T>", () => {
+	it("should unpack and assign function return tuples with LuaTuple<T>", () => {
 		function foo(): LuaTuple<[number, number]> {
 			return [101, 203] as LuaTuple<[number, number]>;
 		}
@@ -110,9 +96,15 @@ export = () => {
 
 		expect(foo()[0]).to.equal(101);
 		expect(foo()[1]).to.equal(203);
+
+		let x = 0;
+		let y = 0;
+		[x, y] = foo();
+		expect(x).to.equal(101);
+		expect(y).to.equal(203);
 	});
 
-	it("should support functions returning tuple calls with LuaTuple<T>", () => {
+	it("should support forwarding and wrapping tuple returns with LuaTuple<T>", () => {
 		function foo(): LuaTuple<[number, string]> {
 			return [1, "2"] as LuaTuple<[number, string]>;
 		}
@@ -124,20 +116,14 @@ export = () => {
 		const [a, b] = bar();
 		expect(a).to.equal(1);
 		expect(b).to.equal("2");
-	});
 
-	it("should support wrapping tuple returns in tuple with LuaTuple<T>", () => {
-		function foo(): LuaTuple<[number, string]> {
-			return [1, "2"] as LuaTuple<[number, string]>;
-		}
-
-		function bar(): LuaTuple<[[number, string], boolean]> {
+		function wrapped(): LuaTuple<[[number, string], boolean]> {
 			return [foo(), true] as unknown as LuaTuple<[[number, string], boolean]>;
 		}
 
-		const [[a, b], c] = bar();
-		expect(a).to.equal(1);
-		expect(b).to.equal("2");
+		const [[wrappedA, wrappedB], c] = wrapped();
+		expect(wrappedA).to.equal(1);
+		expect(wrappedB).to.equal("2");
 		expect(c).to.equal(true);
 	});
 
@@ -151,7 +137,7 @@ export = () => {
 		expect(itWorked).to.equal(true);
 	});
 
-	it("should support indirect tuple returns with LuaTuple<T>", () => {
+	it("should support indirect tuple returns and array methods with LuaTuple<T>", () => {
 		function foo(): LuaTuple<[number, number, number]> {
 			const result: [number, number, number] = [1, 2, 3];
 			return result as LuaTuple<[number, number, number]>;
@@ -160,14 +146,6 @@ export = () => {
 		expect(x).to.equal(1);
 		expect(y).to.equal(2);
 		expect(z).to.equal(3);
-	});
-
-	it("should allow tuples access to array functions with LuaTuple<T>", () => {
-		function foo(): LuaTuple<[number, number, number]> {
-			const result: [number, number, number] = [1, 2, 3];
-			return result as LuaTuple<[number, number, number]>;
-		}
-
 		expect(foo().pop()).to.equal(3);
 	});
 
@@ -177,18 +155,6 @@ export = () => {
 		}
 
 		expect(foo().pop()).to.equal("3");
-	});
-
-	it("should support assigning from LuaTuples", () => {
-		function foo(): LuaTuple<[number, number]> {
-			return [101, 203] as LuaTuple<[number, number]>;
-		}
-
-		let a = 0;
-		let b = 0;
-		[a, b] = foo();
-		expect(a).to.equal(101);
-		expect(b).to.equal(203);
 	});
 
 	it("should support assigning from LuaTuples with omitted expressions", () => {
@@ -291,31 +257,7 @@ export = () => {
 		expect(fnTuple?.()?.[1]?.()?.[1]?.()).to.equal(3);
 	});
 
-	it("should support $tuple macro", () => {
-		function luaTupleMacroReturn() {
-			return $tuple(123, "abc", true);
-		}
-
-		const tuple = luaTupleMacroReturn();
-
-		expect(tuple[0]).to.equal(123);
-		expect(tuple[1]).to.equal("abc");
-		expect(tuple[2]).to.equal(true);
-	});
-
-	it("should support $tuple macro with destructuring", () => {
-		function luaTupleMacroReturn() {
-			return $tuple(123, "abc", true);
-		}
-
-		const [a, b, c] = luaTupleMacroReturn();
-
-		expect(a).to.equal(123);
-		expect(b).to.equal("abc");
-		expect(c).to.equal(true);
-	});
-
-	it("should support $tuple macro in nested calls", () => {
+	it("should preserve $tuple values through indexing, destructuring, and nested calls", () => {
 		function luaTupleMacroReturn() {
 			return $tuple(123, "abc", true);
 		}
@@ -324,11 +266,21 @@ export = () => {
 			return luaTupleMacroReturn();
 		}
 
-		const [a, b, c] = wrapperFunction();
+		const tuple = luaTupleMacroReturn();
 
+		expect(tuple[0]).to.equal(123);
+		expect(tuple[1]).to.equal("abc");
+		expect(tuple[2]).to.equal(true);
+
+		const [a, b, c] = luaTupleMacroReturn();
 		expect(a).to.equal(123);
 		expect(b).to.equal("abc");
 		expect(c).to.equal(true);
+
+		const [wrappedA, wrappedB, wrappedC] = wrapperFunction();
+		expect(wrappedA).to.equal(123);
+		expect(wrappedB).to.equal("abc");
+		expect(wrappedC).to.equal(true);
 	});
 
 	it("should support $tuple macro with type assertion", () => {


### PR DESCRIPTION
- Remove runtime smoke tests already covered by stronger cases and consolidate repeated fixtures while retaining distinct syntax, types, and assertions.
- Share runtime cleanup and declaration plugin fixtures, and reuse the watcher's initial build. This removes 18 test cases, five build calls, and 188 lines overall.
- Validation: `npm test` and `npm run eslint` pass. Line, statement, function, and branch coverage remain 100% with unchanged totals.
